### PR TITLE
refactor: address all 17 code smells in app/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ APP_ENV=development          # development | staging | production
 LOG_LEVEL=INFO
 RETRIEVER_K=5
 
+# ── CORS ──────────────────────────────────────
+# Comma-separated exact origins allowed by the FastAPI CORS middleware.
+# Defaults cover local Vite (5173) and CRA (3000) dev servers.
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
+# Regex applied in addition to CORS_ALLOWED_ORIGINS. Set to empty to disable.
+CORS_ALLOWED_ORIGIN_REGEX=https://.*\.vercel\.app$
+
 # ── Ingestion ─────────────────────────────────
 # Local path or remote URL used by the ingest pipeline
 DATA_SOURCE_PATH=./data/cities.jsonl

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,7 @@ python scripts/seed.py    # Generate sample JSONL data
 ## Key Conventions
 
 - Python 3.10+; ruff for linting/formatting (line-length 100, rules: E, F, I, N, UP, B, SIM)
+- Pre-commit hooks run ruff (`check` + `format`) automatically on commit; no need to run them manually beforehand
 - Dependency management: single `pyproject.toml` with Poetry main dependencies plus a `dev` group
 - Tests use pytest with `asyncio_mode = "auto"`; conftest patches env vars so tests never hit real services
 - Integration tests are skipped unless `APP_ENV=integration` is set

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ python scripts/seed.py    # Generate sample JSONL data
 ## Key Conventions
 
 - Python 3.10+; ruff for linting/formatting (line-length 100, rules: E, F, I, N, UP, B, SIM)
+- Pre-commit hooks run ruff (`check` + `format`) automatically on commit; no need to run them manually beforehand
 - Dependency management: single `pyproject.toml` with Poetry main dependencies plus a `dev` group
 - Tests use pytest with `asyncio_mode = "auto"`; conftest patches env vars so tests never hit real services
 - Integration tests are skipped unless `APP_ENV=integration` is set

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ python scripts/seed.py    # Generate sample JSONL data
 ## Key Conventions
 
 - Python 3.10+; ruff for linting/formatting (line-length 100, rules: E, F, I, N, UP, B, SIM)
+- Pre-commit hooks run ruff (`check` + `format`) automatically on commit; no need to run them manually beforehand
 - Dependency management: single `pyproject.toml` with Poetry main dependencies plus a `dev` group
 - Tests use pytest with `asyncio_mode = "auto"`; conftest patches env vars so tests never hit real services
 - Integration tests are skipped unless `APP_ENV=integration` is set

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+import mlflow
+
+from .chain import build_rag_chain
+from .config import get_settings, resolve_llm_api_key
+from .providers import get_provider
+from .schemas import ActiveModelConfig
+
+
+def parse_active_model_config(
+    params: dict[str, str], run_id: str, model_version: str
+) -> ActiveModelConfig:
+    settings = get_settings()
+    llm_provider = (params.get("llm_provider") or "openai").lower()
+    provider = get_provider(llm_provider)
+    default_chat_model = provider.default_chat_model(settings)
+
+    return ActiveModelConfig(
+        llm_provider=llm_provider,
+        chat_model=params.get("chat_model") or default_chat_model,
+        k=int(params.get("k", settings.retriever_k)),
+        temperature=float(params.get("temperature", "0.0")),
+        run_id=run_id,
+        model_version=model_version,
+    )
+
+
+def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
+    settings = get_settings()
+    tracking_uri = settings.mlflow_tracking_uri
+
+    mlflow.set_tracking_uri(tracking_uri)
+    client = mlflow.MlflowClient(tracking_uri=tracking_uri)
+
+    try:
+        model_version = client.get_model_version_by_alias(
+            settings.mlflow_model_name,
+            "production",
+        )
+    except Exception as exc:  # pragma: no cover - exercised via startup tests
+        raise RuntimeError(
+            "Unable to load the MLflow production alias for "
+            f"registered model '{settings.mlflow_model_name}'."
+        ) from exc
+
+    run = client.get_run(model_version.run_id)
+    config = parse_active_model_config(
+        run.data.params,
+        run_id=model_version.run_id,
+        model_version=str(model_version.version),
+    )
+    chain = build_rag_chain(
+        api_key=resolve_llm_api_key(config.llm_provider),
+        llm_provider=config.llm_provider,
+        chat_model=config.chat_model,
+        k=config.k,
+        temperature=config.temperature,
+    )
+    return chain, config

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import mlflow
+from mlflow.exceptions import MlflowException
 
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
@@ -52,7 +53,7 @@ def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
             settings.mlflow_model_name,
             "production",
         )
-    except Exception as exc:  # pragma: no cover - exercised via startup tests
+    except MlflowException as exc:
         raise RuntimeError(
             "Unable to load the MLflow production alias for "
             f"registered model '{settings.mlflow_model_name}'."

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import mlflow
@@ -9,6 +10,8 @@ from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
 from .providers import get_provider
 from .schemas import ActiveModelConfig
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_int(params: dict[str, str], key: str, default: int) -> int:
@@ -71,5 +74,14 @@ def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
         chat_model=config.chat_model,
         k=config.k,
         temperature=config.temperature,
+    )
+    logger.info(
+        "loaded RAG chain: model=%s version=%s provider=%s chat_model=%s k=%d temperature=%s",
+        settings.mlflow_model_name,
+        config.model_version,
+        config.llm_provider,
+        config.chat_model,
+        config.k,
+        config.temperature,
     )
     return chain, config

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -10,6 +10,16 @@ from .providers import get_provider
 from .schemas import ActiveModelConfig
 
 
+def _parse_int(params: dict[str, str], key: str, default: int) -> int:
+    raw = params.get(key) or str(default)
+    return int(raw)
+
+
+def _parse_float(params: dict[str, str], key: str, default: float) -> float:
+    raw = params.get(key) or str(default)
+    return float(raw)
+
+
 def parse_active_model_config(
     params: dict[str, str], run_id: str, model_version: str
 ) -> ActiveModelConfig:
@@ -21,8 +31,8 @@ def parse_active_model_config(
     return ActiveModelConfig(
         llm_provider=llm_provider,
         chat_model=params.get("chat_model") or default_chat_model,
-        k=int(params.get("k", settings.retriever_k)),
-        temperature=float(params.get("temperature", "0.0")),
+        k=_parse_int(params, "k", settings.retriever_k),
+        temperature=_parse_float(params, "temperature", 0.0),
         run_id=run_id,
         model_version=model_version,
     )

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -31,6 +31,8 @@ def parse_active_model_config(
 def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
     settings = get_settings()
     tracking_uri = settings.mlflow_tracking_uri
+    if not tracking_uri:
+        raise RuntimeError("MLFLOW_TRACKING_URI is required (set it in .env).")
 
     mlflow.set_tracking_uri(tracking_uri)
     client = mlflow.MlflowClient(tracking_uri=tracking_uri)

--- a/app/chain.py
+++ b/app/chain.py
@@ -8,7 +8,6 @@ from .retriever import PgVectorRetriever
 
 
 def build_rag_chain(
-    connection_string: str,
     api_key: str,
     llm_provider: str,
     chat_model: str,
@@ -17,7 +16,6 @@ def build_rag_chain(
 ) -> RetrievalQA:
     settings = get_settings()
     retriever = PgVectorRetriever(
-        connection_string=connection_string,
         embedding_model=settings.openai_embedding_model,
         k=k,
         openai_api_key=settings.openai_api_key,

--- a/app/chain.py
+++ b/app/chain.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 from langchain.chains import RetrievalQA
-from langchain_core.language_models import BaseChatModel
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_openai import ChatOpenAI
-from pydantic import SecretStr
 
 from .config import get_settings
+from .providers import get_provider
 from .retriever import PgVectorRetriever
 
 
@@ -26,18 +23,7 @@ def build_rag_chain(
         openai_api_key=settings.openai_api_key,
     )
 
-    provider = llm_provider.lower()
-    llm: BaseChatModel
-    if provider == "openai":
-        llm = ChatOpenAI(model=chat_model, api_key=SecretStr(api_key), temperature=temperature)
-    elif provider == "gemini":
-        llm = ChatGoogleGenerativeAI(
-            model=chat_model,
-            google_api_key=SecretStr(api_key),
-            temperature=temperature,
-        )
-    else:
-        raise ValueError(f"Unsupported llm_provider: {llm_provider}")
+    llm = get_provider(llm_provider).build_llm(chat_model, api_key, temperature)
 
     return RetrievalQA.from_chain_type(
         llm=llm,

--- a/app/config.py
+++ b/app/config.py
@@ -87,8 +87,8 @@ class Settings(BaseSettings):
     openai_embedding_model: str = "text-embedding-3-small"
     gemini_api_key: str = ""
     gemini_chat_model: str = "gemini-2.5-flash"
-    mlflow_tracking_uri: str = "http://35.223.147.177:5000"
-    mlflow_artifacts_uri: str = "mlflow-artifacts://35.223.147.177:5000"
+    mlflow_tracking_uri: str = ""
+    mlflow_artifacts_uri: str = ""
     mlflow_model_name: str = "city-concierge-rag"
     retriever_k: int = 5
     cors_allowed_origins: list[str] = [

--- a/app/config.py
+++ b/app/config.py
@@ -91,6 +91,11 @@ class Settings(BaseSettings):
     mlflow_artifacts_uri: str = "mlflow-artifacts://35.223.147.177:5000"
     mlflow_model_name: str = "city-concierge-rag"
     retriever_k: int = 5
+    cors_allowed_origins: list[str] = [
+        "http://localhost:5173",
+        "http://localhost:3000",
+    ]
+    cors_allowed_origin_regex: str | None = r"https://.*\.vercel\.app$"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/app/config.py
+++ b/app/config.py
@@ -120,6 +120,13 @@ def get_settings() -> Settings:
 settings = get_settings()
 
 
+def require_database_url() -> str:
+    url = get_settings().resolved_database_url
+    if not url:
+        raise RuntimeError("Missing DATABASE_URL or POSTGRES_* database settings.")
+    return url
+
+
 def resolve_llm_api_key(llm_provider: str) -> str:
     """Return the API key for the given LLM provider, or raise if missing."""
     from .providers import get_provider

--- a/app/config.py
+++ b/app/config.py
@@ -122,16 +122,9 @@ settings = get_settings()
 
 def resolve_llm_api_key(llm_provider: str) -> str:
     """Return the API key for the given LLM provider, or raise if missing."""
-    s = get_settings()
-    provider = llm_provider.lower()
+    from .providers import get_provider
 
-    if provider == "openai":
-        api_key = s.openai_api_key
-    elif provider == "gemini":
-        api_key = s.gemini_api_key
-    else:
-        raise ValueError(f"Unsupported llm_provider: {llm_provider}")
-
+    api_key = get_provider(llm_provider).api_key(get_settings())
     if not api_key:
         raise RuntimeError(f"Missing API key for llm_provider={llm_provider}.")
     return api_key

--- a/app/config.py
+++ b/app/config.py
@@ -96,6 +96,7 @@ class Settings(BaseSettings):
         "http://localhost:3000",
     ]
     cors_allowed_origin_regex: str | None = r"https://.*\.vercel\.app$"
+    log_level: str = "INFO"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/app/db.py
+++ b/app/db.py
@@ -3,14 +3,11 @@ from collections.abc import Generator
 import psycopg2
 from psycopg2.extensions import connection
 
-from .config import get_settings
+from .config import require_database_url
 
 
 def get_db() -> Generator[connection, None, None]:
-    database_url = get_settings().resolved_database_url
-    if not database_url:
-        raise RuntimeError("Missing DATABASE_URL or POSTGRES_* database settings.")
-    conn = psycopg2.connect(database_url)
+    conn = psycopg2.connect(require_database_url())
     try:
         yield conn
     finally:

--- a/app/db.py
+++ b/app/db.py
@@ -1,14 +1,38 @@
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
+from contextlib import contextmanager
 
-import psycopg2
 from psycopg2.extensions import connection
+from psycopg2.pool import ThreadedConnectionPool
 
 from .config import require_database_url
 
+_pool: ThreadedConnectionPool | None = None
 
-def get_db() -> Generator[connection, None, None]:
-    conn = psycopg2.connect(require_database_url())
+
+def get_pool() -> ThreadedConnectionPool:
+    global _pool
+    if _pool is None:
+        _pool = ThreadedConnectionPool(minconn=1, maxconn=10, dsn=require_database_url())
+    return _pool
+
+
+def close_pool() -> None:
+    global _pool
+    if _pool is not None:
+        _pool.closeall()
+        _pool = None
+
+
+@contextmanager
+def borrow_connection() -> Iterator[connection]:
+    pool = get_pool()
+    conn = pool.getconn()
     try:
         yield conn
     finally:
-        conn.close()
+        pool.putconn(conn)
+
+
+def get_db() -> Generator[connection, None, None]:
+    with borrow_connection() as conn:
+        yield conn

--- a/app/db.py
+++ b/app/db.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Generator, Iterator
 from contextlib import contextmanager
 
@@ -6,13 +7,20 @@ from psycopg2.pool import ThreadedConnectionPool
 
 from .config import require_database_url
 
+logger = logging.getLogger(__name__)
+
 _pool: ThreadedConnectionPool | None = None
+_POOL_MIN = 1
+_POOL_MAX = 10
 
 
 def get_pool() -> ThreadedConnectionPool:
     global _pool
     if _pool is None:
-        _pool = ThreadedConnectionPool(minconn=1, maxconn=10, dsn=require_database_url())
+        _pool = ThreadedConnectionPool(
+            minconn=_POOL_MIN, maxconn=_POOL_MAX, dsn=require_database_url()
+        )
+        logger.info("postgres pool created (min=%d, max=%d)", _POOL_MIN, _POOL_MAX)
     return _pool
 
 
@@ -21,6 +29,7 @@ def close_pool() -> None:
     if _pool is not None:
         _pool.closeall()
         _pool = None
+        logger.info("postgres pool closed")
 
 
 @contextmanager

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import openai
+import psycopg2
+from google.api_core import exceptions as google_exceptions
+
+
+def status_for_invoke_error(exc: BaseException) -> tuple[int, str]:
+    """Map an exception raised by rag_chain.invoke to (status_code, public_message_prefix).
+
+    Returns the most specific match. Vendor exception classes are imported here so
+    routes.py doesn't need to know about openai/psycopg2/google internals.
+    """
+    if isinstance(exc, openai.RateLimitError | google_exceptions.ResourceExhausted):
+        return 429, "LLM rate limit hit"
+    if isinstance(exc, openai.OpenAIError | google_exceptions.GoogleAPIError):
+        return 502, "Upstream LLM error"
+    if isinstance(exc, psycopg2.OperationalError):
+        return 503, "Database temporarily unavailable"
+    if isinstance(exc, psycopg2.DatabaseError):
+        return 500, "Database error"
+    return 500, "Internal server error"

--- a/app/main.py
+++ b/app/main.py
@@ -31,8 +31,8 @@ def create_app() -> FastAPI:
     )
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:5173", "http://localhost:3000"],
-        allow_origin_regex=r"https://.*\.vercel\.app$",
+        allow_origins=settings.cors_allowed_origins,
+        allow_origin_regex=settings.cors_allowed_origin_regex,
         allow_credentials=False,
         allow_methods=["GET", "POST", "OPTIONS"],
         allow_headers=["*"],

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,10 @@ from .config import get_settings
 from .db import close_pool
 from .routes import router
 
+logging.basicConfig(
+    level=get_settings().log_level.upper(),
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from psycopg2.extensions import connection
 from pydantic import BaseModel, Field
 
 from .chain import build_rag_chain
-from .config import get_settings, resolve_llm_api_key
+from .config import get_settings, require_database_url, resolve_llm_api_key
 from .db import get_db
 from .providers import get_provider
 
@@ -93,11 +93,8 @@ def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
         run_id=model_version.run_id,
         model_version=str(model_version.version),
     )
-    database_url = settings.resolved_database_url
-    if not database_url:
-        raise RuntimeError("Missing DATABASE_URL or POSTGRES_* database settings.")
     chain = build_rag_chain(
-        connection_string=database_url,
+        connection_string=require_database_url(),
         api_key=resolve_llm_api_key(config.llm_provider),
         llm_provider=config.llm_provider,
         chat_model=config.chat_model,

--- a/app/main.py
+++ b/app/main.py
@@ -1,121 +1,14 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import Any
 
-import mlflow
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from psycopg2.extensions import connection
-from pydantic import BaseModel, Field
 
-from .chain import build_rag_chain
-from .config import get_settings, resolve_llm_api_key
-from .db import close_pool, get_db
-from .providers import get_provider
-
-db_connection_dependency = Depends(get_db)
-
-
-class RecommendationRequest(BaseModel):
-    query: str = Field(
-        ...,
-        description="User's recommendation query (for example, 'Best tacos in the Mission').",
-    )
-    limit: int = Field(
-        default=5,
-        ge=1,
-        le=20,
-        description="Maximum number of source places to include in the response.",
-    )
-
-
-class RecommendationSource(BaseModel):
-    name: str | None = None
-    rating: float | None = None
-    address: str | None = None
-    similarity: float | None = None
-
-
-class RecommendationResponse(BaseModel):
-    response: str
-    sources: list[RecommendationSource]
-
-
-class ActiveModelConfig(BaseModel):
-    llm_provider: str
-    chat_model: str
-    k: int
-    temperature: float = 0.0
-    run_id: str | None = None
-    model_version: str | None = None
-
-
-def parse_active_model_config(
-    params: dict[str, str], run_id: str, model_version: str
-) -> ActiveModelConfig:
-    settings = get_settings()
-    llm_provider = (params.get("llm_provider") or "openai").lower()
-    provider = get_provider(llm_provider)
-    default_chat_model = provider.default_chat_model(settings)
-
-    return ActiveModelConfig(
-        llm_provider=llm_provider,
-        chat_model=params.get("chat_model") or default_chat_model,
-        k=int(params.get("k", settings.retriever_k)),
-        temperature=float(params.get("temperature", "0.0")),
-        run_id=run_id,
-        model_version=model_version,
-    )
-
-
-def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
-    settings = get_settings()
-    tracking_uri = settings.mlflow_tracking_uri
-
-    mlflow.set_tracking_uri(tracking_uri)
-    client = mlflow.MlflowClient(tracking_uri=tracking_uri)
-
-    try:
-        model_version = client.get_model_version_by_alias(
-            settings.mlflow_model_name,
-            "production",
-        )
-    except Exception as exc:  # pragma: no cover - exercised via startup tests
-        raise RuntimeError(
-            "Unable to load the MLflow production alias for "
-            f"registered model '{settings.mlflow_model_name}'."
-        ) from exc
-
-    run = client.get_run(model_version.run_id)
-    config = parse_active_model_config(
-        run.data.params,
-        run_id=model_version.run_id,
-        model_version=str(model_version.version),
-    )
-    chain = build_rag_chain(
-        api_key=resolve_llm_api_key(config.llm_provider),
-        llm_provider=config.llm_provider,
-        chat_model=config.chat_model,
-        k=config.k,
-        temperature=config.temperature,
-    )
-    return chain, config
-
-
-def serialize_sources(source_documents: list[Any], limit: int) -> list[RecommendationSource]:
-    sources: list[RecommendationSource] = []
-    for document in source_documents[:limit]:
-        metadata = getattr(document, "metadata", {}) or {}
-        sources.append(
-            RecommendationSource(
-                name=metadata.get("name"),
-                rating=metadata.get("rating"),
-                address=metadata.get("address"),
-                similarity=metadata.get("similarity"),
-            )
-        )
-    return sources
+from .bootstrap import load_registered_rag_chain
+from .config import get_settings
+from .db import close_pool
+from .routes import router
 
 
 @asynccontextmanager
@@ -144,49 +37,8 @@ def create_app() -> FastAPI:
         allow_methods=["GET", "POST", "OPTIONS"],
         allow_headers=["*"],
     )
+    app.include_router(router)
     return app
 
 
 app = create_app()
-
-
-@app.get("/root")
-def root() -> dict[str, str]:
-    return {"message": "Welcome!"}
-
-
-@app.get("/health")
-def health(request: Request) -> dict[str, str]:
-    model_config = getattr(request.app.state, "active_model_config", None)
-    if model_config is None:
-        raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
-
-    return {
-        "status": "ok",
-        "llm_provider": model_config.llm_provider,
-        "chat_model": model_config.chat_model,
-    }
-
-
-@app.get("/health/db")
-def health_db(conn: connection = db_connection_dependency) -> dict[str, str]:
-    with conn.cursor() as cur:
-        cur.execute("SELECT 1")
-        _ = cur.fetchone()
-    return {"status": "ok"}
-
-
-@app.post("/predict", response_model=RecommendationResponse)
-def predict(request_body: RecommendationRequest, request: Request) -> RecommendationResponse:
-    rag_chain = getattr(request.app.state, "rag_chain", None)
-    if rag_chain is None:
-        raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
-
-    result = rag_chain.invoke({"query": request_body.query})
-    response_text = result.get("result") or result.get("response") or ""
-    source_documents = result.get("source_documents") or []
-
-    return RecommendationResponse(
-        response=response_text,
-        sources=serialize_sources(source_documents, request_body.limit),
-    )

--- a/app/main.py
+++ b/app/main.py
@@ -10,8 +10,8 @@ from psycopg2.extensions import connection
 from pydantic import BaseModel, Field
 
 from .chain import build_rag_chain
-from .config import get_settings, require_database_url, resolve_llm_api_key
-from .db import get_db
+from .config import get_settings, resolve_llm_api_key
+from .db import close_pool, get_db
 from .providers import get_provider
 
 db_connection_dependency = Depends(get_db)
@@ -94,7 +94,6 @@ def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
         model_version=str(model_version.version),
     )
     chain = build_rag_chain(
-        connection_string=require_database_url(),
         api_key=resolve_llm_api_key(config.llm_provider),
         llm_provider=config.llm_provider,
         chat_model=config.chat_model,
@@ -124,7 +123,10 @@ async def lifespan(app: FastAPI):
     rag_chain, model_config = load_registered_rag_chain()
     app.state.rag_chain = rag_chain
     app.state.active_model_config = model_config
-    yield
+    try:
+        yield
+    finally:
+        close_pool()
 
 
 def create_app() -> FastAPI:

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
 from .db import get_db
+from .providers import get_provider
 
 db_connection_dependency = Depends(get_db)
 
@@ -55,12 +56,8 @@ def parse_active_model_config(
 ) -> ActiveModelConfig:
     settings = get_settings()
     llm_provider = (params.get("llm_provider") or "openai").lower()
-    if llm_provider == "openai":
-        default_chat_model = settings.openai_chat_model
-    elif llm_provider == "gemini":
-        default_chat_model = settings.gemini_chat_model
-    else:
-        raise ValueError(f"Unsupported llm_provider: {llm_provider}")
+    provider = get_provider(llm_provider)
+    default_chat_model = provider.default_chat_model(settings)
 
     return ActiveModelConfig(
         llm_provider=llm_provider,

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -10,12 +11,21 @@ from .config import get_settings
 from .db import close_pool
 from .routes import router
 
+logger = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    rag_chain, model_config = load_registered_rag_chain()
-    app.state.rag_chain = rag_chain
-    app.state.active_model_config = model_config
+    app.state.rag_chain = None
+    app.state.active_model_config = None
+    app.state.startup_error = None
+    try:
+        rag_chain, model_config = load_registered_rag_chain()
+        app.state.rag_chain = rag_chain
+        app.state.active_model_config = model_config
+    except Exception as exc:
+        logger.exception("Failed to load RAG chain at startup")
+        app.state.startup_error = f"{type(exc).__name__}: {exc}"
     try:
         yield
     finally:

--- a/app/providers.py
+++ b/app/providers.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from langchain_core.language_models import BaseChatModel
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import ChatOpenAI
+from pydantic import SecretStr
+
+from .config import Settings
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    default_chat_model: Callable[[Settings], str]
+    api_key: Callable[[Settings], str]
+    build_llm: Callable[[str, str, float], BaseChatModel]
+
+
+PROVIDERS: dict[str, ProviderSpec] = {
+    "openai": ProviderSpec(
+        default_chat_model=lambda s: s.openai_chat_model,
+        api_key=lambda s: s.openai_api_key,
+        build_llm=lambda model, key, temp: ChatOpenAI(
+            model=model, api_key=SecretStr(key), temperature=temp
+        ),
+    ),
+    "gemini": ProviderSpec(
+        default_chat_model=lambda s: s.gemini_chat_model,
+        api_key=lambda s: s.gemini_api_key,
+        build_llm=lambda model, key, temp: ChatGoogleGenerativeAI(
+            model=model, google_api_key=SecretStr(key), temperature=temp
+        ),
+    ),
+}
+
+
+def get_provider(name: str) -> ProviderSpec:
+    spec = PROVIDERS.get(name.lower())
+    if spec is None:
+        raise ValueError(f"Unsupported llm_provider: {name}")
+    return spec

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import psycopg2
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
@@ -8,6 +7,7 @@ from langchain_openai import OpenAIEmbeddings
 from pydantic import SecretStr
 
 from .config import get_settings
+from .db import borrow_connection
 
 
 def vector_to_pg(embedding: list[float]) -> str:
@@ -15,7 +15,6 @@ def vector_to_pg(embedding: list[float]) -> str:
 
 
 class PgVectorRetriever(BaseRetriever):
-    connection_string: str
     embedding_model: str = "text-embedding-3-small"
     k: int = 5
     openai_api_key: str | None = None
@@ -51,7 +50,7 @@ class PgVectorRetriever(BaseRetriever):
         LIMIT %s
         """
 
-        with psycopg2.connect(self.connection_string) as conn, conn.cursor() as cur:
+        with borrow_connection() as conn, conn.cursor() as cur:
             cur.execute(sql, (vector_literal, self.embedding_model, vector_literal, self.k))
             rows = cur.fetchall()
 

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -11,7 +11,7 @@ from .db import borrow_connection
 
 
 def vector_to_pg(embedding: list[float]) -> str:
-    return "[" + ",".join(f"{value:.8f}" for value in embedding) + "]"
+    return "[" + ",".join(repr(value) for value in embedding) + "]"
 
 
 class PgVectorRetriever(BaseRetriever):

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
@@ -8,6 +10,8 @@ from pydantic import SecretStr
 
 from .config import get_settings
 from .db import borrow_connection
+
+logger = logging.getLogger(__name__)
 
 
 def vector_to_pg(embedding: list[float]) -> str:
@@ -57,6 +61,9 @@ class PgVectorRetriever(BaseRetriever):
         with borrow_connection() as conn, conn.cursor() as cur:
             cur.execute(sql, (vector_literal, self.embedding_model, vector_literal, self.k))
             rows = cur.fetchall()
+
+        if not rows:
+            logger.info("retriever returned 0 rows for query of length %d", len(query))
 
         return [
             Document(

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -18,6 +18,17 @@ class PgVectorRetriever(BaseRetriever):
     embedding_model: str = "text-embedding-3-small"
     k: int = 5
     openai_api_key: str | None = None
+    _embeddings: OpenAIEmbeddings | None = None
+
+    def _get_embeddings(self) -> OpenAIEmbeddings:
+        if self._embeddings is None:
+            api_key = self.openai_api_key or get_settings().openai_api_key
+            if not api_key:
+                raise RuntimeError("Missing OPENAI_API_KEY for query embedding generation.")
+            self._embeddings = OpenAIEmbeddings(
+                model=self.embedding_model, api_key=SecretStr(api_key)
+            )
+        return self._embeddings
 
     def _get_relevant_documents(
         self,
@@ -27,12 +38,7 @@ class PgVectorRetriever(BaseRetriever):
     ) -> list[Document]:
         del run_manager
 
-        api_key = self.openai_api_key or get_settings().openai_api_key
-        if not api_key:
-            raise RuntimeError("Missing OPENAI_API_KEY for query embedding generation.")
-
-        embeddings = OpenAIEmbeddings(model=self.embedding_model, api_key=SecretStr(api_key))
-        vector_literal = vector_to_pg(embeddings.embed_query(query))
+        vector_literal = vector_to_pg(self._get_embeddings().embed_query(query))
 
         sql = """
         SELECT

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -36,8 +36,6 @@ class PgVectorRetriever(BaseRetriever):
         *,
         run_manager: CallbackManagerForRetrieverRun,
     ) -> list[Document]:
-        del run_manager
-
         vector_literal = vector_to_pg(self._get_embeddings().embed_query(query))
 
         sql = """

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -19,7 +19,7 @@ def vector_to_pg(embedding: list[float]) -> str:
 
 
 class PgVectorRetriever(BaseRetriever):
-    embedding_model: str = "text-embedding-3-small"
+    embedding_model: str
     k: int = 5
     openai_api_key: str | None = None
     _embeddings: OpenAIEmbeddings | None = None

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import logging
+import time
+import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -12,6 +15,7 @@ from .schemas import (
     RecommendationSource,
 )
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 db_connection_dependency = Depends(get_db)
 
@@ -63,13 +67,26 @@ def health_db(conn: connection = db_connection_dependency) -> dict[str, str]:
 
 @router.post("/predict", response_model=RecommendationResponse)
 def predict(request_body: RecommendationRequest, request: Request) -> RecommendationResponse:
+    request_id = uuid.uuid4().hex[:8]
+    start = time.perf_counter()
+    logger.info("predict[%s] start: query_len=%d", request_id, len(request_body.query))
+
     rag_chain = getattr(request.app.state, "rag_chain", None)
     if rag_chain is None:
+        logger.warning("predict[%s] rag_chain not loaded", request_id)
         raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
 
     result = rag_chain.invoke({"query": request_body.query})
     response_text = result.get("result") or result.get("response") or ""
     source_documents = result.get("source_documents") or []
+
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    logger.info(
+        "predict[%s] ok: sources=%d elapsed_ms=%.0f",
+        request_id,
+        len(source_documents),
+        elapsed_ms,
+    )
 
     return RecommendationResponse(
         response=response_text,

--- a/app/routes.py
+++ b/app/routes.py
@@ -40,7 +40,11 @@ def root() -> dict[str, str]:
 def health(request: Request) -> dict[str, str]:
     model_config = getattr(request.app.state, "active_model_config", None)
     if model_config is None:
-        raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
+        startup_error = getattr(request.app.state, "startup_error", None) or "unknown"
+        raise HTTPException(
+            status_code=503,
+            detail={"status": "degraded", "error": startup_error},
+        )
 
     return {
         "status": "ok",

--- a/app/routes.py
+++ b/app/routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from psycopg2.extensions import connection
 
 from .db import get_db
+from .errors import status_for_invoke_error
 from .schemas import (
     RecommendationRequest,
     RecommendationResponse,
@@ -76,7 +77,21 @@ def predict(request_body: RecommendationRequest, request: Request) -> Recommenda
         logger.warning("predict[%s] rag_chain not loaded", request_id)
         raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
 
-    result = rag_chain.invoke({"query": request_body.query})
+    try:
+        result = rag_chain.invoke({"query": request_body.query})
+    except Exception as exc:
+        status_code, message_prefix = status_for_invoke_error(exc)
+        logger.exception(
+            "predict[%s] failed: status=%d type=%s",
+            request_id,
+            status_code,
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=status_code,
+            detail=f"{message_prefix} (request_id={request_id}).",
+        ) from exc
+
     response_text = result.get("result") or result.get("response") or ""
     source_documents = result.get("source_documents") or []
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -16,9 +16,9 @@ router = APIRouter()
 db_connection_dependency = Depends(get_db)
 
 
-def serialize_sources(source_documents: list[Any], limit: int) -> list[RecommendationSource]:
+def serialize_sources(source_documents: list[Any]) -> list[RecommendationSource]:
     sources: list[RecommendationSource] = []
-    for document in source_documents[:limit]:
+    for document in source_documents:
         metadata = getattr(document, "metadata", {}) or {}
         sources.append(
             RecommendationSource(
@@ -73,5 +73,5 @@ def predict(request_body: RecommendationRequest, request: Request) -> Recommenda
 
     return RecommendationResponse(
         response=response_text,
-        sources=serialize_sources(source_documents, request_body.limit),
+        sources=serialize_sources(source_documents),
     )

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from psycopg2.extensions import connection
+
+from .db import get_db
+from .schemas import (
+    RecommendationRequest,
+    RecommendationResponse,
+    RecommendationSource,
+)
+
+router = APIRouter()
+db_connection_dependency = Depends(get_db)
+
+
+def serialize_sources(source_documents: list[Any], limit: int) -> list[RecommendationSource]:
+    sources: list[RecommendationSource] = []
+    for document in source_documents[:limit]:
+        metadata = getattr(document, "metadata", {}) or {}
+        sources.append(
+            RecommendationSource(
+                name=metadata.get("name"),
+                rating=metadata.get("rating"),
+                address=metadata.get("address"),
+                similarity=metadata.get("similarity"),
+            )
+        )
+    return sources
+
+
+@router.get("/root")
+def root() -> dict[str, str]:
+    return {"message": "Welcome!"}
+
+
+@router.get("/health")
+def health(request: Request) -> dict[str, str]:
+    model_config = getattr(request.app.state, "active_model_config", None)
+    if model_config is None:
+        raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
+
+    return {
+        "status": "ok",
+        "llm_provider": model_config.llm_provider,
+        "chat_model": model_config.chat_model,
+    }
+
+
+@router.get("/health/db")
+def health_db(conn: connection = db_connection_dependency) -> dict[str, str]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1")
+        _ = cur.fetchone()
+    return {"status": "ok"}
+
+
+@router.post("/predict", response_model=RecommendationResponse)
+def predict(request_body: RecommendationRequest, request: Request) -> RecommendationResponse:
+    rag_chain = getattr(request.app.state, "rag_chain", None)
+    if rag_chain is None:
+        raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
+
+    result = rag_chain.invoke({"query": request_body.query})
+    response_text = result.get("result") or result.get("response") or ""
+    source_documents = result.get("source_documents") or []
+
+    return RecommendationResponse(
+        response=response_text,
+        sources=serialize_sources(source_documents, request_body.limit),
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class RecommendationRequest(BaseModel):
+    query: str = Field(
+        ...,
+        description="User's recommendation query (for example, 'Best tacos in the Mission').",
+    )
+    limit: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Maximum number of source places to include in the response.",
+    )
+
+
+class RecommendationSource(BaseModel):
+    name: str | None = None
+    rating: float | None = None
+    address: str | None = None
+    similarity: float | None = None
+
+
+class RecommendationResponse(BaseModel):
+    response: str
+    sources: list[RecommendationSource]
+
+
+class ActiveModelConfig(BaseModel):
+    llm_provider: str
+    chat_model: str
+    k: int
+    temperature: float = 0.0
+    run_id: str | None = None
+    model_version: str | None = None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RecommendationRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
     query: str = Field(
         ...,
         description="User's recommendation query (for example, 'Best tacos in the Mission').",
-    )
-    limit: int = Field(
-        default=5,
-        ge=1,
-        le=20,
-        description="Maximum number of source places to include in the response.",
     )
 
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -20,9 +20,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** Added `require_database_url()` helper in `config.py`. Both call sites now use it. `resolved_database_url` still exists as the optional-returning property; `require_database_url()` is the assertive variant.
 
-### 3. `PgVectorRetriever` opens its own connection per query
+### 3. `PgVectorRetriever` opens its own connection per query — ✅ FIXED (with #16)
 
-`app/retriever.py:54` — the retriever bypasses `get_db()` and dials Postgres directly using `connection_string`. Under load this is a fresh TCP+auth roundtrip per request. Use a shared connection pool (`psycopg2.pool.SimpleConnectionPool` or migrate to `psycopg[pool]`).
+`app/retriever.py:54` — the retriever bypassed `get_db()` and dialed Postgres directly using `connection_string`. Under load this was a fresh TCP+auth roundtrip per request.
+
+**Resolution:** See #16. Both call sites now share a `ThreadedConnectionPool` via `borrow_connection()`. `PgVectorRetriever` no longer takes a `connection_string` kwarg.
 
 ### 4. `PgVectorRetriever` re-instantiates `OpenAIEmbeddings` every call
 
@@ -84,9 +86,11 @@ Zero `logging` calls in the package. Startup, MLflow load, and prediction errors
 
 ## Performance
 
-### 16. `get_db()` opens a fresh connection per request
+### 16. `get_db()` opens a fresh connection per request — ✅ FIXED
 
-`app/db.py:13` — same root cause as #3. Needs a pool for any real traffic.
+`app/db.py:13` — same root cause as #3.
+
+**Resolution:** Added a module-level `ThreadedConnectionPool` in `app/db.py` (`minconn=1, maxconn=10`) with a `borrow_connection()` context manager. Both `get_db()` and `PgVectorRetriever` borrow from it. `lifespan` calls `close_pool()` on shutdown so the pool is cleanly drained.
 
 ### 17. Duplicated embedding model default
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -51,9 +51,13 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** Added `cors_allowed_origins: list[str]` and `cors_allowed_origin_regex: str | None` to `Settings`. Defaults preserve current dev behavior. `.env.example` documents `CORS_ALLOWED_ORIGINS` (comma-separated) and `CORS_ALLOWED_ORIGIN_REGEX`. Methods/headers/credentials remain in code since they're tied to API surface, not deployment.
 
-### 7. Hard-coded MLflow IPs in defaults
+### 7. Hard-coded MLflow IPs in defaults — ✅ FIXED
 
-`app/config.py:90-91` defaults to `http://35.223.147.177:5000`, leaking infra into source. Require it via env (`= ""` + validation) or at minimum comment that it's the shared class server. Also `mlflow_artifacts_uri` looks malformed — `mlflow-artifacts://` URIs normally don't include `host:port`.
+`app/config.py:90-91` previously defaulted to `http://35.223.147.177:5000` (shared class MLflow server), leaking infra into source.
+
+**Resolution:** Both `mlflow_tracking_uri` and `mlflow_artifacts_uri` now default to `""`. Required via `.env` (already documented in `.env.example`). `app/bootstrap.py` raises a clear `RuntimeError` at startup if `MLFLOW_TRACKING_URI` is missing. `scripts/log_model_to_mlflow.py` skips `os.environ.setdefault("MLFLOW_ARTIFACTS_URI", ...)` when the setting is empty so we don't pollute the env with an empty string.
+
+**Note:** the `mlflow-artifacts://host:port/` form in `.env.example` may still be incorrect per the MLflow URI spec (the scheme is normally host-less), but it works empirically with the running tracking server. Out of scope here — verify with whoever owns the tracking server before changing.
 
 ### 8. `lifespan` has no error handling
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -26,9 +26,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** See #16. Both call sites now share a `ThreadedConnectionPool` via `borrow_connection()`. `PgVectorRetriever` no longer takes a `connection_string` kwarg.
 
-### 4. `PgVectorRetriever` re-instantiates `OpenAIEmbeddings` every call
+### 4. `PgVectorRetriever` re-instantiates `OpenAIEmbeddings` every call — ✅ FIXED
 
-`app/retriever.py:35` — construct the embeddings client once (in `__init__` or as a pydantic field), not per query.
+`app/retriever.py:35` — previously built a fresh `OpenAIEmbeddings` client on every query.
+
+**Resolution:** Added `_embeddings` private field + `_get_embeddings()` lazy-init method. The client is constructed once on first use and cached on the retriever instance. (`cached_property` doesn't compose cleanly with langchain's pydantic-based `BaseRetriever`, hence the manual lazy field.)
 
 ## Code Quality
 
@@ -37,6 +39,7 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 `main.py` previously mixed Pydantic schemas, MLflow loading, chain bootstrapping, source serialization, app factory, and routes (195 lines).
 
 **Resolution:** Split into:
+
 - `app/schemas.py` — Pydantic request/response models + `ActiveModelConfig`
 - `app/bootstrap.py` — `load_registered_rag_chain`, `parse_active_model_config`
 - `app/routes.py` — endpoints (`APIRouter`) + `serialize_sources`

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -59,9 +59,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Note:** the `mlflow-artifacts://host:port/` form in `.env.example` may still be incorrect per the MLflow URI spec (the scheme is normally host-less), but it works empirically with the running tracking server. Out of scope here — verify with whoever owns the tracking server before changing.
 
-### 8. `lifespan` has no error handling
+### 8. `lifespan` has no error handling — ✅ FIXED
 
-`app/main.py:128-133` — if `load_registered_rag_chain` raises, the app crashes at startup with a stack trace and `/health` can never report why. Catch, log, and store the error on `app.state` so `/health` returns `"rag_chain unavailable: <reason>"`.
+`app/main.py:128-133` — previously, if `load_registered_rag_chain` raised at startup, uvicorn exited with a stack trace and `/health` could never report why.
+
+**Resolution:** `lifespan` now catches startup errors, logs them via `logger.exception(...)`, and stores `f"{type(exc).__name__}: {exc}"` on `app.state.startup_error`. `/health` returns **503** with `{status: "degraded", error: <reason>}` when `active_model_config` is `None`. Added `test_health_reports_degraded_when_startup_fails` to verify. (Side effect: introduces the first `logging` call in `app/`, partially addresses #14.)
 
 ### 9. `parse_active_model_config` mixes types from MLflow params
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -65,9 +65,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** `lifespan` now catches startup errors, logs them via `logger.exception(...)`, and stores `f"{type(exc).__name__}: {exc}"` on `app.state.startup_error`. `/health` returns **503** with `{status: "degraded", error: <reason>}` when `active_model_config` is `None`. Added `test_health_reports_degraded_when_startup_fails` to verify. (Side effect: introduces the first `logging` call in `app/`, partially addresses #14.)
 
-### 9. `parse_active_model_config` mixes types from MLflow params
+### 9. `parse_active_model_config` mixes types from MLflow params — ✅ FIXED
 
-`app/main.py:65-72` — `int(params.get("k", settings.retriever_k))` works because the default is already an int, but `params.get("temperature", "0.0")` mixes string and float defaults. Standardize on strings everywhere or normalize once.
+`app/bootstrap.py` (post-#5 split) previously mixed an int default (`settings.retriever_k`) with a string default (`"0.0"`) and didn't handle the empty-string-from-MLflow edge case.
+
+**Resolution:** Added `_parse_int` / `_parse_float` helpers that treat missing key and empty string identically by stringifying the default first (`params.get(key) or str(default)`). Both numeric fields now use them. Three new tests in `tests/unit/test_bootstrap.py` cover string params, missing-key fallback, and the empty-string edge case.
 
 ### 10. Bare `except Exception` at MLflow load
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -14,9 +14,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** Consolidated into `app/providers.py` with a `PROVIDERS` dict keyed by name. Each entry holds `default_chat_model`, `api_key`, and `build_llm` callables. All three call sites now go through `get_provider(name)`.
 
-### 2. Duplicated "missing DATABASE_URL" guard
+### 2. Duplicated "missing DATABASE_URL" guard — ✅ FIXED
 
-`app/main.py:100-101` and `app/db.py:11-12` both raise the same `RuntimeError` with the same message. Push the check into `Settings.resolved_database_url` (return-or-raise) or a single helper.
+`app/main.py:100-101` and `app/db.py:11-12` both raised the same `RuntimeError` with the same message.
+
+**Resolution:** Added `require_database_url()` helper in `config.py`. Both call sites now use it. `resolved_database_url` still exists as the optional-returning property; `require_database_url()` is the assertive variant.
 
 ### 3. `PgVectorRetriever` opens its own connection per query
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -77,9 +77,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** Narrowed to `except MlflowException` (the base class for MLflow's API/network/protocol errors). Pragma removed. Added `test_load_registered_rag_chain_wraps_mlflow_exception` to verify the path. Programmer bugs now bubble up to the lifespan catch-all from #8 with a generic message — the right layered behavior.
 
-### 11. `serialize_sources` slices after retrieval
+### 11. `serialize_sources` slices after retrieval — ✅ FIXED
 
-`app/main.py:115` — `/predict` accepts `limit` up to 20, but the retriever fetches only `k` (e.g., 5) per MLflow config. If `k=5` and the user asks for `limit=20`, they silently get 5. Either clamp `limit` to `k` and document it, or thread `limit` through to the retriever.
+`/predict` accepted `limit` up to 20, but the retriever fetched only `k` per the MLflow config. `k=5` + `limit=20` silently returned 5 sources — the API contract was a lie.
+
+**Resolution:** Removed `limit` from `RecommendationRequest` entirely. `k` (set via MLflow) is now the single source-count knob, which fits the experiment-driven design. `RecommendationRequest` sets `extra="ignore"` so legacy clients that still send `limit` don't break. Frontend (`frontend/src/api/chat.js`) updated to drop the field. New `test_predict_ignores_unknown_request_fields` verifies forward-compat.
 
 ### 12. `del run_manager`
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -45,9 +45,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 - `app/routes.py` — endpoints (`APIRouter`) + `serialize_sources`
 - `app/main.py` — `create_app`, `lifespan`, `app = create_app()` (45 lines)
 
-### 6. Hard-coded CORS origins
+### 6. Hard-coded CORS origins — ✅ FIXED
 
-`app/main.py:145-146` bakes in `http://localhost:5173`, `http://localhost:3000`, and the `*.vercel.app` regex. Move to `Settings` (`cors_allowed_origins: list[str]`) so dev/staging/prod differ via env.
+`app/main.py:145-146` previously baked in `http://localhost:5173`, `http://localhost:3000`, and the `*.vercel.app` regex.
+
+**Resolution:** Added `cors_allowed_origins: list[str]` and `cors_allowed_origin_regex: str | None` to `Settings`. Defaults preserve current dev behavior. `.env.example` documents `CORS_ALLOWED_ORIGINS` (comma-separated) and `CORS_ALLOWED_ORIGIN_REGEX`. Methods/headers/credentials remain in code since they're tied to API surface, not deployment.
 
 ### 7. Hard-coded MLflow IPs in defaults
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -4,15 +4,15 @@ Audit of `app/` (`main.py`, `config.py`, `db.py`, `chain.py`, `retriever.py`).
 
 ## Architecture / Design
 
-### 1. Duplicated provider-dispatch logic (DRY violation — highest priority)
+### 1. Duplicated provider-dispatch logic (DRY violation — highest priority) — ✅ FIXED
 
-The "openai vs gemini, else raise" branching exists in three places with slightly different shapes:
+The "openai vs gemini, else raise" branching previously existed in three places with slightly different shapes:
 
 - `app/main.py:57-63` — picks default chat model
 - `app/config.py:128-133` — picks API key
 - `app/chain.py:31-40` — instantiates the LLM
 
-Adding a third provider requires editing all three. Consolidate into a single registry/dispatch table — e.g., a `PROVIDERS` dict keyed by name with `{default_model, api_key_attr, llm_factory}`.
+**Resolution:** Consolidated into `app/providers.py` with a `PROVIDERS` dict keyed by name. Each entry holds `default_chat_model`, `api_key`, and `build_llm` callables. All three call sites now go through `get_provider(name)`.
 
 ### 2. Duplicated "missing DATABASE_URL" guard
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -132,9 +132,11 @@ Failures log via `logger.exception` at ERROR (full stack server-side), and the c
 
 **Resolution:** Added a module-level `ThreadedConnectionPool` in `app/db.py` (`minconn=1, maxconn=10`) with a `borrow_connection()` context manager. Both `get_db()` and `PgVectorRetriever` borrow from it. `lifespan` calls `close_pool()` on shutdown so the pool is cleanly drained.
 
-### 17. Duplicated embedding model default
+### 17. Duplicated embedding model default — ✅ FIXED
 
-`app/retriever.py:19` defaults to `"text-embedding-3-small"` and `app/config.py:87` does the same. The retriever default is dead code (always overridden in `app/chain.py:25`) — drop it, or read from settings inside the retriever.
+`app/retriever.py:19` previously hardcoded `"text-embedding-3-small"` as the field default while `app/config.py:87` held the same value as the source of truth. The retriever default was dead code (always overridden by `chain.py`).
+
+**Resolution:** Dropped the default — `embedding_model: str` is now required on `PgVectorRetriever`. Forgetting to pass it raises a clear pydantic validation error at construction time instead of silently using a stale hardcoded model.
 
 ---
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -83,9 +83,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** Removed `limit` from `RecommendationRequest` entirely. `k` (set via MLflow) is now the single source-count knob, which fits the experiment-driven design. `RecommendationRequest` sets `extra="ignore"` so legacy clients that still send `limit` don't break. Frontend (`frontend/src/api/chat.js`) updated to drop the field. New `test_predict_ignores_unknown_request_fields` verifies forward-compat.
 
-### 12. `del run_manager`
+### 12. `del run_manager` — ✅ FIXED
 
-`app/retriever.py:29` — unusual style. Rename the parameter `_run_manager` or drop the `del`.
+`app/retriever.py:29` previously used `del run_manager` as paranoid defense against an unused-arg lint that isn't actually enabled in `pyproject.toml` (ruff rules `E, F, I, N, UP, B, SIM` — no `ARG`).
+
+**Resolution:** Dropped the `del` line. If ruff `ARG` ever gets enabled, the failure mode is a single visible lint error.
 
 ### 13. `vector_to_pg` truncates float precision
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -1,0 +1,99 @@
+# `app/` Code Smell Audit
+
+Audit of `app/` (`main.py`, `config.py`, `db.py`, `chain.py`, `retriever.py`).
+
+## Architecture / Design
+
+### 1. Duplicated provider-dispatch logic (DRY violation — highest priority)
+
+The "openai vs gemini, else raise" branching exists in three places with slightly different shapes:
+
+- `app/main.py:57-63` — picks default chat model
+- `app/config.py:128-133` — picks API key
+- `app/chain.py:31-40` — instantiates the LLM
+
+Adding a third provider requires editing all three. Consolidate into a single registry/dispatch table — e.g., a `PROVIDERS` dict keyed by name with `{default_model, api_key_attr, llm_factory}`.
+
+### 2. Duplicated "missing DATABASE_URL" guard
+
+`app/main.py:100-101` and `app/db.py:11-12` both raise the same `RuntimeError` with the same message. Push the check into `Settings.resolved_database_url` (return-or-raise) or a single helper.
+
+### 3. `PgVectorRetriever` opens its own connection per query
+
+`app/retriever.py:54` — the retriever bypasses `get_db()` and dials Postgres directly using `connection_string`. Under load this is a fresh TCP+auth roundtrip per request. Use a shared connection pool (`psycopg2.pool.SimpleConnectionPool` or migrate to `psycopg[pool]`).
+
+### 4. `PgVectorRetriever` re-instantiates `OpenAIEmbeddings` every call
+
+`app/retriever.py:35` — construct the embeddings client once (in `__init__` or as a pydantic field), not per query.
+
+## Code Quality
+
+### 5. `main.py` is doing too much
+
+`main.py` mixes Pydantic schemas, MLflow loading, chain bootstrapping, source serialization, app factory, and routes. Split into:
+
+- `app/schemas.py` — request/response models
+- `app/bootstrap.py` (or `app/mlflow_loader.py`) — `load_registered_rag_chain`, `parse_active_model_config`
+- `app/routes.py` — endpoints
+
+`main.py` should be ~30 lines.
+
+### 6. Hard-coded CORS origins
+
+`app/main.py:145-146` bakes in `http://localhost:5173`, `http://localhost:3000`, and the `*.vercel.app` regex. Move to `Settings` (`cors_allowed_origins: list[str]`) so dev/staging/prod differ via env.
+
+### 7. Hard-coded MLflow IPs in defaults
+
+`app/config.py:90-91` defaults to `http://35.223.147.177:5000`, leaking infra into source. Require it via env (`= ""` + validation) or at minimum comment that it's the shared class server. Also `mlflow_artifacts_uri` looks malformed — `mlflow-artifacts://` URIs normally don't include `host:port`.
+
+### 8. `lifespan` has no error handling
+
+`app/main.py:128-133` — if `load_registered_rag_chain` raises, the app crashes at startup with a stack trace and `/health` can never report why. Catch, log, and store the error on `app.state` so `/health` returns `"rag_chain unavailable: <reason>"`.
+
+### 9. `parse_active_model_config` mixes types from MLflow params
+
+`app/main.py:65-72` — `int(params.get("k", settings.retriever_k))` works because the default is already an int, but `params.get("temperature", "0.0")` mixes string and float defaults. Standardize on strings everywhere or normalize once.
+
+### 10. Bare `except Exception` at MLflow load
+
+`app/main.py:87` — the `# pragma: no cover` flags this as known sketchy. Catch `mlflow.exceptions.MlflowException` / `RestException` specifically.
+
+### 11. `serialize_sources` slices after retrieval
+
+`app/main.py:115` — `/predict` accepts `limit` up to 20, but the retriever fetches only `k` (e.g., 5) per MLflow config. If `k=5` and the user asks for `limit=20`, they silently get 5. Either clamp `limit` to `k` and document it, or thread `limit` through to the retriever.
+
+### 12. `del run_manager`
+
+`app/retriever.py:29` — unusual style. Rename the parameter `_run_manager` or drop the `del`.
+
+### 13. `vector_to_pg` truncates float precision
+
+`app/retriever.py:14` — `f"{value:.8f}"` loses precision unnecessarily. pgvector accepts full float repr; use `repr(value)` or `str(value)`.
+
+## Tests / Observability
+
+### 14. No logging anywhere in `app/`
+
+Zero `logging` calls in the package. Startup, MLflow load, and prediction errors are all silent. Add a module logger and log at minimum: model version + provider on startup, retriever errors, predict failures.
+
+### 15. `/predict` has no error handling around `rag_chain.invoke`
+
+`app/main.py:189` — any LLM/DB exception 500s with a stack trace to the client. Wrap and return a structured error response.
+
+## Performance
+
+### 16. `get_db()` opens a fresh connection per request
+
+`app/db.py:13` — same root cause as #3. Needs a pool for any real traffic.
+
+### 17. Duplicated embedding model default
+
+`app/retriever.py:19` defaults to `"text-embedding-3-small"` and `app/config.py:87` does the same. The retriever default is dead code (always overridden in `app/chain.py:25`) — drop it, or read from settings inside the retriever.
+
+---
+
+## Suggested fix order
+
+1. **#1** — provider registry. Eliminates ~30 lines of triplicated branching across three files.
+2. **#3 / #16** — connection pooling. Actual production risk under load.
+3. **#5** — split `main.py`. Unlocks easier testing of everything above.

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -89,9 +89,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** Dropped the `del` line. If ruff `ARG` ever gets enabled, the failure mode is a single visible lint error.
 
-### 13. `vector_to_pg` truncates float precision
+### 13. `vector_to_pg` truncates float precision — ✅ FIXED
 
-`app/retriever.py:14` — `f"{value:.8f}"` loses precision unnecessarily. pgvector accepts full float repr; use `repr(value)` or `str(value)`.
+`app/retriever.py:14` previously used `f"{value:.8f}"`, which dropped precision (~7 significant digits) and zeroed out small values like `1e-12`.
+
+**Resolution:** Switched to `repr(value)` — Python's canonical lossless float-to-string. pgvector parses it fine. Test assertion updated to the new format (`"[0.125,0.5,1.0]"` instead of `"[0.12500000,0.50000000,1.00000000]"`).
 
 ## Tests / Observability
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -97,9 +97,18 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 ## Tests / Observability
 
-### 14. No logging anywhere in `app/`
+### 14. No logging anywhere in `app/` — ✅ FIXED
 
-Zero `logging` calls in the package. Startup, MLflow load, and prediction errors are all silent. Add a module logger and log at minimum: model version + provider on startup, retriever errors, predict failures.
+Previously zero `logging` calls in the package — startup, MLflow load, and prediction failures were all silent. (#8 added the first one in lifespan.)
+
+**Resolution:**
+
+- `Settings.log_level: str = "INFO"` (configurable via `LOG_LEVEL` env, already in `.env.example`).
+- `app/main.py` calls `logging.basicConfig(level=..., format="%(asctime)s %(levelname)s %(name)s: %(message)s")` at module load.
+- `app/bootstrap.py` logs `INFO` on successful MLflow load with model/version/provider/chat_model/k/temperature.
+- `app/db.py` logs pool create + pool close at `INFO`.
+- `app/retriever.py` logs `INFO` when a query returns zero rows.
+- `app/routes.py` logs `/predict` start (query length only — never content, for privacy) and end (source count + elapsed ms) tagged with a per-request id.
 
 ### 15. `/predict` has no error handling around `rag_chain.invoke`
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -110,9 +110,19 @@ Previously zero `logging` calls in the package — startup, MLflow load, and pre
 - `app/retriever.py` logs `INFO` when a query returns zero rows.
 - `app/routes.py` logs `/predict` start (query length only — never content, for privacy) and end (source count + elapsed ms) tagged with a per-request id.
 
-### 15. `/predict` has no error handling around `rag_chain.invoke`
+### 15. `/predict` has no error handling around `rag_chain.invoke` — ✅ FIXED
 
-`app/main.py:189` — any LLM/DB exception 500s with a stack trace to the client. Wrap and return a structured error response.
+`/predict` previously let any LLM/DB exception bubble up as a 500 with a stack trace.
+
+**Resolution:** Wrapped `rag_chain.invoke` in try/except. Vendor exception classes mapped via new `app/errors.py` helper:
+
+- `openai.RateLimitError` / `google.api_core.exceptions.ResourceExhausted` → **429**
+- `openai.OpenAIError` / `google.api_core.exceptions.GoogleAPIError` → **502**
+- `psycopg2.OperationalError` → **503**
+- `psycopg2.DatabaseError` (other) → **500**
+- Anything else → **500**
+
+Failures log via `logger.exception` at ERROR (full stack server-side), and the client gets a generic `<message_prefix> (request_id=<8-char-id>)` so users can quote the id when reporting issues. Three new tests cover the LLM, rate-limit, and DB-operational paths.
 
 ## Performance
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -71,9 +71,11 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 **Resolution:** Added `_parse_int` / `_parse_float` helpers that treat missing key and empty string identically by stringifying the default first (`params.get(key) or str(default)`). Both numeric fields now use them. Three new tests in `tests/unit/test_bootstrap.py` cover string params, missing-key fallback, and the empty-string edge case.
 
-### 10. Bare `except Exception` at MLflow load
+### 10. Bare `except Exception` at MLflow load — ✅ FIXED
 
-`app/main.py:87` — the `# pragma: no cover` flags this as known sketchy. Catch `mlflow.exceptions.MlflowException` / `RestException` specifically.
+`app/bootstrap.py` (post-#5 split) previously used `except Exception` to wrap MLflow-load failures, with a `# pragma: no cover` admitting discomfort. Programmer bugs (`TypeError`, `AttributeError`) would have been swallowed and mislabeled.
+
+**Resolution:** Narrowed to `except MlflowException` (the base class for MLflow's API/network/protocol errors). Pragma removed. Added `test_load_registered_rag_chain_wraps_mlflow_exception` to verify the path. Programmer bugs now bubble up to the lifespan catch-all from #8 with a generic message — the right layered behavior.
 
 ### 11. `serialize_sources` slices after retrieval
 

--- a/docs/code-smells/app-code-smells.md
+++ b/docs/code-smells/app-code-smells.md
@@ -32,15 +32,15 @@ The "openai vs gemini, else raise" branching previously existed in three places 
 
 ## Code Quality
 
-### 5. `main.py` is doing too much
+### 5. `main.py` is doing too much — ✅ FIXED
 
-`main.py` mixes Pydantic schemas, MLflow loading, chain bootstrapping, source serialization, app factory, and routes. Split into:
+`main.py` previously mixed Pydantic schemas, MLflow loading, chain bootstrapping, source serialization, app factory, and routes (195 lines).
 
-- `app/schemas.py` — request/response models
-- `app/bootstrap.py` (or `app/mlflow_loader.py`) — `load_registered_rag_chain`, `parse_active_model_config`
-- `app/routes.py` — endpoints
-
-`main.py` should be ~30 lines.
+**Resolution:** Split into:
+- `app/schemas.py` — Pydantic request/response models + `ActiveModelConfig`
+- `app/bootstrap.py` — `load_registered_rag_chain`, `parse_active_model_config`
+- `app/routes.py` — endpoints (`APIRouter`) + `serialize_sources`
+- `app/main.py` — `create_app`, `lifespan`, `app = create_app()` (45 lines)
 
 ### 6. Hard-coded CORS origins
 

--- a/frontend/src/api/chat.js
+++ b/frontend/src/api/chat.js
@@ -19,7 +19,6 @@
  */
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
-const DEFAULT_LIMIT = 7
 
 /**
  * Send a chat message to the FastAPI /predict endpoint and adapt the
@@ -27,16 +26,14 @@ const DEFAULT_LIMIT = 7
  *
  * @param {string} message
  * @param {{ role: string, content: string }[]} _history  (unused; kept for signature compatibility)
- * @param {{ limit?: number }} [opts]
+ * @param {{}} [_opts]  (reserved for future per-request options)
  * @returns {Promise<{ reply: string, places: object[], ragLabel?: string }>}
  */
-export async function sendMessage(message, _history = [], opts = {}) {
-  const limit = opts.limit ?? DEFAULT_LIMIT
-
+export async function sendMessage(message, _history = [], _opts = {}) {
   const res = await fetch(`${API_BASE}/predict`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query: message, limit }),
+    body: JSON.stringify({ query: message }),
   })
 
   if (!res.ok) {

--- a/scripts/log_model_to_mlflow.py
+++ b/scripts/log_model_to_mlflow.py
@@ -187,7 +187,8 @@ def log_rag_experiment(
     tracking_uri = tracking_uri or settings.mlflow_tracking_uri
     model_name = model_name or settings.mlflow_model_name
 
-    os.environ.setdefault("MLFLOW_ARTIFACTS_URI", settings.mlflow_artifacts_uri)
+    if settings.mlflow_artifacts_uri:
+        os.environ.setdefault("MLFLOW_ARTIFACTS_URI", settings.mlflow_artifacts_uri)
     mlflow.set_tracking_uri(tracking_uri)
     mlflow.set_experiment(experiment_name)
 
@@ -263,7 +264,8 @@ def log_rag_experiments_from_config(
     resolved_sample_queries = sample_queries or config.sample_queries
     resolved_tracking_uri = tracking_uri or settings.mlflow_tracking_uri
 
-    os.environ.setdefault("MLFLOW_ARTIFACTS_URI", settings.mlflow_artifacts_uri)
+    if settings.mlflow_artifacts_uri:
+        os.environ.setdefault("MLFLOW_ARTIFACTS_URI", settings.mlflow_artifacts_uri)
     mlflow.set_tracking_uri(resolved_tracking_uri)
     mlflow.set_experiment(resolved_experiment_name)
 

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from app.bootstrap import parse_active_model_config
+import pytest
+from mlflow.exceptions import MlflowException
+
+from app.bootstrap import load_registered_rag_chain, parse_active_model_config
 
 
 def test_parse_active_model_config_uses_string_params_from_mlflow() -> None:
@@ -28,3 +31,21 @@ def test_parse_active_model_config_handles_empty_string_numerics() -> None:
     # Empty string should be treated as missing, not raise ValueError.
     assert config.k >= 1
     assert config.temperature == 0.0
+
+
+def test_load_registered_rag_chain_wraps_mlflow_exception(mocker, monkeypatch) -> None:
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://test-mlflow:5000")
+    mocker.patch(
+        "app.bootstrap.get_settings",
+        return_value=mocker.Mock(
+            mlflow_tracking_uri="http://test-mlflow:5000",
+            mlflow_model_name="city-concierge-rag",
+        ),
+    )
+    mocker.patch("app.bootstrap.mlflow.set_tracking_uri")
+    fake_client = mocker.Mock()
+    fake_client.get_model_version_by_alias.side_effect = MlflowException("alias not found")
+    mocker.patch("app.bootstrap.mlflow.MlflowClient", return_value=fake_client)
+
+    with pytest.raises(RuntimeError, match="Unable to load the MLflow production alias"):
+        load_registered_rag_chain()

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from app.bootstrap import parse_active_model_config
+
+
+def test_parse_active_model_config_uses_string_params_from_mlflow() -> None:
+    config = parse_active_model_config(
+        {"llm_provider": "openai", "chat_model": "gpt-4o-mini", "k": "7", "temperature": "0.3"},
+        run_id="run-abc",
+        model_version="3",
+    )
+    assert config.k == 7
+    assert config.temperature == 0.3
+    assert config.chat_model == "gpt-4o-mini"
+    assert config.run_id == "run-abc"
+    assert config.model_version == "3"
+
+
+def test_parse_active_model_config_falls_back_to_defaults_when_missing() -> None:
+    config = parse_active_model_config({}, run_id="r", model_version="1")
+    assert config.llm_provider == "openai"
+    assert config.k >= 1  # falls back to settings.retriever_k
+    assert config.temperature == 0.0
+
+
+def test_parse_active_model_config_handles_empty_string_numerics() -> None:
+    config = parse_active_model_config({"k": "", "temperature": ""}, run_id="r", model_version="1")
+    # Empty string should be treated as missing, not raise ValueError.
+    assert config.k >= 1
+    assert config.temperature == 0.0

--- a/tests/unit/test_chain.py
+++ b/tests/unit/test_chain.py
@@ -17,7 +17,6 @@ def test_build_rag_chain_supports_openai(mocker) -> None:
     from_chain = mocker.patch("app.chain.RetrievalQA.from_chain_type", return_value=chain)
 
     result_chain = build_rag_chain(
-        connection_string="postgresql://example",
         api_key="openai-key",
         llm_provider="openai",
         chat_model="gpt-4o-mini",
@@ -57,7 +56,6 @@ def test_build_rag_chain_supports_gemini(mocker) -> None:
     mocker.patch("app.chain.RetrievalQA.from_chain_type", return_value=chain)
 
     result_chain = build_rag_chain(
-        connection_string="postgresql://example",
         api_key="gemini-key",
         llm_provider="gemini",
         chat_model="gemini-2.5-flash",
@@ -79,7 +77,6 @@ def test_build_rag_chain_supports_gemini(mocker) -> None:
 def test_build_rag_chain_rejects_invalid_provider() -> None:
     with pytest.raises(ValueError, match="Unsupported llm_provider"):
         build_rag_chain(
-            connection_string="postgresql://example",
             api_key="unused",
             llm_provider="anthropic",
             chat_model="claude",

--- a/tests/unit/test_chain.py
+++ b/tests/unit/test_chain.py
@@ -12,8 +12,8 @@ def test_build_rag_chain_supports_openai(mocker) -> None:
     chain.invoke.return_value = {"result": "Try Taqueria Example.", "source_documents": []}
 
     retriever_cls = mocker.patch("app.chain.PgVectorRetriever", return_value=retriever)
-    openai_cls = mocker.patch("app.chain.ChatOpenAI", return_value="openai-llm")
-    mocker.patch("app.chain.ChatGoogleGenerativeAI")
+    openai_cls = mocker.patch("app.providers.ChatOpenAI", return_value="openai-llm")
+    mocker.patch("app.providers.ChatGoogleGenerativeAI")
     from_chain = mocker.patch("app.chain.RetrievalQA.from_chain_type", return_value=chain)
 
     result_chain = build_rag_chain(
@@ -49,9 +49,9 @@ def test_build_rag_chain_supports_gemini(mocker) -> None:
     chain.invoke.return_value = {"result": "Try Del Popolo.", "source_documents": []}
 
     mocker.patch("app.chain.PgVectorRetriever", return_value=retriever)
-    mocker.patch("app.chain.ChatOpenAI")
+    mocker.patch("app.providers.ChatOpenAI")
     gemini_cls = mocker.patch(
-        "app.chain.ChatGoogleGenerativeAI",
+        "app.providers.ChatGoogleGenerativeAI",
         return_value="gemini-llm",
     )
     mocker.patch("app.chain.RetrievalQA.from_chain_type", return_value=chain)

--- a/tests/unit/test_predict_endpoint.py
+++ b/tests/unit/test_predict_endpoint.py
@@ -58,3 +58,18 @@ def test_predict_endpoint_returns_response_and_sources(mocker) -> None:
         ],
     }
     fake_chain.invoke.assert_called_once_with({"query": "Best tacos in the Mission"})
+
+
+def test_health_reports_degraded_when_startup_fails(mocker) -> None:
+    mocker.patch(
+        "app.main.load_registered_rag_chain",
+        side_effect=RuntimeError("MLFLOW_TRACKING_URI is required (set it in .env)."),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["detail"]["status"] == "degraded"
+    assert "MLFLOW_TRACKING_URI" in body["detail"]["error"]

--- a/tests/unit/test_predict_endpoint.py
+++ b/tests/unit/test_predict_endpoint.py
@@ -4,7 +4,8 @@ from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
-from app.main import ActiveModelConfig, app
+from app.main import app
+from app.schemas import ActiveModelConfig
 
 
 def test_predict_endpoint_returns_response_and_sources(mocker) -> None:

--- a/tests/unit/test_predict_endpoint.py
+++ b/tests/unit/test_predict_endpoint.py
@@ -2,10 +2,26 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import openai
+import psycopg2
 from fastapi.testclient import TestClient
 
 from app.main import app
 from app.schemas import ActiveModelConfig
+
+
+def _stub_chain_raising(mocker, exc: Exception):
+    fake_chain = mocker.Mock()
+    fake_chain.invoke.side_effect = exc
+    mocker.patch(
+        "app.main.load_registered_rag_chain",
+        return_value=(
+            fake_chain,
+            ActiveModelConfig(
+                llm_provider="openai", chat_model="gpt-4o-mini", k=5, temperature=0.0
+            ),
+        ),
+    )
 
 
 def test_predict_endpoint_returns_response_and_sources(mocker) -> None:
@@ -58,6 +74,42 @@ def test_predict_endpoint_returns_response_and_sources(mocker) -> None:
         ],
     }
     fake_chain.invoke.assert_called_once_with({"query": "Best tacos in the Mission"})
+
+
+class _FakeRateLimit(openai.RateLimitError):
+    def __init__(self, msg: str = "rate limited") -> None:
+        Exception.__init__(self, msg)
+
+
+def test_predict_returns_502_on_openai_error(mocker) -> None:
+    _stub_chain_raising(mocker, openai.OpenAIError("upstream borked"))
+
+    with TestClient(app) as client:
+        response = client.post("/predict", json={"query": "anything"})
+
+    assert response.status_code == 502
+    assert "Upstream LLM error" in response.json()["detail"]
+    assert "request_id=" in response.json()["detail"]
+
+
+def test_predict_returns_429_on_rate_limit(mocker) -> None:
+    _stub_chain_raising(mocker, _FakeRateLimit())
+
+    with TestClient(app) as client:
+        response = client.post("/predict", json={"query": "anything"})
+
+    assert response.status_code == 429
+    assert "rate limit" in response.json()["detail"].lower()
+
+
+def test_predict_returns_503_on_db_operational_error(mocker) -> None:
+    _stub_chain_raising(mocker, psycopg2.OperationalError("connection timed out"))
+
+    with TestClient(app) as client:
+        response = client.post("/predict", json={"query": "anything"})
+
+    assert response.status_code == 503
+    assert "Database" in response.json()["detail"]
 
 
 def test_predict_ignores_unknown_request_fields(mocker) -> None:

--- a/tests/unit/test_predict_endpoint.py
+++ b/tests/unit/test_predict_endpoint.py
@@ -42,7 +42,7 @@ def test_predict_endpoint_returns_response_and_sources(mocker) -> None:
     with TestClient(app) as client:
         response = client.post(
             "/predict",
-            json={"query": "Best tacos in the Mission", "limit": 5},
+            json={"query": "Best tacos in the Mission"},
         )
 
     assert response.status_code == 200
@@ -58,6 +58,29 @@ def test_predict_endpoint_returns_response_and_sources(mocker) -> None:
         ],
     }
     fake_chain.invoke.assert_called_once_with({"query": "Best tacos in the Mission"})
+
+
+def test_predict_ignores_unknown_request_fields(mocker) -> None:
+    fake_chain = mocker.Mock()
+    fake_chain.invoke.return_value = {"result": "ok", "source_documents": []}
+    mocker.patch(
+        "app.main.load_registered_rag_chain",
+        return_value=(
+            fake_chain,
+            ActiveModelConfig(
+                llm_provider="openai", chat_model="gpt-4o-mini", k=5, temperature=0.0
+            ),
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/predict",
+            json={"query": "anything", "limit": 99, "made_up_field": True},
+        )
+
+    assert response.status_code == 200
+    fake_chain.invoke.assert_called_once_with({"query": "anything"})
 
 
 def test_health_reports_degraded_when_startup_fails(mocker) -> None:

--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -55,14 +55,13 @@ def test_get_relevant_documents_formats_vector_and_maps_metadata(mocker) -> None
     ]
     fake_cursor = FakeCursor(rows)
     fake_connection = FakeConnection(fake_cursor)
-    mocker.patch("app.retriever.psycopg2.connect", return_value=fake_connection)
+    mocker.patch("app.retriever.borrow_connection", return_value=fake_connection)
 
     embeddings = mocker.Mock()
     embeddings.embed_query.return_value = [0.125, 0.5, 1.0]
     embeddings_cls = mocker.patch("app.retriever.OpenAIEmbeddings", return_value=embeddings)
 
     retriever = PgVectorRetriever(
-        connection_string="postgresql://example",
         embedding_model="text-embedding-3-small",
         k=3,
         openai_api_key="test-key",

--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -77,9 +77,9 @@ def test_get_relevant_documents_formats_vector_and_maps_metadata(mocker) -> None
     assert "JOIN places_raw" in fake_cursor.executed_sql
     assert "ORDER BY e.embedding <=> %s::vector" in fake_cursor.executed_sql
     assert fake_cursor.executed_params == (
-        "[0.12500000,0.50000000,1.00000000]",
+        "[0.125,0.5,1.0]",
         "text-embedding-3-small",
-        "[0.12500000,0.50000000,1.00000000]",
+        "[0.125,0.5,1.0]",
         3,
     )
 


### PR DESCRIPTION
## Summary

- Walked through all 17 smells in `docs/code-smells/app-code-smells.md` interactively, one at a time
- Each fix is its own commit with explicit before/after rationale
- Test count: **40 → 49** (unit tests passing throughout)

## Highlights

| # | Smell | Fix |
|---|---|---|
| 1 | Triplicated provider dispatch | New `app/providers.py` registry |
| 2 | Duplicated DATABASE_URL guard | `require_database_url()` helper |
| 3 + 16 | Per-request DB connections | Shared `ThreadedConnectionPool` |
| 4 | Embeddings client rebuilt per query | Lazy-init + cached on retriever |
| 5 | `main.py` doing too much | Split into `schemas.py`, `bootstrap.py`, `routes.py` |
| 6 | Hardcoded CORS origins | Configurable via env |
| 7 | Hardcoded MLflow IPs | Required via env, defaults dropped |
| 8 | `lifespan` no error handling | Catches startup errors → `/health` returns 503 with reason |
| 9 | Mixed-type MLflow param parsing | `_parse_int` / `_parse_float` helpers |
| 10 | Bare `except Exception` at MLflow load | Narrowed to `MlflowException` |
| 11 | `serialize_sources` post-slice (`limit` lie) | Removed `limit` from API; `k` from MLflow drives it |
| 12 | `del run_manager` paranoia | Dropped |
| 13 | `vector_to_pg` precision loss | `repr()` for lossless serialization |
| 14 | No logging in `app/` | Loggers + `logging.basicConfig` from `Settings.log_level`, lifecycle/request events |
| 15 | `/predict` no error handling | New `app/errors.py` maps vendor exceptions to 429/502/503/500 with request_id |
| 17 | Duplicated embedding model default | Dropped dead default; required at construction |

Plus supporting commits: test fix for #1's mock paths, and a CLAUDE/AGENTS/copilot-instructions note about pre-commit ruff.

## Test plan

- [x] `poetry run pytest tests/unit/` passes (49 tests)
- [x] pre-commit hooks (ruff check + format) pass on every commit
- [ ] Manual smoke test of `/predict` against Cloud SQL via `make dev` after merge
- [ ] Verify `/health` reports `degraded` with helpful detail when `MLFLOW_TRACKING_URI` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)