### PR TITLE
ci: auto-deploy to Cloud Run on merge to main + document deployment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,40 +120,32 @@ jobs:
           cache-from: type=gha
 
   # ---------------------------------------------------------------------------
-  # Cloud Run deploy
+  # Cloud Run auto-deploy
   #
-  # Uncomment this job after you have created the Cloud Run service manually
-  # once (so env vars / Secret Manager mounts are wired up). After that, each
-  # merge to main will roll the service forward to the new image.
-  #
-  # Initial manual deploy (run once from your terminal):
-  #
-  #   gcloud run deploy city-concierge-api \
-  #     --image us-central1-docker.pkg.dev/mlops-491820/ml-repo/city-concierge:latest \
-  #     --region us-central1 \
-  #     --platform managed \
-  #     --allow-unauthenticated \
-  #     --set-env-vars APP_ENV=production \
-  #     --set-secrets OPENAI_API_KEY=OPENAI_API_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,DATABASE_URL=DATABASE_URL:latest
+  # Only runs on push to main (not on tags or manual dispatch). Swaps in the
+  # new image on the existing service; existing env vars, secret mounts, and
+  # Cloud SQL attachments are preserved by deploy-cloudrun@v2 when only
+  # `image` is specified. The service itself must already exist (created
+  # manually once via `gcloud run deploy ...`).
   # ---------------------------------------------------------------------------
-  #
-  # deploy:
-  #   name: Deploy to Cloud Run
-  #   needs: build-scan-push
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     id-token: write
-  #   steps:
-  #     - name: Authenticate to Google Cloud
-  #       uses: google-github-actions/auth@v2
-  #       with:
-  #         workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-  #         service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-  #
-  #     - name: Deploy new image to Cloud Run
-  #       uses: google-github-actions/deploy-cloudrun@v2
-  #       with:
-  #         service: ${{ env.CLOUD_RUN_SERVICE }}
-  #         region: ${{ env.CLOUD_RUN_REGION }}
-  #         image: ${{ needs.build-scan-push.outputs.image_uri }}
+  deploy:
+    name: Deploy to Cloud Run
+    needs: build-scan-push
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Deploy new image to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.CLOUD_RUN_SERVICE }}
+          region: ${{ env.CLOUD_RUN_REGION }}
+          image: ${{ needs.build-scan-push.outputs.image_uri }}

--- a/README.md
+++ b/README.md
@@ -135,14 +135,75 @@ CLOUD_SQL_SOCKET_DIR=/cloudsql
 
 When `DATABASE_URL` is unset, the app and scripts now build the connection string from `POSTGRES_*`, and if `CLOUD_SQL_INSTANCE_CONNECTION_NAME` is present they connect through the Cloud SQL socket path automatically. For direct-host Cloud SQL connections, `POSTGRES_SSLMODE` and `POSTGRES_SSLROOTCERT` are also supported.
 
-## Common Commands
+## Deployment
+
+### Live Environment
+
+- **Backend (Cloud Run):** https://city-concierge-api-6amzjx52nq-uc.a.run.app
+- **Frontend (Vercel):** see the `frontend/` directory; configure `VITE_API_URL` to the Cloud Run URL above
+- **Image registry:** `us-central1-docker.pkg.dev/mlops-491820/ml-repo/city-concierge`
+- **Cloud SQL instance:** `mlops-491820:us-central1:mlops--city-concierge` (Postgres 18, pgvector 0.8.1)
+
+### CI/CD Pipeline
+
+GitHub Actions handle everything from lint to deploy. Triggers and jobs:
+
+| Workflow | Trigger | Jobs |
+|---|---|---|
+| `.github/workflows/ci.yml` | Every push + PRs to `main` | Ruff lint (incl. bandit security rules), format check, mypy, pytest with coverage |
+| `.github/workflows/docker.yml` | Push to `main`, tags `v*`, manual | Buildx image build, Trivy vulnerability scan, push to Artifact Registry, **auto-deploy to Cloud Run** (on `main` only) |
+| `.github/dependabot.yml` | Weekly (Mondays) | PRs for Python, npm, GitHub Actions, and Docker base image updates |
+
+**Auto-deploy behavior:** every merge to `main` rebuilds the image, pushes to Artifact Registry, and rolls the Cloud Run service forward. Existing env vars, secret mounts, and Cloud SQL connections on the service are preserved — the workflow only swaps the image.
+
+### Secrets & Environment Variables
+
+**Secrets (Secret Manager, mounted into Cloud Run at runtime):**
+
+- `POSTGRES_PASSWORD`
+- `OPENAI_API_KEY`
+- `GEMINI_API_KEY`
+
+**Plain env vars (set directly on the Cloud Run service):**
+
+- `MLFLOW_TRACKING_URI`
+- `POSTGRES_DB`, `POSTGRES_USER`
+- `CLOUD_SQL_INSTANCE_CONNECTION_NAME`
+
+**Frontend (Vercel — `VITE_*` vars are compiled into the JS bundle and visible in the browser, so never put secrets here):**
+
+- `VITE_API_URL=https://city-concierge-api-6amzjx52nq-uc.a.run.app`
+- `VITE_USE_MOCK=false`
+
+### Initial Manual Deploy
+
+The Cloud Run service must exist before CI auto-deploy works. It was created once with:
+
+```bash
+gcloud run deploy city-concierge-api \
+  --image us-central1-docker.pkg.dev/mlops-491820/ml-repo/city-concierge:latest \
+  --region us-central1 \
+  --platform managed \
+  --allow-unauthenticated \
+  --port 8000 \
+  --add-cloudsql-instances mlops-491820:us-central1:mlops--city-concierge \
+  --set-env-vars "MLFLOW_TRACKING_URI=http://35.223.147.177:5000,POSTGRES_DB=mlops-city-concierge,POSTGRES_USER=postgres,CLOUD_SQL_INSTANCE_CONNECTION_NAME=mlops-491820:us-central1:mlops--city-concierge" \
+  --set-secrets "POSTGRES_PASSWORD=POSTGRES_PASSWORD:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest" \
+  --project mlops-491820
+```
+
+Re-run this command only if you need to change env vars or secret mounts; otherwise merge to `main` and let CI handle image updates.
+
+### Manual Docker Build
 
 ```bash
 docker build -t city-concierge .
 docker run --rm -p 8000:8000 --env-file .env city-concierge
 ```
 
-### Push to GCP Artifact Registry
+### Manual Push to Artifact Registry
+
+Usually unnecessary — CI does this automatically on merge to `main`. For ad-hoc pushes:
 
 ```bash
 gcloud auth configure-docker us-central1-docker.pkg.dev


### PR DESCRIPTION
## Summary

Finishes the CI/CD pipeline by auto-deploying to Cloud Run on every merge to \`main\`, and adds a Deployment section to the README covering the now-live service.

## Changes

### \`docker.yml\` — auto-deploy job

Replaces the previously-commented-out \`deploy\` job with a live one:

- **Gated to \`main\` only** via \`if: github.ref == 'refs/heads/main'\`. Tags (\`v*\`) and manual dispatches still build + scan + push the image but don't auto-deploy — hotfix tags shouldn't roll out without an explicit merge.
- Uses \`google-github-actions/deploy-cloudrun@v2\` with only \`image\` specified; existing env vars, secret mounts, and \`--add-cloudsql-instances\` attachments on the Cloud Run service are preserved by the action.
- Authenticates via the same WIF setup used for Artifact Registry pushes.

### \`README.md\` — Deployment section

- Live Cloud Run URL, Artifact Registry path, Cloud SQL instance details
- CI/CD pipeline table (ci.yml / docker.yml / dependabot.yml triggers + jobs)
- Secret Manager vs plain env var split — which of the app's configuration values are secrets and which aren't
- Vercel frontend config, with a note that \`VITE_*\` vars are public by design (bundled into JS) so nothing sensitive should go there
- The exact initial \`gcloud run deploy\` command used to create the service, for reference / disaster recovery
- De-duplicated the two "Common Commands" headings that had diverged into different content

## Not in this PR

- Local unrelated changes (Terraform setup, sync-env script, .gitignore/Makefile edits) — those look like in-progress work by someone else and belong in a separate PR.

## Test plan

- [x] Manual \`gcloud run deploy\` confirmed working (deployed revision 00001-ml9 earlier today; all four smoke tests pass: \`/root\`, \`/health\`, \`/health/db\`, CORS preflight)
- [ ] On merge, the \`deploy\` job in docker.yml should roll the service to a new revision using the freshly-built image
- [ ] Frontend can set \`VITE_API_URL=https://city-concierge-api-6amzjx52nq-uc.a.run.app\` and call \`/predict\` from a Vercel preview