### PR TITLE
ci(infra): plan-on-PR via Workload Identity Federation

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,95 @@
+name: terraform plan
+
+on:
+  pull_request:
+    paths:
+      - "infra/**"
+      - ".github/workflows/terraform-plan.yml"
+
+permissions:
+  contents: read
+  id-token: write       # required for Workload Identity Federation
+  pull-requests: write  # required to comment the plan back on the PR
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via WIF
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/739618408593/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: terraform-ci@mlops-491820.iam.gserviceaccount.com
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.14.9
+          terraform_wrapper: false
+
+      - name: terraform fmt -check
+        run: terraform fmt -check -recursive
+
+      - name: terraform init
+        run: terraform init -input=false
+
+      - name: terraform validate
+        run: terraform validate
+
+      - name: terraform plan
+        id: plan
+        run: |
+          set +e
+          terraform plan -no-color -input=false -out=tfplan 2>&1 | tee plan.txt
+          exitcode=${PIPESTATUS[0]}
+          echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+          exit $exitcode
+
+      - name: Comment plan on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'infra/plan.txt';
+            let plan = '(no plan output)';
+            if (fs.existsSync(path)) {
+              plan = fs.readFileSync(path, 'utf8');
+            }
+            const MAX = 60000;
+            if (plan.length > MAX) {
+              plan = plan.slice(0, MAX) + '\n\n…(truncated)';
+            }
+            const exitcode = '${{ steps.plan.outputs.exitcode }}';
+            const status = exitcode === '0' ? '✅ plan succeeded' : `❌ plan failed (exit ${exitcode})`;
+            const body = [
+              `### terraform plan — ${status}`,
+              '',
+              '<details><summary>Plan output</summary>',
+              '',
+              '```hcl',
+              plan,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const marker = '<!-- terraform-plan-comment -->';
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find(c => c.body && c.body.includes(marker));
+            const finalBody = `${marker}\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: finalBody });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: finalBody });
+            }

--- a/infra/CI_SETUP.md
+++ b/infra/CI_SETUP.md
@@ -1,0 +1,117 @@
+# CI setup for Terraform (Workload Identity Federation)
+
+This runbook configures GitHub Actions to run `terraform plan` on PRs that
+touch `infra/**`, authenticating via Workload Identity Federation (no
+long-lived service-account keys in GitHub secrets).
+
+**Run these commands once per project.** They are documented here rather
+than executed by Terraform because they bootstrap the auth that Terraform
+itself depends on — chicken-and-egg.
+
+## Variables used below
+
+| | |
+| --- | --- |
+| Project ID | `mlops-491820` |
+| Project number | `739618408593` |
+| Repo | `deshmukh-neel/mlops_city_concierge` |
+| WIF pool | `github-actions` |
+| WIF provider | `github` |
+| Plan-only SA | `terraform-ci@mlops-491820.iam.gserviceaccount.com` |
+| State bucket | `mlops-491820-terraform-state` |
+
+## 1. Enable required APIs
+
+```bash
+gcloud services enable \
+  iamcredentials.googleapis.com \
+  iam.googleapis.com \
+  sts.googleapis.com \
+  --project=mlops-491820
+```
+
+## 2. Create the Workload Identity Pool
+
+```bash
+gcloud iam workload-identity-pools create github-actions \
+  --project=mlops-491820 \
+  --location=global \
+  --display-name="GitHub Actions"
+```
+
+## 3. Create the GitHub OIDC provider in the pool
+
+The `attribute-condition` restricts which GitHub repos can mint tokens
+against this provider — without it, *any* GitHub repo could authenticate.
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc github \
+  --project=mlops-491820 \
+  --location=global \
+  --workload-identity-pool=github-actions \
+  --display-name="GitHub" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner,attribute.ref=assertion.ref" \
+  --attribute-condition="assertion.repository_owner == 'deshmukh-neel'"
+```
+
+## 4. Create the plan-only service account
+
+```bash
+gcloud iam service-accounts create terraform-ci \
+  --project=mlops-491820 \
+  --display-name="Terraform CI (plan only)"
+```
+
+## 5. Grant the SA the minimum permissions to run `terraform plan`
+
+`plan` only reads — no write permissions on resources. It also needs read
+access to the GCS state backend.
+
+```bash
+# Read-only on project resources (covers SQL describe, GCE describe, firewall describe)
+gcloud projects add-iam-policy-binding mlops-491820 \
+  --member="serviceAccount:terraform-ci@mlops-491820.iam.gserviceaccount.com" \
+  --role="roles/viewer"
+
+gcloud projects add-iam-policy-binding mlops-491820 \
+  --member="serviceAccount:terraform-ci@mlops-491820.iam.gserviceaccount.com" \
+  --role="roles/cloudsql.viewer"
+
+# Read+write on the state bucket: terraform plan writes a lockfile in the bucket
+# and refreshes state during the plan. objectAdmin is the standard role.
+gcloud storage buckets add-iam-policy-binding gs://mlops-491820-terraform-state \
+  --member="serviceAccount:terraform-ci@mlops-491820.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+```
+
+## 6. Bind the GitHub repo to the SA via WIF
+
+This is what lets the GitHub Actions workflow impersonate the SA without
+a downloaded key. The `principalSet` matches any token from the
+`deshmukh-neel/mlops_city_concierge` repo.
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  terraform-ci@mlops-491820.iam.gserviceaccount.com \
+  --project=mlops-491820 \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/739618408593/locations/global/workloadIdentityPools/github-actions/attribute.repository/deshmukh-neel/mlops_city_concierge"
+```
+
+## 7. Verify
+
+After all of the above, the workflow at `.github/workflows/terraform-plan.yml`
+will run on the next PR touching `infra/**` and post a plan comment.
+
+To smoke-test before opening a real change PR: open a no-op PR that adds
+a comment to `infra/sql.tf`. The bot should comment with
+`No changes. Your infrastructure matches the configuration.`
+
+## Future: apply-on-merge
+
+A separate PR will add a second workflow (`terraform-apply.yml`) that
+runs on push to `main` and uses a different SA (`terraform-deploy@`)
+with broader permissions. Setup will be similar but with a tighter
+`attribute-condition` (e.g. only the `main` branch ref) on either the
+provider or the SA binding.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/terraform-plan.yml` — runs `terraform plan` on every PR that touches `infra/**` and posts the plan as a sticky PR comment (updated in place, not duplicated per push).
- Authenticates via **Workload Identity Federation**, not a downloaded service-account key. No long-lived secrets in GitHub.
- The CI service account `terraform-ci@mlops-491820.iam.gserviceaccount.com` is **plan-only** — `roles/viewer` + `roles/cloudsql.viewer` on the project, `roles/storage.objectAdmin` on the state bucket. It cannot mutate any managed resource.
- Documents the one-time GCP setup (WIF pool, OIDC provider, SA, IAM bindings) in `infra/CI_SETUP.md` for reproducibility.

## Why this PR is read-only

This is part one of two. Apply-on-merge (mutating GCP from `main`) is intentionally **not** in this PR — it lands separately with a different SA (`terraform-deploy@`) that has broader permissions. Splitting the rollout means we can validate plan-on-PR against a real change before turning on auto-apply.

## How to verify

Once merged:

1. The workflow file exists on `main`.
2. Open a follow-up no-op PR (e.g. add a comment line to `infra/sql.tf`).
3. The workflow should run and post a comment ending with `No changes. Your infrastructure matches the configuration.`

If WIF auth fails, the most common causes are:

- The OIDC provider's `attribute-condition` doesn't match the repo (we restricted to `repository_owner == 'deshmukh-neel'`).
- The SA's IAM policy doesn't include the `principalSet://...attribute.repository/deshmukh-neel/mlops_city_concierge` binding.

## Test plan

- [x] Reviewer confirms the workflow YAML, runbook, and IAM scope (read-only on resources) look right.
- [ ] After merge, open a no-op PR touching `infra/**` and confirm the bot comments with a clean plan.
- [ ] Confirm the comment updates in place (not duplicated) when a follow-up commit is pushed to that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)