### PR TITLE
chore(precommit): bump ruff hook to v0.15.8 to match poetry.lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 repos:
+  # Keep this rev in sync with the ruff version pinned in poetry.lock
+  # (currently 0.15.8). Otherwise local hooks and CI's `ruff format --check`
+  # disagree and produce reformat-loops on commit.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.8
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
## Summary
Bumps the pre-commit ruff pin from `v0.6.9` to `v0.15.8` so it matches the ruff version pinned in `poetry.lock` (and used by CI's `ruff format --check`).

## Why
The pre-commit hook and the CI lint job were running different ruff versions, and the formatters disagree on details (collapsing short two-line f-strings, assert-message wrapping). The user-visible failure mode:

1. Local commit → pre-commit hook (old ruff) auto-formats files → commit succeeds.
2. Push → CI runs `ruff format --check` (new ruff) → fails because new ruff wants different formatting.
3. Run `poetry run ruff format` to fix → re-commit → pre-commit hook (old ruff) reverts the changes → commit blocked or files re-broken.

This was hit on PR #58 (W0a embeddings v2). The bypass there was `--no-verify` for one commit. This PR fixes the underlying mismatch so it doesn't keep happening.

## Change
Single-file edit to `.pre-commit-config.yaml`:
- `rev: v0.6.9` → `rev: v0.15.8`
- Adds a comment instructing future maintainers to keep the rev aligned with `poetry.lock`.

## Test plan
- [x] `poetry run pre-commit run --all-files` passes locally with the new pin.
- [x] Verified `poetry run ruff --version` reports `0.15.8` (matches the pin).
- [x] After merge, a future commit on any branch should not produce the local-vs-CI reformat loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)