### PR TITLE
ci(infra): apply-on-merge gated by GitHub Environment + main-only WIF

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,50 @@
+name: terraform apply
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "infra/**"
+      - ".github/workflows/terraform-apply.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write       # required for Workload Identity Federation
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    # Manual approval gate. The workflow pauses here until a reviewer
+    # approves in the Actions UI. Configure the approver list at
+    # Settings → Environments → infra-prod.
+    environment: infra-prod
+    defaults:
+      run:
+        working-directory: infra
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/739618408593/locations/global/workloadIdentityPools/github-actions/providers/github-main
+          service_account: terraform-deploy@mlops-491820.iam.gserviceaccount.com
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.14.9
+          terraform_wrapper: false
+
+      - name: terraform init
+        run: terraform init -input=false
+
+      - name: terraform plan
+        run: terraform plan -no-color -input=false -out=tfplan
+
+      - name: terraform apply
+        run: terraform apply -input=false -no-color tfplan

--- a/infra/CI_SETUP.md
+++ b/infra/CI_SETUP.md
@@ -108,10 +108,109 @@ To smoke-test before opening a real change PR: open a no-op PR that adds
 a comment to `infra/sql.tf`. The bot should comment with
 `No changes. Your infrastructure matches the configuration.`
 
-## Future: apply-on-merge
+---
 
-A separate PR will add a second workflow (`terraform-apply.yml`) that
-runs on push to `main` and uses a different SA (`terraform-deploy@`)
-with broader permissions. Setup will be similar but with a tighter
-`attribute-condition` (e.g. only the `main` branch ref) on either the
-provider or the SA binding.
+# Apply-on-merge setup (terraform-deploy)
+
+The plan workflow above is read-only. To let GitHub Actions actually
+mutate GCP on push to `main`, set up a second service account
+(`terraform-deploy@`) with `roles/editor`, gated behind:
+
+1. **A manual approval gate** (GitHub Environment `infra-prod`) — the
+   workflow pauses before `terraform apply` until a designated reviewer
+   approves in the Actions UI.
+2. **A `main`-branch-only WIF binding** — the deploy SA can only be
+   impersonated from workflow runs triggered by the `main` ref, so a
+   malicious PR cannot mint a token that has apply permissions.
+
+## 1. Create the deploy service account
+
+```bash
+gcloud iam service-accounts create terraform-deploy \
+  --project=mlops-491820 \
+  --display-name="Terraform CI (apply)"
+```
+
+## 2. Grant project Editor + state bucket admin
+
+```bash
+gcloud projects add-iam-policy-binding mlops-491820 \
+  --member="serviceAccount:terraform-deploy@mlops-491820.iam.gserviceaccount.com" \
+  --role="roles/editor"
+
+gcloud storage buckets add-iam-policy-binding gs://mlops-491820-terraform-state \
+  --member="serviceAccount:terraform-deploy@mlops-491820.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+```
+
+`roles/editor` was chosen for simplicity over scoped IAM
+(`cloudsql.admin` + `compute.instanceAdmin.v1` + `compute.securityAdmin`).
+The deploy SA is gated behind WIF (only this repo can mint tokens for it)
+*and* the GitHub Environment approval gate, so the practical blast
+radius is bounded by the human approver, not the IAM scope.
+
+## 3. Create a `main`-only OIDC provider in the same pool
+
+The plan provider (`github`) accepts tokens from any branch — that's
+fine for read-only plans. For apply, add a second provider in the same
+pool that only accepts tokens whose `ref` claim is `refs/heads/main`.
+A malicious PR on a feature branch can't mint a token usable against
+the deploy SA, even if it edits the workflow.
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc github-main \
+  --project=mlops-491820 \
+  --location=global \
+  --workload-identity-pool=github-actions \
+  --display-name="GitHub (main only)" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner,attribute.ref=assertion.ref" \
+  --attribute-condition="assertion.repository_owner == 'deshmukh-neel' && assertion.ref == 'refs/heads/main'"
+```
+
+## 4. Bind the deploy SA to `main`-ref tokens only
+
+The principalSet here is keyed on `attribute.ref` (not
+`attribute.repository`), so the SA only accepts tokens whose `ref`
+claim equals `refs/heads/main`. A token from a feature-branch run
+can't satisfy this binding regardless of which provider it came
+through.
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  terraform-deploy@mlops-491820.iam.gserviceaccount.com \
+  --project=mlops-491820 \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/739618408593/locations/global/workloadIdentityPools/github-actions/attribute.ref/refs/heads/main"
+```
+
+Defense in depth: the `github-main` OIDC provider's `attribute-condition`
+already rejects non-main tokens at provider-level, *and* this SA binding
+rejects them at SA-level. Either control on its own is sufficient;
+together they fail-safe.
+
+## 5. Configure the GitHub Environment
+
+In the GitHub UI: **Settings → Environments → New environment →
+`infra-prod`**.
+
+Configure:
+- **Required reviewers**: add the people allowed to approve applies
+  (project owners — `pjnhek`, `neel.deshmukh1`, `ankitjai3000`).
+- **Deployment branches**: restrict to `main` only.
+- (Optional) **Wait timer**: 0 minutes is fine; the human gate is
+  the actual control.
+
+The workflow's `environment: infra-prod` line is what triggers the
+approval gate.
+
+## 6. Verify
+
+After all of the above:
+1. Open a tiny no-op infra PR (e.g. one whitespace change in a `.tf` file).
+2. The plan workflow runs and posts a clean plan comment.
+3. Merge the PR.
+4. The apply workflow starts, reaches the approval step, and pauses.
+5. An approver clicks "Review deployments → Approve" in the Actions UI.
+6. `terraform apply` runs against `main` and reports the same plan was
+   applied.


### PR DESCRIPTION
## Summary

Part 2 of the infra-CI rollout (part 1 was #51, plan-on-PR). Adds `terraform apply` on push to `main` when `infra/**` changes, gated behind three independent controls:

1. **GitHub Environment `infra-prod`** with required reviewers: the workflow pauses before `terraform apply` until a designated owner approves in the Actions UI.
2. **A `main`-only OIDC provider** (`github-main` in the same WIF pool) that rejects tokens from any branch other than `main` at the provider level.
3. **The deploy SA is bound to `attribute.ref/refs/heads/main`** — defense in depth at the SA level, so even if a token leaked through another path it can't mint this SA without the right ref claim.

## Why `roles/editor` instead of scoped IAM

The deploy SA carries `roles/editor`. We considered scoped IAM (`cloudsql.admin` + `compute.instanceAdmin.v1` + `compute.securityAdmin`) but the SA is already double-gated (WIF main-only + human approver), so the practical blast radius is bounded by the approver, not the IAM scope. Scoped IAM would also require IAM updates every time we add a new resource type. If the threat model changes (e.g. compromised approver account), tighten this.

## What this PR does NOT do

- Does not change any managed resource. Merging this PR will trigger the apply workflow, but the workflow will run `terraform plan` first and find `No changes` (the workflow file change is outside `infra/**`... wait, actually `infra/CI_SETUP.md` is under `infra/`, so it WILL trigger). Either way, no resource diffs — apply will be a no-op.
- Does not enable branch protection on `main`. That's a separate hardening PR.
- Does not address the cleanup backlog (#44–#49). Those are separate, and now they go through this pipeline.

## How to verify after merge

1. Merge this PR.
2. The `terraform apply` workflow fires (because `infra/CI_SETUP.md` is under `infra/**`).
3. Check the Actions UI: the run pauses with **"Waiting on review"**.
4. Click into the run, hit **"Review deployments"**, approve `infra-prod`.
5. Apply runs and reports `No changes. Your infrastructure matches the configuration.` (or `Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`).
6. If anything shows as changed, **stop and reject the apply** — investigate first.

After this PR is verified, the cleanup backlog (#44–#49) becomes the next set of PRs and they all flow through this pipeline automatically.

## Test plan

- [x] Reviewer confirms the workflow YAML, the runbook in `infra/CI_SETUP.md`, and the IAM/WIF configuration look right.
- [ ] After merge, the apply workflow triggers, pauses for approval, and on approval completes a no-op apply.
- [x] Confirm `gcloud iam workload-identity-pools providers list --workload-identity-pool=github-actions --location=global` shows both `github` and `github-main` providers.
- [x] Confirm the `infra-prod` GitHub Environment has the right reviewer list and is restricted to `main` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)