### PR TITLE
Adding shared DB connection pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ DATABASE_URL=postgresql://postgres:changeme@localhost:5432/city_concierge
 # POSTGRES_SSLMODE=require
 # POSTGRES_SSLROOTCERT=/path/to/server-ca.pem
 
+# Shared DB connection pool used by FastAPI request dependencies.
+DB_POOL_MIN_CONNECTIONS=0
+DB_POOL_MAX_CONNECTIONS=10
+
 # ── OpenAI (embeddings + LLM) ─────────────────
 OPENAI_API_KEY=sk-...
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small

--- a/app/config.py
+++ b/app/config.py
@@ -95,6 +95,8 @@ class Settings(BaseSettings):
     mlflow_model_name: str = "city-concierge-rag"
     retriever_k: int = 5
     embedding_table: str = "place_embeddings"
+    db_pool_min_connections: int = 0
+    db_pool_max_connections: int = 10
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/app/db.py
+++ b/app/db.py
@@ -1,36 +1,46 @@
+import logging
 from collections.abc import Generator
 from contextlib import contextmanager
 
-import psycopg2
 from psycopg2.extensions import connection
 
-from .config import get_settings
+from .db_pool import get_connection, return_connection
+
+logger = logging.getLogger(__name__)
 
 
-def _resolve_url() -> str:
-    url = get_settings().resolved_database_url
-    if not url:
-        raise RuntimeError("Missing DATABASE_URL or POSTGRES_* database settings.")
-    return url
+def _return_connection_safely(conn: connection) -> None:
+    close_connection = False
+    try:
+        if conn.closed:
+            close_connection = True
+        else:
+            conn.rollback()
+    except Exception:
+        logger.warning(
+            "Failed to reset DB connection before returning it to the pool.",
+            exc_info=True,
+        )
+        close_connection = True
+    return_connection(conn, close=close_connection)
 
 
 def get_db() -> Generator[connection, None, None]:
-    conn = psycopg2.connect(_resolve_url())
+    conn = get_connection()
     try:
         yield conn
     finally:
-        conn.close()
+        _return_connection_safely(conn)
 
 
 @contextmanager
 def get_conn() -> Generator[connection, None, None]:
     """Context-manager Postgres connection for scripts and agent tools.
 
-    Opens a fresh psycopg2 connection per call. PR #56 will swap this body
-    to borrow from the shared pool with no caller change.
+    Borrows from the shared pool with the same lifecycle guarantees as get_db().
     """
-    conn = psycopg2.connect(_resolve_url())
+    conn = get_connection()
     try:
         yield conn
     finally:
-        conn.close()
+        _return_connection_safely(conn)

--- a/app/db_pool.py
+++ b/app/db_pool.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from threading import Lock
+
+from psycopg2.extensions import connection
+from psycopg2.pool import ThreadedConnectionPool
+
+from .config import get_settings
+
+_pool: ThreadedConnectionPool | None = None
+_pool_lock = Lock()
+
+
+def init_db_pool(
+    database_url: str,
+    min_connections: int,
+    max_connections: int,
+) -> ThreadedConnectionPool:
+    """Create the process-local DB pool if it does not already exist."""
+    if min_connections < 0:
+        raise ValueError("db_pool_min_connections must be greater than or equal to 0.")
+    if max_connections < 1:
+        raise ValueError("db_pool_max_connections must be greater than or equal to 1.")
+    if min_connections > max_connections:
+        raise ValueError("db_pool_min_connections cannot exceed db_pool_max_connections.")
+
+    global _pool
+    with _pool_lock:
+        if _pool is None:
+            _pool = ThreadedConnectionPool(
+                min_connections,
+                max_connections,
+                dsn=database_url,
+            )
+        return _pool
+
+
+def get_connection() -> connection:
+    """Borrow a connection from the shared pool, creating the pool lazily if needed."""
+    return _ensure_db_pool().getconn()
+
+
+def return_connection(conn: connection, *, close: bool = False) -> None:
+    """Return a borrowed connection to the shared pool."""
+    pool = _pool
+    if pool is None:
+        conn.close()
+        return
+
+    pool.putconn(conn, close=close)
+
+
+def close_db_pool() -> None:
+    """Close every connection owned by the process-local pool."""
+    global _pool
+    with _pool_lock:
+        if _pool is not None:
+            _pool.closeall()
+            _pool = None
+
+
+def _ensure_db_pool() -> ThreadedConnectionPool:
+    pool = _pool
+    if pool is not None:
+        return pool
+
+    # init_db_pool re-checks under _pool_lock, so concurrent lazy callers converge safely.
+    settings = get_settings()
+    database_url = settings.resolved_database_url
+    if not database_url:
+        raise RuntimeError("Missing DATABASE_URL or POSTGRES_* database settings.")
+
+    return init_db_pool(
+        database_url,
+        settings.db_pool_min_connections,
+        settings.db_pool_max_connections,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
 from .db import get_db
+from .db_pool import close_db_pool, init_db_pool
 
 logger = logging.getLogger(__name__)
 
@@ -135,19 +136,32 @@ def serialize_sources(source_documents: list[Any], limit: int) -> list[Recommend
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    settings = get_settings()
+    database_url = settings.resolved_database_url
+    if not database_url:
+        raise RuntimeError("Missing DATABASE_URL or POSTGRES_* database settings.")
+
+    init_db_pool(
+        database_url,
+        settings.db_pool_min_connections,
+        settings.db_pool_max_connections,
+    )
     try:
-        rag_chain, model_config = load_registered_rag_chain()
-    except Exception:
-        logger.warning(
-            "Failed to load RAG chain from MLflow registry — app will boot in "
-            "degraded mode and RAG endpoints will return 503.",
-            exc_info=True,
-        )
-        rag_chain = None
-        model_config = None
-    app.state.rag_chain = rag_chain
-    app.state.active_model_config = model_config
-    yield
+        try:
+            rag_chain, model_config = load_registered_rag_chain()
+        except Exception:
+            logger.warning(
+                "Failed to load RAG chain from MLflow registry — app will boot in "
+                "degraded mode and RAG endpoints will return 503.",
+                exc_info=True,
+            )
+            rag_chain = None
+            model_config = None
+        app.state.rag_chain = rag_chain
+        app.state.active_model_config = model_config
+        yield
+    finally:
+        close_db_pool()
 
 
 def create_app() -> FastAPI:

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from app.db import get_conn, get_db
+
+
+def test_get_db_returns_connection_to_pool(mocker) -> None:
+    conn = mocker.Mock()
+    conn.closed = 0
+    get_connection = mocker.patch("app.db.get_connection", return_value=conn)
+    return_connection = mocker.patch("app.db.return_connection")
+
+    db = get_db()
+    assert next(db) is conn
+    with pytest.raises(StopIteration):
+        next(db)
+
+    get_connection.assert_called_once_with()
+    conn.rollback.assert_called_once_with()
+    return_connection.assert_called_once_with(conn, close=False)
+
+
+def test_get_db_returns_connection_after_caller_error(mocker) -> None:
+    conn = mocker.Mock()
+    conn.closed = 0
+    mocker.patch("app.db.get_connection", return_value=conn)
+    return_connection = mocker.patch("app.db.return_connection")
+
+    db = get_db()
+    next(db)
+    with pytest.raises(ValueError, match="boom"):
+        db.throw(ValueError("boom"))
+
+    conn.rollback.assert_called_once_with()
+    return_connection.assert_called_once_with(conn, close=False)
+
+
+def test_get_db_closes_connection_when_reset_fails(mocker) -> None:
+    conn = mocker.Mock()
+    conn.closed = 0
+    conn.rollback.side_effect = RuntimeError("connection reset failed")
+    mocker.patch("app.db.get_connection", return_value=conn)
+    return_connection = mocker.patch("app.db.return_connection")
+    logger = mocker.patch("app.db.logger")
+
+    db = get_db()
+    next(db)
+    with pytest.raises(StopIteration):
+        next(db)
+
+    logger.warning.assert_called_once()
+    return_connection.assert_called_once_with(conn, close=True)
+
+
+def test_get_db_discards_already_closed_connection(mocker) -> None:
+    conn = mocker.Mock()
+    conn.closed = 1
+    mocker.patch("app.db.get_connection", return_value=conn)
+    return_connection = mocker.patch("app.db.return_connection")
+
+    db = get_db()
+    next(db)
+    with pytest.raises(StopIteration):
+        next(db)
+
+    conn.rollback.assert_not_called()
+    return_connection.assert_called_once_with(conn, close=True)
+
+
+def test_get_conn_context_manager_uses_pool(mocker) -> None:
+    conn = mocker.Mock()
+    conn.closed = 0
+    get_connection = mocker.patch("app.db.get_connection", return_value=conn)
+    return_connection = mocker.patch("app.db.return_connection")
+
+    with get_conn() as borrowed:
+        assert borrowed is conn
+
+    get_connection.assert_called_once_with()
+    conn.rollback.assert_called_once_with()
+    return_connection.assert_called_once_with(conn, close=False)

--- a/tests/unit/test_db_pool.py
+++ b/tests/unit/test_db_pool.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from app.config import get_settings
+from app.db_pool import close_db_pool, get_connection, init_db_pool, return_connection
+
+TEST_DATABASE_URL = "postgresql://postgres:test@localhost:5432/city_concierge_test"
+
+
+@pytest.fixture(autouse=True)
+def _reset_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    get_settings.cache_clear()
+    close_db_pool()
+    yield
+    close_db_pool()
+    get_settings.cache_clear()
+
+
+def test_init_db_pool_creates_threaded_pool(mocker) -> None:
+    pool = mocker.Mock()
+    pool_cls = mocker.patch("app.db_pool.ThreadedConnectionPool", return_value=pool)
+
+    result = init_db_pool(
+        TEST_DATABASE_URL,
+        0,
+        10,
+    )
+
+    assert result is pool
+    pool_cls.assert_called_once_with(
+        0,
+        10,
+        dsn=TEST_DATABASE_URL,
+    )
+
+
+def test_init_db_pool_reuses_existing_pool(mocker) -> None:
+    pool = mocker.Mock()
+    pool_cls = mocker.patch("app.db_pool.ThreadedConnectionPool", return_value=pool)
+
+    first = init_db_pool("postgresql://example", 0, 10)
+    second = init_db_pool("postgresql://different", 0, 5)
+
+    assert first is second
+    pool_cls.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("min_connections", "max_connections", "match"),
+    [
+        (-1, 10, "greater than or equal to 0"),
+        (0, 0, "greater than or equal to 1"),
+        (11, 10, "cannot exceed"),
+    ],
+)
+def test_init_db_pool_validates_pool_size(
+    min_connections: int,
+    max_connections: int,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        init_db_pool("postgresql://example", min_connections, max_connections)
+
+
+def test_get_connection_lazily_initializes_pool_from_settings(mocker) -> None:
+    conn = mocker.Mock()
+    pool = mocker.Mock()
+    pool.getconn.return_value = conn
+    pool_cls = mocker.patch("app.db_pool.ThreadedConnectionPool", return_value=pool)
+
+    result = get_connection()
+
+    assert result is conn
+    pool_cls.assert_called_once_with(
+        0,
+        10,
+        dsn=TEST_DATABASE_URL,
+    )
+    pool.getconn.assert_called_once_with()
+
+
+def test_return_connection_returns_to_pool(mocker) -> None:
+    conn = mocker.Mock()
+    pool = mocker.Mock()
+    mocker.patch("app.db_pool.ThreadedConnectionPool", return_value=pool)
+    init_db_pool("postgresql://example", 0, 10)
+
+    return_connection(conn)
+
+    pool.putconn.assert_called_once_with(conn, close=False)
+
+
+def test_return_connection_closes_when_pool_is_missing(mocker) -> None:
+    conn = mocker.Mock()
+
+    return_connection(conn)
+
+    conn.close.assert_called_once_with()
+
+
+def test_close_db_pool_closes_all_connections(mocker) -> None:
+    pool = mocker.Mock()
+    mocker.patch("app.db_pool.ThreadedConnectionPool", return_value=pool)
+    init_db_pool("postgresql://example", 0, 10)
+
+    close_db_pool()
+
+    pool.closeall.assert_called_once_with()

--- a/tests/unit/test_lifespan.py
+++ b/tests/unit/test_lifespan.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.config import get_settings
+from app.main import ActiveModelConfig, lifespan
+
+TEST_DATABASE_URL = "postgresql://postgres:test@localhost:5432/city_concierge_test"
+
+
+@pytest.fixture(autouse=True)
+def _force_test_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_initializes_and_closes_db_pool(mocker) -> None:
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    fake_chain = object()
+    model_config = ActiveModelConfig(
+        llm_provider="openai",
+        chat_model="gpt-4o-mini",
+        k=5,
+        temperature=0.0,
+        run_id="run-123",
+        model_version="7",
+    )
+    init_db_pool = mocker.patch("app.main.init_db_pool")
+    close_db_pool = mocker.patch("app.main.close_db_pool")
+    load_registered_rag_chain = mocker.patch(
+        "app.main.load_registered_rag_chain",
+        return_value=(fake_chain, model_config),
+    )
+
+    async with lifespan(fake_app):
+        assert fake_app.state.rag_chain is fake_chain
+        assert fake_app.state.active_model_config is model_config
+
+    init_db_pool.assert_called_once_with(
+        TEST_DATABASE_URL,
+        0,
+        10,
+    )
+    load_registered_rag_chain.assert_called_once_with()
+    close_db_pool.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_preserves_degraded_mode_when_rag_load_fails(mocker) -> None:
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    init_db_pool = mocker.patch("app.main.init_db_pool")
+    close_db_pool = mocker.patch("app.main.close_db_pool")
+    load_registered_rag_chain = mocker.patch(
+        "app.main.load_registered_rag_chain",
+        side_effect=RuntimeError("mlflow unavailable"),
+    )
+    logger = mocker.patch("app.main.logger")
+
+    async with lifespan(fake_app):
+        assert fake_app.state.rag_chain is None
+        assert fake_app.state.active_model_config is None
+
+    init_db_pool.assert_called_once_with(
+        TEST_DATABASE_URL,
+        0,
+        10,
+    )
+    load_registered_rag_chain.assert_called_once_with()
+    logger.warning.assert_called_once()
+    close_db_pool.assert_called_once_with()


### PR DESCRIPTION
## Summary
- Add a small `app/db_pool.py` module using `psycopg2.pool.ThreadedConnectionPool`
- Add configurable pool size settings via `DB_POOL_MIN_CONNECTIONS` and `DB_POOL_MAX_CONNECTIONS`
- Update `get_db()` to borrow and return pooled connections safely
- Initialize and close the pool during FastAPI lifespan
- Add unit tests for pool lifecycle, DB dependency cleanup, and app lifespan wiring

## Notes
- `/predict` behavior is unchanged.
- The retriever still uses its existing direct `psycopg2.connect(...)` path and will be pooled in a follow-up PR.

## Verification
- `pytest tests/unit/test_db_pool.py tests/unit/test_db.py tests/unit/test_lifespan.py -v`
- `pytest tests/unit/test_predict_endpoint.py tests/unit/test_config.py -v`
- `pytest tests/unit/ -v`
- `ruff check .`
- `mypy app/`
