### PR TITLE
test(infra): smoke-test the terraform-plan CI workflow

### DIFF
--- a/infra/sql.tf
+++ b/infra/sql.tf
@@ -1,4 +1,5 @@
 resource "google_sql_database_instance" "main" {
+  # Smoke test for terraform-plan CI workflow (PR #51); revert this comment once verified.
   name             = "mlops--city-concierge"
   database_version = "POSTGRES_18"
   region           = "us-central1"


### PR DESCRIPTION
## Summary

This PR exists to verify the new `terraform-plan` CI workflow (merged in #51) actually runs end-to-end against live GCP via Workload Identity Federation. It changes nothing in live infrastructure — just adds a one-line comment inside `infra/sql.tf`.

## What success looks like

The workflow should:

1. Trigger because `infra/sql.tf` is under the `paths: infra/**` filter.
2. Authenticate to GCP via WIF as `terraform-ci@mlops-491820.iam.gserviceaccount.com`.
3. Run `terraform fmt -check`, `terraform init`, `terraform validate`, `terraform plan`.
4. Post a sticky PR comment ending with `No changes. Your infrastructure matches the configuration.`

## What failure modes to watch for

- **WIF auth fails**: `principalSet://...attribute.repository/deshmukh-neel/mlops_city_concierge` doesn't match what GitHub presented. Most often a typo in the binding or in the OIDC provider's `attribute-condition`.
- **`terraform init` fails**: SA lacks `roles/storage.objectAdmin` on the state bucket.
- **`terraform plan` shows a diff**: shouldn't happen since this is a comment-only change. If it does, something drifted out-of-band.

## After verification

Close this PR without merging. The comment in `sql.tf` is harmless but pointless on `main` — recommendation is **close-and-leave** rather than merging an empty change. Apply-on-merge work follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)