### PR TITLE
feat(w0a): cleaner embeddings on parallel place_embeddings_v2 table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,9 @@ __marimo__/
 # Claude Code local settings
 .claude/
 
+# VS Code workspace settings (machine-specific)
+.vscode/
+
 # Local dev binaries / symlinks (machine-specific)
 cloud-sql-proxy
 frontend/node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python-envs.defaultEnvManager": "ms-python.python:conda",
-    "python-envs.defaultPackageManager": "ms-python.python:conda",
-    "python-envs.pythonProjects": []
-}

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ ingest-places: ## Pull SF Google Places data into Postgres
 embed-places: ## Generate pgvector embeddings for places
 	$(PYTHON) scripts/embed_places_pgvector.py
 
+.PHONY: embed-v2
+embed-v2: ## Generate cleaned pgvector embeddings into place_embeddings_v2
+	$(PYTHON) scripts/embed_places_pgvector_v2.py
+
 .PHONY: log-mlflow
 log-mlflow: ## Log a RAG configuration and sample outputs to MLflow
 	$(PYTHON) scripts/log_model_to_mlflow.py --config configs/experiments.yaml

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ ingest-places: ## Pull SF Google Places data into Postgres
 
 .PHONY: embed-places
 embed-places: ## Generate pgvector embeddings for places
-	$(PYTHON) scripts/embed_places_pgvector.py
+	poetry run python -m scripts.embed_places_pgvector
 
 .PHONY: embed-v2
 embed-v2: ## Generate cleaned pgvector embeddings into place_embeddings_v2
-	$(PYTHON) scripts/embed_places_pgvector_v2.py
+	poetry run python -m scripts.embed_places_pgvector_v2
 
 .PHONY: log-mlflow
 log-mlflow: ## Log a RAG configuration and sample outputs to MLflow

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,10 @@ from collections.abc import Mapping
 from functools import lru_cache
 from urllib.parse import quote_plus, urlencode
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+ALLOWED_EMBEDDING_TABLES: frozenset[str] = frozenset({"place_embeddings", "place_embeddings_v2"})
 
 
 def build_database_url(
@@ -91,8 +94,19 @@ class Settings(BaseSettings):
     mlflow_artifacts_uri: str = "mlflow-artifacts://localhost:5000"
     mlflow_model_name: str = "city-concierge-rag"
     retriever_k: int = 5
+    embedding_table: str = "place_embeddings"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    @field_validator("embedding_table")
+    @classmethod
+    def _validate_embedding_table(cls, value: str) -> str:
+        if value not in ALLOWED_EMBEDDING_TABLES:
+            raise ValueError(
+                f"EMBEDDING_TABLE must be one of {sorted(ALLOWED_EMBEDDING_TABLES)}; "
+                f"got {value!r}."
+            )
+        return value
 
     @property
     def resolved_database_url(self) -> str | None:

--- a/app/config.py
+++ b/app/config.py
@@ -103,8 +103,7 @@ class Settings(BaseSettings):
     def _validate_embedding_table(cls, value: str) -> str:
         if value not in ALLOWED_EMBEDDING_TABLES:
             raise ValueError(
-                f"EMBEDDING_TABLE must be one of {sorted(ALLOWED_EMBEDDING_TABLES)}; "
-                f"got {value!r}."
+                f"EMBEDDING_TABLE must be one of {sorted(ALLOWED_EMBEDDING_TABLES)}; got {value!r}."
             )
         return value
 

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -28,14 +28,17 @@ class PgVectorRetriever(BaseRetriever):
     ) -> list[Document]:
         del run_manager
 
-        api_key = self.openai_api_key or get_settings().openai_api_key
+        settings = get_settings()
+        api_key = self.openai_api_key or settings.openai_api_key
         if not api_key:
             raise RuntimeError("Missing OPENAI_API_KEY for query embedding generation.")
 
         embeddings = OpenAIEmbeddings(model=self.embedding_model, api_key=SecretStr(api_key))
         vector_literal = vector_to_pg(embeddings.embed_query(query))
 
-        sql = """
+        # settings.embedding_table is validated against an allowlist at config load
+        # (see ALLOWED_EMBEDDING_TABLES in app/config.py), so f-stringing is safe.
+        sql = f"""
         SELECT
             e.embedding_text,
             p.place_id,
@@ -44,12 +47,12 @@ class PgVectorRetriever(BaseRetriever):
             p.formatted_address,
             p.primary_type,
             1 - (e.embedding <=> %s::vector) AS similarity
-        FROM place_embeddings e
+        FROM {settings.embedding_table} e
         JOIN places_raw p ON p.place_id = e.place_id
         WHERE e.embedding_model = %s
         ORDER BY e.embedding <=> %s::vector
         LIMIT %s
-        """
+        """  # noqa: S608
 
         with psycopg2.connect(self.connection_string) as conn, conn.cursor() as cur:
             cur.execute(sql, (vector_literal, self.embedding_model, vector_literal, self.k))

--- a/implementation_plan/james/w0a_embeddings_v2.md
+++ b/implementation_plan/james/w0a_embeddings_v2.md
@@ -460,7 +460,7 @@ psql "$DATABASE_URL" -f scripts/db/migrations/000_place_embeddings_v2.sql
 make embed-v2
 
 # Eyeball v1 vs v2 for 5 random well-known places:
-python scripts/diagnose_chunks.py -n 5
+poetry run python -m scripts.diagnose_chunks -n 5
 
 # Confirm length distribution:
 psql "$DATABASE_URL" -c "
@@ -499,3 +499,22 @@ Expected: v2 chunks roughly 600–900 chars (vs v1 avg ~2,468). v2 retrieval sur
 - **HNSW index recall under filter pressure.** Same caveat as v1; addressed in W1's risks section. Not a v2-specific issue.
 - **v1 and v2 will drift if ingest changes shape.** Both scripts read from the same `places_raw` so they stay in sync as long as both are re-run after an ingest change. Document this in the PR description.
 - **Promotion semantics.** Flipping `EMBEDDING_TABLE=place_embeddings_v2` in production is gated on a W6 eval that shows non-regression on retrieval-quality metrics. No alias mechanism on the embeddings table itself; the env var IS the alias.
+
+## Outcomes (2026-05-04)
+
+Populated `place_embeddings_v2` for the full SF corpus and measured v1 vs v2 chunk lengths on Cloud SQL:
+
+|        | rows  | max len | avg len |
+|--------|-------|---------|---------|
+| v1     | 5,855 | 3,893   | 2,468   |
+| v2     | 5,855 | 1,622   | **873** |
+
+v2 average lands squarely inside the 600–900 char prediction. Spot-checked v1 vs v2 chunks for 3 well-known places (Cull Canyon Recreation Area, The 500 Club, Jasmin's) — every URL, language code, and "Summarized with Gemini" disclosure is gone from v2, and `Neighborhood` / `Containing Areas` / `Nearby Landmarks` are present where the data exists.
+
+### Bugs found while running and fixed in the same PR
+
+While running `make embed-v2` end-to-end against Cloud SQL we hit three pre-existing issues in the embed pipeline. They affected v1 too — fixed once for both:
+
+1. **`ModuleNotFoundError: No module named 'app'`** when running scripts directly. Fixed by adding `scripts/__init__.py` and switching the Make targets to `poetry run python -m scripts.<name>`. Also corrects the manual-verification command above.
+2. **Single-batch run** — `run()` only embedded the first `BATCH_SIZE = 1000` places and exited. Replaced with a `while True` loop that re-fetches until empty; the fetch query already excludes up-to-date rows, so the loop terminates naturally.
+3. **Per-row commit bottleneck** — capped throughput at ~50 rows/min through the Cloud SQL proxy. Replaced the per-row `upsert_embedding` loop with `psycopg2.extras.execute_values` batching (one round-trip per ~1,000-row OpenAI batch). A full corpus re-embed dropped from ~75 minutes to ~3 minutes. Applied to v2 only; v1 left unchanged since it's being deprecated.

--- a/scripts/db/migrations/000_place_embeddings_v2.sql
+++ b/scripts/db/migrations/000_place_embeddings_v2.sql
@@ -1,0 +1,19 @@
+-- Parallel embeddings table. Same schema as place_embeddings; lives next to it
+-- so we can A/B-compare retrieval quality before flipping the app over.
+-- Once W0a + W1 + W6 confirm v2 wins, v1 may be dropped in a follow-up PR.
+
+CREATE TABLE IF NOT EXISTS place_embeddings_v2 (
+    place_id              TEXT PRIMARY KEY REFERENCES places_raw(place_id) ON DELETE CASCADE,
+    embedding             vector(1536) NOT NULL,
+    embedding_model       TEXT NOT NULL,
+    embedding_text        TEXT NOT NULL,
+    embedded_at           TIMESTAMPTZ DEFAULT NOW(),
+    source_updated_at     TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_place_embeddings_v2_vector
+    ON place_embeddings_v2
+    USING hnsw (embedding vector_cosine_ops);
+
+COMMENT ON TABLE place_embeddings_v2 IS
+  'Cleaned embeddings (no URLs, no structured facts, with neighborhood + landmark names). Drives retrieval when EMBEDDING_TABLE=place_embeddings_v2.';

--- a/scripts/diagnose_chunks.py
+++ b/scripts/diagnose_chunks.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Print v1 vs v2 chunks for the same place_ids. Used to eyeball quality
+before/after the cleanup. Read-only; never writes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import psycopg2
+from dotenv import load_dotenv
+
+from app.config import resolve_database_url
+
+load_dotenv()
+
+QUERY = """
+SELECT p.name, v1.embedding_text AS v1_text, v2.embedding_text AS v2_text,
+       LENGTH(v1.embedding_text) AS v1_len, LENGTH(v2.embedding_text) AS v2_len
+FROM places_raw p
+LEFT JOIN place_embeddings    v1 ON v1.place_id = p.place_id
+LEFT JOIN place_embeddings_v2 v2 ON v2.place_id = p.place_id
+WHERE v1.place_id IS NOT NULL AND v2.place_id IS NOT NULL
+  AND p.user_rating_count > 100
+ORDER BY random()
+LIMIT %s
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-n", type=int, default=5, help="number of places to sample")
+    args = parser.parse_args()
+
+    database_url = resolve_database_url(os.environ)
+    if not database_url:
+        raise RuntimeError("Missing DATABASE_URL in environment.")
+
+    with psycopg2.connect(database_url) as conn, conn.cursor() as cur:
+        cur.execute(QUERY, (args.n,))
+        for name, v1, v2, v1_len, v2_len in cur.fetchall():
+            print("=" * 80)
+            print(f"NAME: {name}    v1={v1_len} chars   v2={v2_len} chars")
+            print("--- V1 ---\n" + v1)
+            print("--- V2 ---\n" + v2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/embed_places_pgvector.py
+++ b/scripts/embed_places_pgvector.py
@@ -364,35 +364,43 @@ def run() -> None:
         raise RuntimeError("Missing OPENAI_API_KEY in environment.")
 
     client = OpenAI(api_key=OPENAI_API_KEY)
+    total_embedded = 0
 
     with psycopg2.connect(DATABASE_URL) as conn:
-        rows = fetch_rows_to_embed(conn, limit=BATCH_SIZE)
-        if not rows:
-            print("No new or updated places to embed.")
-            return
+        # Loop until fetch_rows_to_embed returns no more rows. Each iteration
+        # streams up to BATCH_SIZE places into memory, embeds them, and upserts.
+        # The fetch query itself excludes already-embedded rows, so the loop
+        # terminates naturally and is safe to interrupt + resume.
+        while True:
+            rows = fetch_rows_to_embed(conn, limit=BATCH_SIZE)
+            if not rows:
+                if total_embedded == 0:
+                    print("No new or updated places to embed.")
+                break
 
-        embedded_count = 0
-        batches = iter_embedding_batches(rows)
-        for index, batch in enumerate(batches, start=1):
-            inputs = [row.text for row in batch]
-            input_chars = sum(len(text) for text in inputs)
-            print(
-                f"Embedding request {index}/{len(batches)}: "
-                f"{len(batch)} places, {input_chars} chars"
-            )
-            response = client.embeddings.create(model=EMBED_MODEL, input=inputs)
-
-            for row, item in zip(batch, response.data, strict=True):
-                upsert_embedding(
-                    conn,
-                    place_id=row.place_id,
-                    source_updated_at=row.source_updated_at,
-                    text=row.text,
-                    embedding=item.embedding,
+            batches = iter_embedding_batches(rows)
+            for index, batch in enumerate(batches, start=1):
+                inputs = [row.text for row in batch]
+                input_chars = sum(len(text) for text in inputs)
+                print(
+                    f"Embedding request {index}/{len(batches)} "
+                    f"(cumulative: {total_embedded}): "
+                    f"{len(batch)} places, {input_chars} chars",
+                    flush=True,
                 )
-                embedded_count += 1
+                response = client.embeddings.create(model=EMBED_MODEL, input=inputs)
 
-    print(f"Embedded and upserted {embedded_count} places with model {EMBED_MODEL}.")
+                for row, item in zip(batch, response.data, strict=True):
+                    upsert_embedding(
+                        conn,
+                        place_id=row.place_id,
+                        source_updated_at=row.source_updated_at,
+                        text=row.text,
+                        embedding=item.embedding,
+                    )
+                    total_embedded += 1
+
+    print(f"Embedded and upserted {total_embedded} places with model {EMBED_MODEL}.")
 
 
 if __name__ == "__main__":

--- a/scripts/embed_places_pgvector_v2.py
+++ b/scripts/embed_places_pgvector_v2.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""
+Generate cleaned embeddings for places_raw rows and upsert into place_embeddings_v2.
+
+This is a fork of scripts/embed_places_pgvector.py with a rewritten
+compose_embedding_text. The two scripts intentionally coexist so we can
+re-run either one and compare retrieval quality. See implementation_plan/
+james/w0a_embeddings_v2.md for the rationale.
+
+Usage:
+    python scripts/embed_places_pgvector_v2.py
+    make embed-v2
+
+Required env vars:
+    OPENAI_API_KEY
+
+Optional env vars:
+    DATABASE_URL              Postgres/Cloud SQL connection URL
+    CLOUD_SQL_INSTANCE_CONNECTION_NAME Cloud SQL instance connection name for socket auth
+    CLOUD_SQL_SOCKET_DIR      Cloud SQL Unix socket directory (default: /cloudsql)
+    POSTGRES_SSLMODE          Optional sslmode for env-built direct DB connections
+    PLACES_EMBED_MODEL       (default: text-embedding-3-small)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import psycopg2
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from app.config import resolve_database_url
+
+load_dotenv()
+
+DATABASE_URL = resolve_database_url(os.environ)
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+EMBED_MODEL = os.getenv("PLACES_EMBED_MODEL", "text-embedding-3-small")
+BATCH_SIZE = 1000
+MAX_EMBED_INPUT_CHARS_PER_REQUEST = 600_000
+TARGET_TABLE = "place_embeddings_v2"
+
+SERVICE_FEATURES = {
+    "curbsidePickup": "curbside pickup",
+    "delivery": "delivery",
+    "dineIn": "dine-in",
+    "reservable": "reservations",
+    "takeout": "takeout",
+}
+
+DINING_FEATURES = {
+    "allowsDogs": "dogs allowed",
+    "goodForChildren": "good for children",
+    "goodForGroups": "good for groups",
+    "goodForWatchingSports": "good for watching sports",
+    "liveMusic": "live music",
+    "menuForChildren": "children's menu",
+    "outdoorSeating": "outdoor seating",
+    "restroom": "restroom",
+}
+
+FOOD_DRINK_FEATURES = {
+    "servesBeer": "beer",
+    "servesBreakfast": "breakfast",
+    "servesBrunch": "brunch",
+    "servesCocktails": "cocktails",
+    "servesCoffee": "coffee",
+    "servesDessert": "dessert",
+    "servesDinner": "dinner",
+    "servesLunch": "lunch",
+    "servesVegetarianFood": "vegetarian food",
+    "servesWine": "wine",
+}
+
+JSON_FLAG_GROUPS = {
+    "Accessibility": "accessibilityOptions",
+    "Parking": "parkingOptions",
+    "Payment": "paymentOptions",
+}
+
+
+@dataclass
+class PlaceRow:
+    place_id: str
+    source_updated_at: str
+    text: str
+
+
+def _join_nonempty(values: list[str]) -> str:
+    return ", ".join(value for value in values if value)
+
+
+def _localized_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        text = value.get("text")
+        if isinstance(text, str):
+            return text
+    return ""
+
+
+def _humanize_key(key: str) -> str:
+    words: list[str] = []
+    current = ""
+    for char in key:
+        if char.isupper() and current:
+            words.append(current)
+            current = char.lower()
+        else:
+            current += char.lower()
+    if current:
+        words.append(current)
+    return " ".join(words)
+
+
+def _enabled_features(source_json: dict, fields: dict[str, str]) -> str:
+    return _join_nonempty([label for key, label in fields.items() if source_json.get(key) is True])
+
+
+def _json_flags(source_json: dict, key: str) -> str:
+    value = source_json.get(key) or {}
+    if not isinstance(value, dict):
+        return ""
+    return _join_nonempty(
+        [_humanize_key(field) for field, enabled in value.items() if enabled is True]
+    )
+
+
+# ---- text composition ------------------------------------------------------
+
+
+def _summary_object_text(value: object) -> str:
+    """Extract the human-readable text from Places v1 summary objects.
+
+    Shape: {"text": {"text": "...", "languageCode": "en-US"},
+            "disclosureText": {...}, "flagContentUri": "...", "reviewsUri": "..."}
+    We want ONLY the inner text; everything else is noise (URLs, language tags,
+    "Summarized with Gemini" boilerplate).
+    """
+    if not isinstance(value, dict):
+        return ""
+    inner = value.get("text") or value.get("overview")
+    if isinstance(inner, dict):
+        text = inner.get("text")
+        if isinstance(text, str):
+            return text
+    if isinstance(inner, str):
+        return inner
+    return ""
+
+
+def _neighborhood_from_address_components(source_json: dict) -> str:
+    """Extract the structured neighborhood from addressComponents.
+
+    Shape: addressComponents: [{"types": ["neighborhood", "political"],
+                                "longText": "Mission Bay", ...}, ...]
+    """
+    components = source_json.get("addressComponents") or []
+    if not isinstance(components, list):
+        return ""
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        types = component.get("types") or []
+        if "neighborhood" in types:
+            text = component.get("longText") or component.get("shortText")
+            if isinstance(text, str):
+                return text
+    return ""
+
+
+def _containing_area_names(source_json: dict) -> str:
+    """Names of containing areas from addressDescriptor.areas[].displayName.
+
+    Shape: addressDescriptor.areas: [{"displayName": {"text": "Mission Bay", ...},
+                                       "containment": "WITHIN"}, ...]
+    """
+    descriptor = source_json.get("addressDescriptor") or {}
+    if not isinstance(descriptor, dict):
+        return ""
+    areas = descriptor.get("areas") or []
+    if not isinstance(areas, list):
+        return ""
+    names: list[str] = []
+    for area in areas:
+        if not isinstance(area, dict):
+            continue
+        text = _localized_text(area.get("displayName"))
+        if text and text not in names:
+            names.append(text)
+    return ", ".join(names)
+
+
+def _nearby_landmark_names(source_json: dict, max_landmarks: int = 5) -> str:
+    """Names of nearby landmarks (no distances, no place IDs).
+
+    Distance + place IDs are consumed by W7 (knowledge graph) directly from
+    source_json — they are KG inputs, not embedding inputs.
+    """
+    descriptor = source_json.get("addressDescriptor") or {}
+    if not isinstance(descriptor, dict):
+        return ""
+    landmarks = descriptor.get("landmarks") or []
+    if not isinstance(landmarks, list):
+        return ""
+    names: list[str] = []
+    for landmark in landmarks[:max_landmarks]:
+        if not isinstance(landmark, dict):
+            continue
+        text = _localized_text(landmark.get("displayName"))
+        if text:
+            names.append(text)
+    return ", ".join(names)
+
+
+def compose_embedding_text_v2(record: dict) -> str:
+    """Cleaned embedding text. See w0a_embeddings_v2.md for the role taxonomy.
+
+    KEEP (Role 1 — semantic signal):
+      name, primary_type, types, editorial_summary, generative summary text,
+      review summary text, service / dining / food-drink boolean labels,
+      neighborhood, containing areas, nearby landmark names, accessibility /
+      parking / payment labels.
+
+    DROP (Role 2 / Role 3 — facts and action payloads, do NOT embed):
+      rating, user_rating_count, price_level, price_range, opening hours text,
+      lat/lng, business_status, phone numbers, all URLs (websiteUri,
+      googleMapsUri, googleMapsLinks, flagContentUri, reviewsUri inside
+      summaries), language codes, "Summarized with Gemini" disclosure text.
+    """
+    source_json = record.get("source_json") or {}
+    if not isinstance(source_json, dict):
+        source_json = {}
+
+    parts: list[str] = []
+
+    # --- core identification ------------------------------------------------
+    parts.append(f"Name: {record.get('name') or ''}")
+    parts.append(f"Primary Type: {record.get('primary_type') or ''}")
+    types = record.get("types") or []
+    if types:
+        parts.append(f"Types: {', '.join(types)}")
+
+    # --- geographic context (names only, never numbers) ---------------------
+    neighborhood = _neighborhood_from_address_components(source_json)
+    if neighborhood:
+        parts.append(f"Neighborhood: {neighborhood}")
+    containing = _containing_area_names(source_json)
+    if containing:
+        parts.append(f"Containing Areas: {containing}")
+    landmarks = _nearby_landmark_names(source_json)
+    if landmarks:
+        parts.append(f"Nearby Landmarks: {landmarks}")
+
+    # --- editorial / generative / review prose ------------------------------
+    editorial = record.get("editorial_summary") or _summary_object_text(
+        source_json.get("editorialSummary")
+    )
+    if editorial:
+        parts.append(f"Editorial Summary: {editorial}")
+    generative = _summary_object_text(source_json.get("generativeSummary"))
+    if generative:
+        parts.append(f"Generative Summary: {generative}")
+    review_summary = _summary_object_text(source_json.get("reviewSummary"))
+    if review_summary:
+        parts.append(f"Review Summary: {review_summary}")
+
+    # --- amenities (boolean labels only — no values, no JSON) ---------------
+    service = _enabled_features(source_json, SERVICE_FEATURES)
+    if service:
+        parts.append(f"Service Options: {service}")
+    dining = _enabled_features(source_json, DINING_FEATURES)
+    if dining:
+        parts.append(f"Dining Features: {dining}")
+    food_drink = _enabled_features(source_json, FOOD_DRINK_FEATURES)
+    if food_drink:
+        parts.append(f"Food and Drink: {food_drink}")
+    for label, key in JSON_FLAG_GROUPS.items():
+        flags = _json_flags(source_json, key)
+        if flags:
+            parts.append(f"{label}: {flags}")
+
+    # --- raw reviews (only if ingest started capturing places.reviews) ------
+    reviews = source_json.get("reviews") or []
+    if isinstance(reviews, list) and reviews:
+        review_texts: list[str] = []
+        for review in reviews[:5]:
+            if not isinstance(review, dict):
+                continue
+            text = _localized_text(review.get("text"))
+            if text:
+                review_texts.append(text)
+        if review_texts:
+            parts.append("Reviews: " + " | ".join(review_texts))
+
+    return "\n".join(part for part in parts if not part.endswith(": "))
+
+
+def fetch_rows_to_embed(conn: psycopg2.extensions.connection, limit: int) -> list[PlaceRow]:
+    # TARGET_TABLE is a module-level constant, not user input.
+    sql = f"""
+    SELECT
+        p.place_id,
+        p.source_updated_at,
+        p.name,
+        p.primary_type,
+        p.formatted_address,
+        p.types,
+        p.editorial_summary,
+        p.regular_opening_hours,
+        p.rating,
+        p.user_rating_count,
+        p.price_level,
+        p.website_uri,
+        p.business_status,
+        p.latitude,
+        p.longitude,
+        p.source_json
+    FROM places_raw p
+    LEFT JOIN {TARGET_TABLE} e ON e.place_id = p.place_id
+    WHERE e.place_id IS NULL
+       OR e.source_updated_at < p.source_updated_at
+    ORDER BY p.source_updated_at ASC
+    LIMIT %s
+    """  # noqa: S608
+
+    rows: list[PlaceRow] = []
+    with conn.cursor() as cur:
+        cur.execute(sql, (limit,))
+        for row in cur.fetchall():
+            record = {
+                "place_id": row[0],
+                "source_updated_at": row[1],
+                "name": row[2],
+                "primary_type": row[3],
+                "formatted_address": row[4],
+                "types": row[5],
+                "editorial_summary": row[6],
+                "regular_opening_hours": row[7],
+                "rating": row[8],
+                "user_rating_count": row[9],
+                "price_level": row[10],
+                "website_uri": row[11],
+                "business_status": row[12],
+                "latitude": row[13],
+                "longitude": row[14],
+                "source_json": row[15],
+            }
+            rows.append(
+                PlaceRow(
+                    place_id=record["place_id"],
+                    source_updated_at=record["source_updated_at"],
+                    text=compose_embedding_text_v2(record),
+                )
+            )
+    return rows
+
+
+def vector_to_pg(embedding: list[float]) -> str:
+    return "[" + ",".join(f"{value:.8f}" for value in embedding) + "]"
+
+
+def upsert_embedding(
+    conn: psycopg2.extensions.connection,
+    place_id: str,
+    source_updated_at: str,
+    text: str,
+    embedding: list[float],
+) -> None:
+    # TARGET_TABLE is a module-level constant, not user input.
+    sql = f"""
+    INSERT INTO {TARGET_TABLE} (
+        place_id,
+        embedding,
+        embedding_model,
+        embedding_text,
+        embedded_at,
+        source_updated_at
+    )
+    VALUES (%s, %s::vector, %s, %s, NOW(), %s)
+    ON CONFLICT (place_id) DO UPDATE SET
+        embedding = EXCLUDED.embedding,
+        embedding_model = EXCLUDED.embedding_model,
+        embedding_text = EXCLUDED.embedding_text,
+        embedded_at = NOW(),
+        source_updated_at = EXCLUDED.source_updated_at
+    """  # noqa: S608
+
+    with conn.cursor() as cur:
+        cur.execute(
+            sql,
+            (place_id, vector_to_pg(embedding), EMBED_MODEL, text, source_updated_at),
+        )
+    conn.commit()
+
+
+def iter_embedding_batches(rows: list[PlaceRow]) -> list[list[PlaceRow]]:
+    batches: list[list[PlaceRow]] = []
+    current_batch: list[PlaceRow] = []
+    current_chars = 0
+
+    for row in rows:
+        row_chars = len(row.text)
+        if current_batch and current_chars + row_chars > MAX_EMBED_INPUT_CHARS_PER_REQUEST:
+            batches.append(current_batch)
+            current_batch = []
+            current_chars = 0
+
+        current_batch.append(row)
+        current_chars += row_chars
+
+    if current_batch:
+        batches.append(current_batch)
+
+    return batches
+
+
+def run() -> None:
+    if not DATABASE_URL:
+        raise RuntimeError("Missing DATABASE_URL in environment.")
+    if not OPENAI_API_KEY:
+        raise RuntimeError("Missing OPENAI_API_KEY in environment.")
+
+    client = OpenAI(api_key=OPENAI_API_KEY)
+
+    with psycopg2.connect(DATABASE_URL) as conn:
+        rows = fetch_rows_to_embed(conn, limit=BATCH_SIZE)
+        if not rows:
+            print(f"No new or updated places to embed into {TARGET_TABLE}.")
+            return
+
+        embedded_count = 0
+        batches = iter_embedding_batches(rows)
+        for index, batch in enumerate(batches, start=1):
+            inputs = [row.text for row in batch]
+            input_chars = sum(len(text) for text in inputs)
+            print(
+                f"Embedding request {index}/{len(batches)}: "
+                f"{len(batch)} places, {input_chars} chars"
+            )
+            response = client.embeddings.create(model=EMBED_MODEL, input=inputs)
+
+            for row, item in zip(batch, response.data, strict=True):
+                upsert_embedding(
+                    conn,
+                    place_id=row.place_id,
+                    source_updated_at=row.source_updated_at,
+                    text=row.text,
+                    embedding=item.embedding,
+                )
+                embedded_count += 1
+
+    print(
+        f"Embedded and upserted {embedded_count} places into {TARGET_TABLE} "
+        f"with model {EMBED_MODEL}."
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/embed_places_pgvector_v2.py
+++ b/scripts/embed_places_pgvector_v2.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 import psycopg2
 from dotenv import load_dotenv
 from openai import OpenAI
+from psycopg2.extras import execute_values
 
 from app.config import resolve_database_url
 
@@ -397,6 +398,47 @@ def upsert_embedding(
     conn.commit()
 
 
+def upsert_embeddings_batch(
+    conn: psycopg2.extensions.connection,
+    rows: list[tuple[str, str, str, list[float]]],
+) -> None:
+    """Batched upsert: one round-trip + one commit per call.
+
+    Each row is (place_id, source_updated_at, text, embedding). Replaces N
+    sequential upsert_embedding calls (each a network round-trip through the
+    Cloud SQL proxy) with a single execute_values; on a typical 1000-row
+    OpenAI batch, this collapses ~1000 commits into 1.
+    """
+    # TARGET_TABLE is a module-level constant, not user input.
+    sql = f"""
+    INSERT INTO {TARGET_TABLE} (
+        place_id,
+        embedding,
+        embedding_model,
+        embedding_text,
+        embedded_at,
+        source_updated_at
+    )
+    VALUES %s
+    ON CONFLICT (place_id) DO UPDATE SET
+        embedding = EXCLUDED.embedding,
+        embedding_model = EXCLUDED.embedding_model,
+        embedding_text = EXCLUDED.embedding_text,
+        embedded_at = NOW(),
+        source_updated_at = EXCLUDED.source_updated_at
+    """  # noqa: S608
+
+    template = "(%s, %s::vector, %s, %s, NOW(), %s)"
+    values = [
+        (place_id, vector_to_pg(embedding), EMBED_MODEL, text, source_updated_at)
+        for place_id, source_updated_at, text, embedding in rows
+    ]
+
+    with conn.cursor() as cur:
+        execute_values(cur, sql, values, template=template, page_size=len(values) or 1)
+    conn.commit()
+
+
 def iter_embedding_batches(rows: list[PlaceRow]) -> list[list[PlaceRow]]:
     batches: list[list[PlaceRow]] = []
     current_batch: list[PlaceRow] = []
@@ -451,15 +493,12 @@ def run() -> None:
                 )
                 response = client.embeddings.create(model=EMBED_MODEL, input=inputs)
 
-                for row, item in zip(batch, response.data, strict=True):
-                    upsert_embedding(
-                        conn,
-                        place_id=row.place_id,
-                        source_updated_at=row.source_updated_at,
-                        text=row.text,
-                        embedding=item.embedding,
-                    )
-                    total_embedded += 1
+                upsert_rows = [
+                    (row.place_id, row.source_updated_at, row.text, item.embedding)
+                    for row, item in zip(batch, response.data, strict=True)
+                ]
+                upsert_embeddings_batch(conn, upsert_rows)
+                total_embedded += len(upsert_rows)
 
     print(
         f"Embedded and upserted {total_embedded} places into {TARGET_TABLE} "

--- a/scripts/embed_places_pgvector_v2.py
+++ b/scripts/embed_places_pgvector_v2.py
@@ -425,36 +425,44 @@ def run() -> None:
         raise RuntimeError("Missing OPENAI_API_KEY in environment.")
 
     client = OpenAI(api_key=OPENAI_API_KEY)
+    total_embedded = 0
 
     with psycopg2.connect(DATABASE_URL) as conn:
-        rows = fetch_rows_to_embed(conn, limit=BATCH_SIZE)
-        if not rows:
-            print(f"No new or updated places to embed into {TARGET_TABLE}.")
-            return
+        # Loop until fetch_rows_to_embed returns no more rows. Each iteration
+        # streams up to BATCH_SIZE places into memory, embeds them, and upserts.
+        # The fetch query itself excludes already-embedded rows, so the loop
+        # terminates naturally and is safe to interrupt + resume.
+        while True:
+            rows = fetch_rows_to_embed(conn, limit=BATCH_SIZE)
+            if not rows:
+                if total_embedded == 0:
+                    print(f"No new or updated places to embed into {TARGET_TABLE}.")
+                break
 
-        embedded_count = 0
-        batches = iter_embedding_batches(rows)
-        for index, batch in enumerate(batches, start=1):
-            inputs = [row.text for row in batch]
-            input_chars = sum(len(text) for text in inputs)
-            print(
-                f"Embedding request {index}/{len(batches)}: "
-                f"{len(batch)} places, {input_chars} chars"
-            )
-            response = client.embeddings.create(model=EMBED_MODEL, input=inputs)
-
-            for row, item in zip(batch, response.data, strict=True):
-                upsert_embedding(
-                    conn,
-                    place_id=row.place_id,
-                    source_updated_at=row.source_updated_at,
-                    text=row.text,
-                    embedding=item.embedding,
+            batches = iter_embedding_batches(rows)
+            for index, batch in enumerate(batches, start=1):
+                inputs = [row.text for row in batch]
+                input_chars = sum(len(text) for text in inputs)
+                print(
+                    f"Embedding request {index}/{len(batches)} "
+                    f"(cumulative: {total_embedded}): "
+                    f"{len(batch)} places, {input_chars} chars",
+                    flush=True,
                 )
-                embedded_count += 1
+                response = client.embeddings.create(model=EMBED_MODEL, input=inputs)
+
+                for row, item in zip(batch, response.data, strict=True):
+                    upsert_embedding(
+                        conn,
+                        place_id=row.place_id,
+                        source_updated_at=row.source_updated_at,
+                        text=row.text,
+                        embedding=item.embedding,
+                    )
+                    total_embedded += 1
 
     print(
-        f"Embedded and upserted {embedded_count} places into {TARGET_TABLE} "
+        f"Embedded and upserted {total_embedded} places into {TARGET_TABLE} "
         f"with model {EMBED_MODEL}."
     )
 

--- a/tests/integration/test_embed_v2_e2e.py
+++ b/tests/integration/test_embed_v2_e2e.py
@@ -61,8 +61,7 @@ def test_v2_chunks_are_meaningfully_smaller_than_v1(conn) -> None:
     v1_median = median(r[0] for r in rows)
     v2_median = median(r[1] for r in rows)
     assert v2_median < 0.70 * v1_median, (
-        f"Expected v2 median chunk length < 70% of v1 median. "
-        f"Got v1={v1_median}, v2={v2_median}."
+        f"Expected v2 median chunk length < 70% of v1 median. Got v1={v1_median}, v2={v2_median}."
     )
 
 
@@ -88,6 +87,6 @@ def test_v2_chunks_contain_no_disclosure_boilerplate(conn) -> None:
            OR embedding_text ILIKE '%languageCode%'
         """,
     )
-    assert (
-        boilerplate_count == 0
-    ), f"{boilerplate_count} v2 rows still contain disclosure / language-code boilerplate."
+    assert boilerplate_count == 0, (
+        f"{boilerplate_count} v2 rows still contain disclosure / language-code boilerplate."
+    )

--- a/tests/integration/test_embed_v2_e2e.py
+++ b/tests/integration/test_embed_v2_e2e.py
@@ -1,0 +1,93 @@
+"""Integration tests for the v2 embeddings pipeline.
+
+Skipped unless APP_ENV=integration. Assumes both place_embeddings and
+place_embeddings_v2 have been populated from the same places_raw snapshot
+(run `make embed-places` and `make embed-v2` first).
+
+Verifies the v2 outputs satisfy the role taxonomy from
+implementation_plan/james/w0a_embeddings_v2.md.
+"""
+
+from __future__ import annotations
+
+import os
+from statistics import median
+
+import psycopg2
+import pytest
+
+from app.config import resolve_database_url
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("APP_ENV", "test") != "integration",
+    reason="Set APP_ENV=integration and provide a real DATABASE_URL to run integration tests.",
+)
+
+
+@pytest.fixture(scope="module")
+def conn():
+    database_url = resolve_database_url(os.environ)
+    if not database_url:
+        pytest.skip("No DATABASE_URL configured.")
+    connection = psycopg2.connect(database_url)
+    yield connection
+    connection.close()
+
+
+def _fetch_one(conn, sql: str) -> object:
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        return cur.fetchone()[0]
+
+
+def test_v2_table_populated(conn) -> None:
+    count = _fetch_one(conn, "SELECT COUNT(*) FROM place_embeddings_v2")
+    assert count > 0, "place_embeddings_v2 is empty — run `make embed-v2` first."
+
+
+def test_v2_chunks_are_meaningfully_smaller_than_v1(conn) -> None:
+    """Median v2 length should be < 70% of median v1 length on the same place_ids."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT LENGTH(v1.embedding_text), LENGTH(v2.embedding_text)
+            FROM place_embeddings    v1
+            JOIN place_embeddings_v2 v2 USING (place_id)
+            """
+        )
+        rows = cur.fetchall()
+
+    assert rows, "No overlapping rows between place_embeddings and place_embeddings_v2."
+    v1_median = median(r[0] for r in rows)
+    v2_median = median(r[1] for r in rows)
+    assert v2_median < 0.70 * v1_median, (
+        f"Expected v2 median chunk length < 70% of v1 median. "
+        f"Got v1={v1_median}, v2={v2_median}."
+    )
+
+
+def test_v2_chunks_contain_no_urls(conn) -> None:
+    forbidden_count = _fetch_one(
+        conn,
+        """
+        SELECT COUNT(*) FROM place_embeddings_v2
+        WHERE embedding_text ILIKE '%http%'
+           OR embedding_text ILIKE '%g_mp=%'
+           OR embedding_text ILIKE '%googleMapsLinks%'
+        """,
+    )
+    assert forbidden_count == 0, f"{forbidden_count} v2 rows still contain URL/link payloads."
+
+
+def test_v2_chunks_contain_no_disclosure_boilerplate(conn) -> None:
+    boilerplate_count = _fetch_one(
+        conn,
+        """
+        SELECT COUNT(*) FROM place_embeddings_v2
+        WHERE embedding_text ILIKE '%Summarized with Gemini%'
+           OR embedding_text ILIKE '%languageCode%'
+        """,
+    )
+    assert (
+        boilerplate_count == 0
+    ), f"{boilerplate_count} v2 rows still contain disclosure / language-code boilerplate."

--- a/tests/unit/test_embed_v2_compose.py
+++ b/tests/unit/test_embed_v2_compose.py
@@ -1,0 +1,202 @@
+"""Unit tests for the v2 embedding text composer.
+
+Verifies the role taxonomy from implementation_plan/james/w0a_embeddings_v2.md:
+the v2 string keeps semantic signal (Role 1) and drops structured facts and
+URL payloads (Roles 2 & 3).
+"""
+
+from __future__ import annotations
+
+from scripts.embed_places_pgvector_v2 import compose_embedding_text_v2
+
+
+def test_drops_googlemapslinks() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Coffee Shop",
+        "types": ["coffee_shop"],
+        "source_json": {
+            "googleMapsLinks": {
+                "placeUri": "https://maps.google.com/?cid=1&g_mp=...",
+                "photosUri": "https://www.google.com/maps/...",
+            },
+        },
+    }
+    text = compose_embedding_text_v2(record)
+    assert "google.com" not in text
+    assert "g_mp=" not in text
+    assert "googleMapsLinks" not in text
+
+
+def test_drops_facts_and_numbers() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Restaurant",
+        "types": ["restaurant"],
+        "rating": 4.8,
+        "user_rating_count": 254,
+        "price_level": "PRICE_LEVEL_INEXPENSIVE",
+        "latitude": 37.77,
+        "longitude": -122.41,
+        "regular_opening_hours": {"weekdayDescriptions": ["Monday: 8AM-4PM"]},
+        "business_status": "OPERATIONAL",
+        "source_json": {"nationalPhoneNumber": "(415) 555-0100"},
+    }
+    text = compose_embedding_text_v2(record)
+    assert "Rating:" not in text
+    assert "User Ratings:" not in text
+    assert "Price Level:" not in text
+    assert "Latitude:" not in text
+    assert "Longitude:" not in text
+    assert "Opening Hours:" not in text
+    assert "Business Status:" not in text
+    assert "Phone:" not in text
+
+
+def test_summary_extracts_text_only() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Cafe",
+        "types": [],
+        "source_json": {
+            "generativeSummary": {
+                "overview": {
+                    "text": "Coffee shop brewing organic beans.",
+                    "languageCode": "en-US",
+                },
+                "disclosureText": {
+                    "text": "Summarized with Gemini",
+                    "languageCode": "en-US",
+                },
+                "overviewFlagContentUri": "https://www.google.com/local/...",
+            },
+        },
+    }
+    text = compose_embedding_text_v2(record)
+    assert "Coffee shop brewing organic beans." in text
+    assert "Summarized with Gemini" not in text
+    assert "google.com" not in text
+    assert "languageCode" not in text
+
+
+def test_extracts_neighborhood() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Restaurant",
+        "types": [],
+        "source_json": {
+            "addressComponents": [
+                {"types": ["street_number"], "longText": "499"},
+                {"types": ["neighborhood", "political"], "longText": "Mission Bay"},
+                {"types": ["locality", "political"], "longText": "San Francisco"},
+            ],
+        },
+    }
+    assert "Neighborhood: Mission Bay" in compose_embedding_text_v2(record)
+
+
+def test_extracts_containing_areas() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Restaurant",
+        "types": [],
+        "source_json": {
+            "addressDescriptor": {
+                "areas": [
+                    {"displayName": {"text": "Mission Bay"}, "containment": "WITHIN"},
+                    {"displayName": {"text": "South of Market"}, "containment": "NEAR"},
+                ],
+            },
+        },
+    }
+    text = compose_embedding_text_v2(record)
+    assert "Containing Areas: Mission Bay, South of Market" in text
+
+
+def test_extracts_landmarks_without_distances() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Restaurant",
+        "types": [],
+        "source_json": {
+            "addressDescriptor": {
+                "landmarks": [
+                    {
+                        "displayName": {"text": "Chase Center"},
+                        "travelDistanceMeters": 322.04,
+                    },
+                    {
+                        "displayName": {"text": "Crane Cove Park"},
+                        "travelDistanceMeters": 453.77,
+                    },
+                ],
+            },
+        },
+    }
+    text = compose_embedding_text_v2(record)
+    assert "Chase Center" in text
+    assert "Crane Cove Park" in text
+    assert "322" not in text
+    assert "travelDistance" not in text
+
+
+def test_caps_landmarks_at_five() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Restaurant",
+        "types": [],
+        "source_json": {
+            "addressDescriptor": {
+                "landmarks": [{"displayName": {"text": f"Landmark {i}"}} for i in range(10)],
+            },
+        },
+    }
+    text = compose_embedding_text_v2(record)
+    assert "Landmark 0" in text
+    assert "Landmark 4" in text
+    assert "Landmark 5" not in text
+
+
+def test_includes_amenity_labels() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Restaurant",
+        "types": [],
+        "source_json": {
+            "outdoorSeating": True,
+            "servesCoffee": True,
+            "delivery": False,
+            "accessibilityOptions": {"wheelchairAccessibleEntrance": True},
+        },
+    }
+    text = compose_embedding_text_v2(record)
+    assert "outdoor seating" in text
+    assert "coffee" in text
+    assert "delivery" not in text
+    assert "wheelchair accessible entrance" in text
+
+
+def test_includes_reviews_when_present() -> None:
+    record = {
+        "name": "X",
+        "primary_type": "Cafe",
+        "types": [],
+        "source_json": {
+            "reviews": [
+                {"text": {"text": "Great espresso and cozy seating."}},
+                {"text": {"text": "Friendly staff, slow on weekends."}},
+            ],
+        },
+    }
+    text = compose_embedding_text_v2(record)
+    assert "Reviews:" in text
+    assert "Great espresso and cozy seating." in text
+    assert "Friendly staff, slow on weekends." in text
+
+
+def test_no_empty_lines_when_fields_missing() -> None:
+    record = {"name": "X", "primary_type": "", "types": [], "source_json": {}}
+    text = compose_embedding_text_v2(record)
+    assert "Name: X" in text
+    for line in text.splitlines():
+        assert not line.endswith(": ")


### PR DESCRIPTION
## Summary
- Adds `place_embeddings_v2`, a parallel embeddings table that drops URL noise / structured facts and adds neighborhood + landmark names extracted from existing `source_json`. v1 is untouched.
- Adds `EMBEDDING_TABLE` setting (default `place_embeddings`) so the app can A/B-flip between v1 and v2 by env flag once W6 confirms the win.
- Fixes three pre-existing bugs in the embed pipeline that surfaced during the manual verification run.

See `implementation_plan/james/w0a_embeddings_v2.md` for the full design + role taxonomy.

## What ships

- **Schema**: `scripts/db/migrations/000_place_embeddings_v2.sql` (CREATE TABLE + HNSW index, idempotent)
- **Pipeline**: `scripts/embed_places_pgvector_v2.py` with rewritten `compose_embedding_text_v2`
- **App wiring**: `app/config.py` (allowlist-validated `embedding_table`), `app/retriever.py` (reads table from settings)
- **Diagnostic**: `scripts/diagnose_chunks.py` (read-only v1-vs-v2 side-by-side)
- **Tests**: 10 new unit tests on the v2 composer + integration tests gated on `APP_ENV=integration`
- **Make**: `make embed-v2`

## Outcomes (Cloud SQL, full SF corpus)

|        | rows  | max len | avg len |
|--------|-------|---------|---------|
| v1     | 5,855 | 3,893   | 2,468   |
| v2     | 5,855 | 1,622   | **873** |

v2 average lands inside the 600–900 char prediction. Spot-checked v1 vs v2 chunks (Cull Canyon Recreation Area, The 500 Club, Jasmin's): every URL, language code, and "Summarized with Gemini" disclosure is gone from v2; `Neighborhood` / `Containing Areas` / `Nearby Landmarks` populated where data exists.

## Bugs found and fixed in this PR

These existed in the v1 embed pipeline too — fixing once for both, with v1 deprecation noted in the plan:

1. **`fix(scripts): run embed scripts as Python modules`** — `python scripts/foo.py` puts `scripts/` on `sys.path` instead of project root, so `from app.config …` fails. Adds `scripts/__init__.py` and switches Make targets to `poetry run python -m scripts.<name>`.
2. **`fix(scripts): keep embedding until no new rows remain`** — `run()` only embedded the first `BATCH_SIZE = 1000` rows then exited. Replaced with a `while True` loop that re-fetches until empty; the fetch query already excludes up-to-date rows, so the loop terminates naturally and stays interrupt-safe.
3. **`perf(embed-v2): batch upserts via psycopg2 execute_values`** — per-row commit through the Cloud SQL proxy capped throughput at ~50 rows/min. `execute_values` collapses ~1,000 commits into 1; full re-embed dropped from ~75 min to ~3 min. Applied to v2 only; v1 left unchanged.

## Risks / non-risks

- **Re-embed cost**: under \$1 (5,855 places × ~600 chars at \$0.02/1M tokens).
- **Default behavior unchanged**: `EMBEDDING_TABLE` defaults to `place_embeddings` (v1), so this PR is non-breaking. Promotion to v2 requires a one-line env flip after W6 evals.
- **`reviews` array still missing** from `places_raw.source_json` (never in the ingest field mask). The v2 composer already handles a `reviews` array if present, so a future re-ingest PR will populate it automatically via the existing `source_updated_at` change-detection path.

## Commits

```
4056fa5 docs(w0a): record outcomes + fixed verification command
cd26244 perf(embed-v2): batch upserts via psycopg2 execute_values
bea8857 fix(scripts): keep embedding until no new rows remain
13f997d fix(scripts): run embed scripts as Python modules
00be109 feat(w0a): cleaner embeddings on parallel place_embeddings_v2 table
```

## Test plan

- [x] `poetry run pytest tests/unit/` — 50 / 50 pass
- [x] `poetry run ruff check .` — clean
- [x] `poetry run mypy app/` — clean
- [x] Migration applied to Cloud SQL; `place_embeddings_v2` table created
- [x] `make embed-v2` populated 5,855 / 5,855 rows
- [x] `poetry run python -m scripts.diagnose_chunks -n 3` shows expected v1 → v2 cleanup
- [ ] After merge: A/B-test retrieval with `EMBEDDING_TABLE=place_embeddings_v2 make dev` (post-merge step, gated on W6 evals before any prod flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)