### PR TITLE
fix: local docker dev works with private VPC networking + graceful MLflow degradation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,14 @@ GEMINI_API_KEY=AIza...
 GEMINI_CHAT_MODEL=gemini-2.5-flash
 
 # ── MLflow ────────────────────────────────────
-MLFLOW_TRACKING_URI=http://35.223.147.177:5000
-MLFLOW_ARTIFACTS_URI=mlflow-artifacts://35.223.147.177:5000
+# Local development uses an IAP/SSH tunnel to the private MLflow VM.
+# Open the tunnel before running the app:
+#   gcloud compute ssh mlflow-server --project=mlops-491820 \
+#     --zone=us-central1-a --tunnel-through-iap -- -L 5000:localhost:5000
+# Host-side processes use localhost:5000.
+# Docker Compose containers use host.docker.internal:5000 (set in docker-compose.yml).
+MLFLOW_TRACKING_URI=http://localhost:5000
+MLFLOW_ARTIFACTS_URI=mlflow-artifacts://localhost:5000
 MLFLOW_MODEL_NAME=city-concierge-rag
 
 # ── Application ───────────────────────────────

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ python scripts/seed.py    # Generate sample JSONL data
 ## Architecture
 
 - **FastAPI app** served via uvicorn at port 8000 (`app.main:app`) with a startup-loaded RAG chain
-- **PostgreSQL 16 + pgvector** stores Google Places metadata in `places_raw` and semantic vectors in `place_embeddings`
+- **PostgreSQL 18 + pgvector** stores Google Places metadata in `places_raw` and semantic vectors in `place_embeddings` (Cloud SQL prod instance is `POSTGRES_18`; local docker may still be 16)
 - **Retriever stack** uses OpenAI embeddings for query vectors and pgvector HNSW cosine similarity search for source retrieval
 - **LangChain RAG chain** supports OpenAI or Gemini chat models, selected from MLflow Model Registry params
 - **Scripts**: `scripts/ingest_places_sf.py` loads raw Google Places data, `scripts/embed_places_pgvector.py` refreshes embeddings, and `scripts/log_model_to_mlflow.py` logs experiment runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ python scripts/seed.py    # Generate sample JSONL data
 ## Architecture
 
 - **FastAPI app** served via uvicorn at port 8000 (`app.main:app`) with a startup-loaded RAG chain
-- **PostgreSQL 16 + pgvector** stores Google Places metadata in `places_raw` and semantic vectors in `place_embeddings`
+- **PostgreSQL 18 + pgvector** stores Google Places metadata in `places_raw` and semantic vectors in `place_embeddings` (Cloud SQL prod instance is `POSTGRES_18`; local docker may still be 16)
 - **Retriever stack** uses OpenAI embeddings for query vectors and pgvector HNSW cosine similarity search for source retrieval
 - **LangChain RAG chain** supports OpenAI or Gemini chat models, selected from MLflow Model Registry params
 - **Scripts**: `scripts/ingest_places_sf.py` loads raw Google Places data, `scripts/embed_places_pgvector.py` refreshes embeddings, and `scripts/log_model_to_mlflow.py` logs experiment runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,12 +51,8 @@ python scripts/seed.py    # Generate sample JSONL data
 - **LangChain RAG chain** supports OpenAI or Gemini chat models, selected from MLflow Model Registry params
 - **Scripts**: `scripts/ingest_places_sf.py` loads raw Google Places data, `scripts/embed_places_pgvector.py` refreshes embeddings, and `scripts/log_model_to_mlflow.py` logs experiment runs
 - **Alembic** for database migrations (not yet initialized beyond Makefile targets)
-<<<<<<< HEAD
 - **MLflow** for experiment tracking and model-registry-backed runtime selection (shared GCP server)
-=======
-- **MLflow** for experiment tracking (shared GCP server)
 - **React and Vite** for the frontend where user inputs prompt and preferences
->>>>>>> b086152 (feat: add SF concierge frontend with chat, map, and list views)
 
 ## Key Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ python scripts/seed.py    # Generate sample JSONL data
 ## Architecture
 
 - **FastAPI app** served via uvicorn at port 8000 (`app.main:app`) with a startup-loaded RAG chain
-- **PostgreSQL 16 + pgvector** stores Google Places metadata in `places_raw` and semantic vectors in `place_embeddings`
+- **PostgreSQL 18 + pgvector** stores Google Places metadata in `places_raw` and semantic vectors in `place_embeddings` (Cloud SQL prod instance is `POSTGRES_18`; local docker may still be 16)
 - **Retriever stack** uses OpenAI embeddings for query vectors and pgvector HNSW cosine similarity search for source retrieval
 - **LangChain RAG chain** supports OpenAI or Gemini chat models, selected from MLflow Model Registry params
 - **Scripts**: `scripts/ingest_places_sf.py` loads raw Google Places data, `scripts/embed_places_pgvector.py` refreshes embeddings, and `scripts/log_model_to_mlflow.py` logs experiment runs

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ LangChain RetrievalQA Chain
 Response + Source Places
 ```
 
-- **Vector Store**: PostgreSQL 16 + pgvector on Cloud SQL with HNSW cosine index (4,356 SF place embeddings)
+- **Vector Store**: PostgreSQL 18 + pgvector on Cloud SQL with HNSW cosine index (4,356 SF place embeddings)
 - **Embeddings**: OpenAI `text-embedding-3-small` (1536 dims)
 - **LLM**: Configurable via MLflow Model Registry — supports OpenAI and Gemini
-- **MLflow**: Shared tracking server at http://35.223.147.177:5000
+- **MLflow**: Tracking server on GCE VM `mlflow-server`, reachable privately at `http://10.128.0.2:5000`
 - **Container Registry**: GCP Artifact Registry (`us-central1-docker.pkg.dev/mlops-491820/ml-repo/city-concierge`)
 
 ## Getting Started
@@ -123,7 +123,7 @@ POSTGRES_DB=city_concierge
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=your-password
 
-# Public IP / proxy / private IP
+# Local Postgres / Cloud SQL Auth Proxy / private IP from inside the VPC
 POSTGRES_HOST=your-cloud-sql-host
 POSTGRES_PORT=5432
 POSTGRES_SSLMODE=require
@@ -133,7 +133,17 @@ CLOUD_SQL_INSTANCE_CONNECTION_NAME=your-project:your-region:your-instance
 CLOUD_SQL_SOCKET_DIR=/cloudsql
 ```
 
-When `DATABASE_URL` is unset, the app and scripts now build the connection string from `POSTGRES_*`, and if `CLOUD_SQL_INSTANCE_CONNECTION_NAME` is present they connect through the Cloud SQL socket path automatically. For direct-host Cloud SQL connections, `POSTGRES_SSLMODE` and `POSTGRES_SSLROOTCERT` are also supported.
+When `DATABASE_URL` is unset, the app and scripts build the connection string from `POSTGRES_*`, and if `CLOUD_SQL_INSTANCE_CONNECTION_NAME` is present they connect through the Cloud SQL socket path automatically. For direct-host Cloud SQL connections, `POSTGRES_SSLMODE` and `POSTGRES_SSLROOTCERT` are also supported.
+
+Production Cloud SQL is private-only:
+
+- Instance: `mlops-491820:us-central1:mlops--city-concierge`
+- Private IP: `10.127.0.3`
+- Public IPv4: disabled
+- VPC: `default`
+- Private Services Access peering: `servicenetworking-googleapis-com`
+
+Cloud Run should continue using the Cloud SQL attachment/socket path through `CLOUD_SQL_INSTANCE_CONNECTION_NAME`; do not add a plaintext `DATABASE_URL` to Cloud Run unless intentionally moving away from the Cloud SQL socket flow.
 
 ## Deployment
 
@@ -142,7 +152,10 @@ When `DATABASE_URL` is unset, the app and scripts now build the connection strin
 - **Backend (Cloud Run):** https://city-concierge-api-6amzjx52nq-uc.a.run.app
 - **Frontend (Vercel):** see the `frontend/` directory; configure `VITE_API_URL` to the Cloud Run URL above
 - **Image registry:** `us-central1-docker.pkg.dev/mlops-491820/ml-repo/city-concierge`
-- **Cloud SQL instance:** `mlops-491820:us-central1:mlops--city-concierge` (Postgres 18, pgvector 0.8.1)
+- **Cloud SQL instance:** `mlops-491820:us-central1:mlops--city-concierge` (Postgres 18, pgvector 0.8.1, private IP `10.127.0.3`)
+- **Cloud Run egress:** Direct VPC Egress on VPC `default`, subnet `default`, `private-ranges-only`
+- **MLflow VM:** `mlflow-server` in `us-central1-a`, internal IP `10.128.0.2`, no external IP
+- **MLflow firewall:** `allow-mlflow` allows TCP `5000` only from `10.128.0.0/9`
 
 ### CI/CD Pipeline
 
@@ -170,6 +183,13 @@ GitHub Actions handle everything from lint to deploy. Triggers and jobs:
 - `POSTGRES_DB`, `POSTGRES_USER`
 - `CLOUD_SQL_INSTANCE_CONNECTION_NAME`
 
+Current production values:
+
+- `MLFLOW_TRACKING_URI=http://10.128.0.2:5000`
+- `POSTGRES_DB=mlops-city-concierge`
+- `POSTGRES_USER=postgres`
+- `CLOUD_SQL_INSTANCE_CONNECTION_NAME=mlops-491820:us-central1:mlops--city-concierge`
+
 **Frontend (Vercel — `VITE_*` vars are compiled into the JS bundle and visible in the browser, so never put secrets here):**
 
 - `VITE_API_URL=https://city-concierge-api-6amzjx52nq-uc.a.run.app`
@@ -187,7 +207,10 @@ gcloud run deploy city-concierge-api \
   --allow-unauthenticated \
   --port 8000 \
   --add-cloudsql-instances mlops-491820:us-central1:mlops--city-concierge \
-  --set-env-vars "MLFLOW_TRACKING_URI=http://35.223.147.177:5000,POSTGRES_DB=mlops-city-concierge,POSTGRES_USER=postgres,CLOUD_SQL_INSTANCE_CONNECTION_NAME=mlops-491820:us-central1:mlops--city-concierge" \
+  --network default \
+  --subnet default \
+  --vpc-egress private-ranges-only \
+  --set-env-vars "MLFLOW_TRACKING_URI=http://10.128.0.2:5000,POSTGRES_DB=mlops-city-concierge,POSTGRES_USER=postgres,CLOUD_SQL_INSTANCE_CONNECTION_NAME=mlops-491820:us-central1:mlops--city-concierge" \
   --set-secrets "POSTGRES_PASSWORD=POSTGRES_PASSWORD:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest" \
   --project mlops-491820
 ```
@@ -213,7 +236,20 @@ docker push us-central1-docker.pkg.dev/mlops-491820/ml-repo/city-concierge:lates
 
 ## MLflow
 
-**Dashboard:** http://35.223.147.177:5000
+MLflow runs on the private-only GCE VM `mlflow-server`.
+
+- Cloud Run reaches MLflow at `http://10.128.0.2:5000` through Direct VPC Egress.
+- The VM has no external IP. For browser access, open an IAP/SSH tunnel and use the local forwarded port:
+
+```bash
+gcloud compute ssh mlflow-server \
+  --project=mlops-491820 \
+  --zone=us-central1-a \
+  --tunnel-through-iap \
+  -- -L 5000:localhost:5000
+```
+
+Then open http://localhost:5000.
 
 ### Logging Experiments
 
@@ -240,7 +276,7 @@ poetry run python scripts/log_model_to_mlflow.py \
 ```bash
 poetry run python -c "
 import mlflow
-mlflow.set_tracking_uri('http://35.223.147.177:5000')
+mlflow.set_tracking_uri('http://localhost:5000')
 client = mlflow.MlflowClient()
 client.set_registered_model_alias('city-concierge-rag', 'production', '<VERSION>')
 "

--- a/README.md
+++ b/README.md
@@ -92,7 +92,24 @@ make dev-detached # Start in background
 make down         # Stop all containers
 ```
 
-Note: The app container reads `DATABASE_URL` from `.env`. Set it to Cloud SQL for production data, or leave it pointing to the local `db` container for local development.
+Docker Compose is wired for local development even if `.env` contains production database values:
+
+- The local `db` service always creates/healthchecks database `city_concierge`.
+- The app container ignores `.env` `DATABASE_URL` and connects to the Compose database at `db:5432`.
+- The app container reaches MLflow at `host.docker.internal:5000` to use the IAP tunnel running on your host.
+- If your `.env` was previously pointed at production (`DATABASE_URL=postgresql://...`, `POSTGRES_DB=mlops-city-concierge`), it's safe to leave inside the Compose stack — the `app` service overrides those values. But host-side tooling (tests, `scripts/ingest_places_sf.py`, etc.) reads `.env` directly, so update those values if you run anything outside Compose.
+
+Because the MLflow VM is private-only, open the IAP/SSH tunnel in another terminal before running `make dev` if you need RAG endpoints:
+
+```bash
+gcloud compute ssh mlflow-server \
+  --project=mlops-491820 \
+  --zone=us-central1-a \
+  --tunnel-through-iap \
+  -- -L 5000:localhost:5000
+```
+
+Without the tunnel, the app still boots in **degraded mode**: `/health` returns `{"status": "degraded", "rag_chain": "unavailable"}`, `/predict` returns HTTP 503, and all other endpoints (including `/health/db` and the frontend) work normally.
 
 - http://localhost:8000/root
 - http://localhost:8000/health

--- a/app/config.py
+++ b/app/config.py
@@ -87,8 +87,8 @@ class Settings(BaseSettings):
     openai_embedding_model: str = "text-embedding-3-small"
     gemini_api_key: str = ""
     gemini_chat_model: str = "gemini-2.5-flash"
-    mlflow_tracking_uri: str = "http://35.223.147.177:5000"
-    mlflow_artifacts_uri: str = "mlflow-artifacts://35.223.147.177:5000"
+    mlflow_tracking_uri: str = "http://localhost:5000"
+    mlflow_artifacts_uri: str = "mlflow-artifacts://localhost:5000"
     mlflow_model_name: str = "city-concierge-rag"
     retriever_k: int = 5
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -12,6 +13,13 @@ from pydantic import BaseModel, Field
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
 from .db import get_db
+
+logger = logging.getLogger(__name__)
+
+RAG_UNAVAILABLE_DETAIL = (
+    "RAG chain unavailable: MLflow registry could not be reached at startup. "
+    "Ensure the MLflow IAP tunnel is open and restart the app."
+)
 
 db_connection_dependency = Depends(get_db)
 
@@ -127,7 +135,16 @@ def serialize_sources(source_documents: list[Any], limit: int) -> list[Recommend
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    rag_chain, model_config = load_registered_rag_chain()
+    try:
+        rag_chain, model_config = load_registered_rag_chain()
+    except Exception:
+        logger.warning(
+            "Failed to load RAG chain from MLflow registry — app will boot in "
+            "degraded mode and RAG endpoints will return 503.",
+            exc_info=True,
+        )
+        rag_chain = None
+        model_config = None
     app.state.rag_chain = rag_chain
     app.state.active_model_config = model_config
     yield
@@ -163,7 +180,7 @@ def root() -> dict[str, str]:
 def health(request: Request) -> dict[str, str]:
     model_config = getattr(request.app.state, "active_model_config", None)
     if model_config is None:
-        raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
+        return {"status": "degraded", "rag_chain": "unavailable"}
 
     return {
         "status": "ok",
@@ -184,7 +201,7 @@ def health_db(conn: connection = db_connection_dependency) -> dict[str, str]:
 def predict(request_body: RecommendationRequest, request: Request) -> RecommendationResponse:
     rag_chain = getattr(request.app.state, "rag_chain", None)
     if rag_chain is None:
-        raise HTTPException(status_code=500, detail="RAG chain is not loaded.")
+        raise HTTPException(status_code=503, detail=RAG_UNAVAILABLE_DETAIL)
 
     result = rag_chain.invoke({"query": request_body.query})
     response_text = result.get("result") or result.get("response") or ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: city_concierge_db
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-city_concierge}
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_DB: city_concierge
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
@@ -13,7 +13,7 @@ services:
       - pgdata:/var/lib/postgresql/data
       - ./scripts/db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-city_concierge}"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d city_concierge"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -27,14 +27,23 @@ services:
     env_file:
       - .env
     environment:
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: ""
+      POSTGRES_DB: city_concierge
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      CLOUD_SQL_INSTANCE_CONNECTION_NAME: ""
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
-      MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI:-http://35.223.147.177:5000}
+      MLFLOW_TRACKING_URI: http://host.docker.internal:5000
       MLFLOW_MODEL_NAME: ${MLFLOW_MODEL_NAME:-city-concierge-rag}
     ports:
       - "${APP_PORT:-8000}:8000"
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    depends_on:
+      db:
+        condition: service_healthy
 
   frontend:
     image: node:20-alpine


### PR DESCRIPTION
## Summary

- Make local Docker Compose dev resilient to private-IP infra: pin DB connection vars on the `app` service so a stale `.env` (with prod `DATABASE_URL` / `POSTGRES_DB=mlops-city-concierge`) can't leak into the container, point local app at MLflow via `host.docker.internal:5000` for the IAP tunnel, default `app/config.py` MLflow URIs to `localhost:5000`, and document the IAP tunnel + `.env` migration in the README.
- Make app boot resilient when the MLflow registry is unreachable: lifespan now catches the load failure, logs a warning, and lets the app start in **degraded mode** (`/health` returns `{"status":"degraded","rag_chain":"unavailable"}`, `/predict` returns 503, everything else works). Previously this crash-looped uvicorn.

## Why

Cloud SQL and the MLflow VM were moved to private IPs (no public access). Without these changes, `make dev` crashes on startup if the IAP tunnel isn't open, and silently misroutes to non-existent prod IPs if the developer's `.env` still has prod values. Prod (Cloud Run) is unaffected — env config is per-revision and graceful degradation is a strict improvement.

## Test plan

- [x] `make down && make dev` — all 3 containers come up healthy
- [x] `curl /health` → `degraded` without IAP tunnel, `ok` with tunnel
- [x] `curl /health/db` → `ok` (local Postgres reachable)
- [x] `curl -X POST /predict` → 200 with empty sources (local DB is empty by design — RAG retrieval has nothing to match against locally; full data lives in Cloud SQL)
- [x] ruff lint/format pass via pre-commit
- [ ] Post-merge: verify `https://city-concierge-api-739618408593.us-central1.run.app/health` returns `ok` after auto-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)