### PR TITLE
feat: frontend dev server talks to deployed Cloud Run backend by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,8 @@ celerybeat.pid
 .env
 .envrc
 .venv
+# Vite per-mode local overrides (frontend/.env.development.local etc.)
+*.local
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ Without the tunnel, the app still boots in **degraded mode**: `/health` returns 
 - http://localhost:8000/health/db
 - http://localhost:8000/docs
 
+### Frontend → backend wiring
+
+By default the frontend dev server (http://localhost:5173) talks to the **deployed Cloud Run backend** via `frontend/.env.development`. This means:
+
+- Frontend-only contributors can run `make dev` (or `cd frontend && npm run dev`) and immediately get a working app with real data — no IAP tunnel, no local DB, no GCP setup.
+- The local `app` container still runs and is reachable at http://localhost:8000 for direct backend testing (curl, /docs, etc.). It's just not what the browser hits.
+
+To point the frontend at the local backend instead (when iterating on `app/` code):
+
+```bash
+echo 'VITE_API_URL=http://localhost:8000' > frontend/.env.development.local
+# Restart the frontend dev server to pick it up.
+```
+
+`*.local` files are gitignored and override `.env.development`. Delete the file to revert.
+
 Notes:
 
 - The standalone container still needs a reachable Postgres database via `DATABASE_URL`.

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,8 @@
+# Frontend dev mode (npm run dev) talks to the live Cloud Run backend by default,
+# so frontend-only contributors don't need a local app or local DB. The deployed
+# backend has private access to Cloud SQL + MLflow.
+#
+# To point at a local backend instead (e.g. when iterating on app/ code):
+#   echo 'VITE_API_URL=http://localhost:8000' > frontend/.env.development.local
+# Vite loads `*.local` files last and they win. Delete the file to revert.
+VITE_API_URL=https://city-concierge-api-6amzjx52nq-uc.a.run.app


### PR DESCRIPTION
## Summary

Frontend-only contributors no longer need a local backend, local DB, or any GCP setup to see real data while running `make dev`. The committed `frontend/.env.development` sets `VITE_API_URL` to the deployed Cloud Run service URL, so the browser hits prod directly. Cloud Run already has private access to Cloud SQL and MLflow, so RAG works end-to-end with real ingested data.

Backend devs iterating on `app/` code can override locally with one command:

```bash
echo 'VITE_API_URL=http://localhost:8000' > frontend/.env.development.local
```

`*.local` is now in `.gitignore` so personal overrides can't be committed by accident.

## Why

Before this PR, `make dev` ran a local backend against an empty local Postgres, so RAG returned `"I don't know."` for every query. Historically this "worked" only because individual contributors had stale `.env` files pointing `DATABASE_URL` at the (now-private) Cloud SQL public IP. With Cloud SQL private, that path is closed and the local DB is genuinely empty.

This PR doesn't try to seed the local DB — it sidesteps the problem by pointing the frontend at the already-working Cloud Run backend. Local backend dev still works (override file), but it's now opt-in instead of accidentally-required.

## Notes

- The Cloud Run service is currently bound to `allUsers`, so the URL was already publicly discoverable. Committing it doesn't change the security posture.
- Worth setting an OpenAI budget alert as a follow-up since `/predict` calls now go through prod for everyone.

## Test plan

- [x] `make down && make dev` brings up the stack.
- [x] Browser at http://localhost:5173 returns real SF places for a query like "best tacos in sunset".
- [x] DevTools Network tab shows `/predict` requests going to `https://city-concierge-api-6amzjx52nq-uc.a.run.app`, not localhost:8000.
- [x] `frontend/.env.development.local` (when created) is ignored by git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)