### PR TITLE
feat(cors): add CORSMiddleware for Vercel frontend + local dev

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import mlflow
 from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
 from psycopg2.extensions import connection
 from pydantic import BaseModel, Field
 
@@ -134,11 +135,20 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
     settings = get_settings()
-    return FastAPI(
+    app = FastAPI(
         title=settings.api_title,
         version=settings.api_version,
         lifespan=lifespan,
     )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173", "http://localhost:3000"],
+        allow_origin_regex=r"https://.*\.vercel\.app$",
+        allow_credentials=False,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["*"],
+    )
+    return app
 
 
 app = create_app()


### PR DESCRIPTION
## Summary

Prep work for deploying the FastAPI backend to Cloud Run where the React frontend (hosted on Vercel) will call it from the browser. Without CORS middleware, those cross-origin browser requests would be blocked by the browser's same-origin policy.

## What this enables

- **Local dev:** Vite's proxy (`/chat` → `localhost:8000`) means no CORS issues on `localhost:5173`, but the middleware still allows direct cross-origin calls for flexibility.
- **Vercel preview URLs:** every PR in the frontend repo gets a unique `*.vercel.app` URL. The regex pattern covers all of them automatically.
- **Vercel production URL:** matched by the same regex.

## Configuration

```python
allow_origins=["http://localhost:5173", "http://localhost:3000"],
allow_origin_regex=r"https://.*\.vercel\.app$",
allow_credentials=False,
allow_methods=["GET", "POST", "OPTIONS"],
allow_headers=["*"],
```

- `allow_credentials=False` because the API is stateless JSON (no cookies). This lets the `*.vercel.app` wildcard work without requiring exact-origin echoing — simpler and safer.
- When a custom domain is added later (e.g., `api.pavement.app`), append it to `allow_origins`.

## Not in this PR (separate follow-up tasks)

- Actual Cloud Run deployment (manual `gcloud run deploy` — no code change needed)
- Frontend `/chat` vs backend `/predict` endpoint mismatch — the frontend currently calls `/chat` which doesn't exist on the backend. Needs coordination with the frontend branch.
- MLflow server upgrade on the GCP VM (unrelated to CORS)

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy app/`, `pytest tests/unit/` all green locally
- [ ] After merge + deploy, curl the deployed `/health` endpoint with `-H "Origin: https://anything.vercel.app"` and verify `Access-Control-Allow-Origin` in the response headers