### PR TITLE
feat(W0): agent infra — tracing, cost telemetry, and Cloud Run wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ OPENAI_CHAT_MODEL=gpt-4o-mini
 GEMINI_API_KEY=AIza...
 GEMINI_CHAT_MODEL=gemini-2.5-flash
 
+# ── Anthropic / Claude (agent driver, W0+) ────
+ANTHROPIC_API_KEY=sk-ant-...
+
 # ── MLflow ────────────────────────────────────
 # Local development uses an IAP/SSH tunnel to the private MLflow VM.
 # Open the tunnel before running the app:
@@ -43,12 +46,29 @@ GEMINI_CHAT_MODEL=gemini-2.5-flash
 MLFLOW_TRACKING_URI=http://localhost:5000
 MLFLOW_ARTIFACTS_URI=mlflow-artifacts://localhost:5000
 MLFLOW_MODEL_NAME=city-concierge-rag
+# Bearer token for the eventual auth-fronted MLflow (W0 §3, Path A). Leave
+# empty for local dev — the MLflow client only attaches it when set.
+MLFLOW_TRACKING_TOKEN=
+
+# ── Langfuse (per-request agent tracing, W0 §2) ───
+# Leave empty locally — app/observability degrades to a no-op when unset.
+# Get keys at https://cloud.langfuse.com (free tier) or self-host.
+LANGFUSE_SECRET_KEY=
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_HOST=https://cloud.langfuse.com
+
+# ── Embeddings (W0a) ──────────────────────────
+# Selects which embeddings table the retriever reads from. Validated against
+# an allowlist in app/config.py — typos fail loudly at startup.
+EMBEDDING_TABLE=place_embeddings
 
 # ── Application ───────────────────────────────
 APP_PORT=8000
 APP_ENV=development          # development | staging | production
 LOG_LEVEL=INFO
 RETRIEVER_K=5
+# Caps tool-loop iterations per /chat request (W0 → consumed in W2).
+AGENT_MAX_STEPS=8
 
 # ── Ingestion ─────────────────────────────────
 # Local path or remote URL used by the ingest pipeline

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -158,11 +158,13 @@ jobs:
       # MLFLOW_TRACKING_URI, CLOUD_SQL_INSTANCE_CONNECTION_NAME, …) untouched.
       #
       # PREREQUISITE: the 4 new secrets below must exist in Secret Manager before
-      # this job runs, or the deploy step fails. One-time setup (per project):
-      #   for s in anthropic-api-key langfuse-secret-key langfuse-public-key \
-      #            mlflow-tracking-token; do
+      # this job runs, or the deploy step fails. Resource names are UPPERCASE to
+      # match the existing OPENAI_API_KEY / GEMINI_API_KEY / POSTGRES_PASSWORD
+      # secrets and the env-var names in .env / .env.example. One-time setup:
+      #   for s in ANTHROPIC_API_KEY LANGFUSE_SECRET_KEY LANGFUSE_PUBLIC_KEY \
+      #            MLFLOW_TRACKING_TOKEN; do
       #     gcloud secrets create "$s" --replication-policy=automatic
-      #     echo -n "<value>" | gcloud secrets versions add "$s" --data-file=-
+      #     printf '%s' "<value>" | gcloud secrets versions add "$s" --data-file=-
       #     gcloud secrets add-iam-policy-binding "$s" \
       #       --member=serviceAccount:739618408593-compute@developer.gserviceaccount.com \
       #       --role=roles/secretmanager.secretAccessor
@@ -185,7 +187,7 @@ jobs:
             LANGFUSE_HOST=https://cloud.langfuse.com
             EMBEDDING_TABLE=place_embeddings
           secrets: |
-            ANTHROPIC_API_KEY=anthropic-api-key:latest
-            LANGFUSE_SECRET_KEY=langfuse-secret-key:latest
-            LANGFUSE_PUBLIC_KEY=langfuse-public-key:latest
-            MLFLOW_TRACKING_TOKEN=mlflow-tracking-token:latest
+            ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest
+            LANGFUSE_SECRET_KEY=LANGFUSE_SECRET_KEY:latest
+            LANGFUSE_PUBLIC_KEY=LANGFUSE_PUBLIC_KEY:latest
+            MLFLOW_TRACKING_TOKEN=MLFLOW_TRACKING_TOKEN:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -183,6 +183,7 @@ jobs:
           env_vars: |
             AGENT_MAX_STEPS=8
             LANGFUSE_HOST=https://cloud.langfuse.com
+            EMBEDDING_TABLE=place_embeddings
           secrets: |
             ANTHROPIC_API_KEY=anthropic-api-key:latest
             LANGFUSE_SECRET_KEY=langfuse-secret-key:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -143,9 +143,48 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
+      # ----- Cloud Run config (W0 — agent product) -----
+      # Sizing/concurrency flags (replace just the named fields):
+      #   min-instances=1   keep one warm; ~$15/mo to avoid 3–8s cold starts on demo.
+      #   max-instances=10  headroom for class-project demo, capped to bound cost.
+      #   concurrency=15    agent requests do 5+ blocking LLM calls; default 80 stacks
+      #                     too many in-flight astream_events per instance.
+      #   timeout=120       agent self-correction can take 30–60s.
+      #   cpu=2 / memory=2Gi  LangGraph + tool calls + embedding client are heavier
+      #                       than the legacy chain.
+      #
+      # env_vars / secrets default to MERGE — they only add/update the listed keys
+      # and leave existing values (OPENAI_API_KEY, GEMINI_API_KEY, POSTGRES_PASSWORD,
+      # MLFLOW_TRACKING_URI, CLOUD_SQL_INSTANCE_CONNECTION_NAME, …) untouched.
+      #
+      # PREREQUISITE: the 4 new secrets below must exist in Secret Manager before
+      # this job runs, or the deploy step fails. One-time setup (per project):
+      #   for s in anthropic-api-key langfuse-secret-key langfuse-public-key \
+      #            mlflow-tracking-token; do
+      #     gcloud secrets create "$s" --replication-policy=automatic
+      #     echo -n "<value>" | gcloud secrets versions add "$s" --data-file=-
+      #     gcloud secrets add-iam-policy-binding "$s" \
+      #       --member=serviceAccount:739618408593-compute@developer.gserviceaccount.com \
+      #       --role=roles/secretmanager.secretAccessor
+      #   done
       - name: Deploy new image to Cloud Run
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ env.CLOUD_RUN_SERVICE }}
           region: ${{ env.CLOUD_RUN_REGION }}
           image: ${{ needs.build-scan-push.outputs.image_uri }}
+          flags: >-
+            --min-instances=1
+            --max-instances=10
+            --concurrency=15
+            --cpu=2
+            --memory=2Gi
+            --timeout=120
+          env_vars: |
+            AGENT_MAX_STEPS=8
+            LANGFUSE_HOST=https://cloud.langfuse.com
+          secrets: |
+            ANTHROPIC_API_KEY=anthropic-api-key:latest
+            LANGFUSE_SECRET_KEY=langfuse-secret-key:latest
+            LANGFUSE_PUBLIC_KEY=langfuse-public-key:latest
+            MLFLOW_TRACKING_TOKEN=mlflow-tracking-token:latest

--- a/app/observability/__init__.py
+++ b/app/observability/__init__.py
@@ -1,0 +1,57 @@
+"""Per-request tracing for the agent product (W0).
+
+Wired via Langfuse — self-hostable alongside MLflow if cost matters, or use
+the free Cloud tier for class-project usage. Falls back to a no-op if
+LANGFUSE_SECRET_KEY isn't set so local dev still works.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+try:
+    from langfuse import Langfuse
+    from langfuse.callback import CallbackHandler
+except ImportError:  # pragma: no cover - exercised only when extras are absent
+    Langfuse = None  # type: ignore[assignment,misc]
+    CallbackHandler = None  # type: ignore[assignment,misc]
+
+
+def get_client() -> Any | None:
+    """Return a configured Langfuse client, or None if disabled."""
+    if Langfuse is None:
+        return None
+    if not os.getenv("LANGFUSE_SECRET_KEY"):
+        return None
+    return Langfuse(
+        secret_key=os.environ["LANGFUSE_SECRET_KEY"],
+        public_key=os.environ["LANGFUSE_PUBLIC_KEY"],
+        host=os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com"),
+    )
+
+
+def langgraph_callbacks() -> list[Any]:
+    """Callbacks list to pass to LangGraph/LangChain `config={"callbacks": ...}`.
+
+    Empty list when tracing is disabled — LangChain treats that as a no-op.
+    """
+    if CallbackHandler is None or not os.getenv("LANGFUSE_SECRET_KEY"):
+        return []
+    return [CallbackHandler()]
+
+
+@contextmanager
+def trace_request(name: str, **metadata: Any) -> Iterator[str | None]:
+    """Wrap an agent invocation. Yields a trace id you can attach to logs."""
+    client = get_client()
+    if client is None:
+        yield None
+        return
+    trace = client.trace(name=name, metadata=metadata)
+    try:
+        yield trace.id
+    finally:
+        client.flush()

--- a/app/observability/__init__.py
+++ b/app/observability/__init__.py
@@ -7,10 +7,13 @@ LANGFUSE_SECRET_KEY isn't set so local dev still works.
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
+
+logger = logging.getLogger("city_concierge.observability")
 
 try:
     from langfuse import Langfuse
@@ -19,18 +22,49 @@ except ImportError:  # pragma: no cover - exercised only when extras are absent
     Langfuse = None  # type: ignore[assignment,misc]
     CallbackHandler = None  # type: ignore[assignment,misc]
 
+_warned_missing_package = False
+
+
+def _tracing_enabled() -> bool:
+    """Single source of truth for 'is per-request tracing turned on?'."""
+    return Langfuse is not None and bool(os.getenv("LANGFUSE_SECRET_KEY"))
+
+
+def _warn_if_package_missing_but_env_set() -> None:
+    """Warn once if env says tracing is on but the langfuse package failed to import.
+
+    Distinguishes a real misconfig (deps drift, broken image) from an intentional
+    no-op (local dev with no env). Fires at most once per process.
+    """
+    global _warned_missing_package
+    if _warned_missing_package:
+        return
+    if Langfuse is None and os.getenv("LANGFUSE_SECRET_KEY"):
+        logger.warning(
+            "LANGFUSE_SECRET_KEY is set but the 'langfuse' package is not installed; "
+            "tracing is silently disabled. Check that the deployed image includes it."
+        )
+        _warned_missing_package = True
+
 
 def get_client() -> Any | None:
-    """Return a configured Langfuse client, or None if disabled."""
-    if Langfuse is None:
+    """Return a configured Langfuse client, or None if disabled.
+
+    Returns None on any SDK construction failure (bad host, version skew, etc.) —
+    tracing must never break the request path.
+    """
+    _warn_if_package_missing_but_env_set()
+    if not _tracing_enabled():
         return None
-    if not os.getenv("LANGFUSE_SECRET_KEY"):
+    try:
+        return Langfuse(
+            secret_key=os.environ["LANGFUSE_SECRET_KEY"],
+            public_key=os.environ["LANGFUSE_PUBLIC_KEY"],
+            host=os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com"),
+        )
+    except Exception as exc:
+        logger.warning("Langfuse client construction failed: %s", exc)
         return None
-    return Langfuse(
-        secret_key=os.environ["LANGFUSE_SECRET_KEY"],
-        public_key=os.environ["LANGFUSE_PUBLIC_KEY"],
-        host=os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com"),
-    )
 
 
 def langgraph_callbacks() -> list[Any]:
@@ -38,20 +72,33 @@ def langgraph_callbacks() -> list[Any]:
 
     Empty list when tracing is disabled — LangChain treats that as a no-op.
     """
-    if CallbackHandler is None or not os.getenv("LANGFUSE_SECRET_KEY"):
+    _warn_if_package_missing_but_env_set()
+    if not _tracing_enabled() or CallbackHandler is None:
         return []
     return [CallbackHandler()]
 
 
 @contextmanager
 def trace_request(name: str, **metadata: Any) -> Iterator[str | None]:
-    """Wrap an agent invocation. Yields a trace id you can attach to logs."""
+    """Wrap an agent invocation. Yields a trace id you can attach to logs.
+
+    Falls through to a no-op (yield None) if the SDK raises while creating the
+    trace — observability must never break user requests.
+    """
     client = get_client()
     if client is None:
         yield None
         return
-    trace = client.trace(name=name, metadata=metadata)
+    try:
+        trace = client.trace(name=name, metadata=metadata)
+    except Exception as exc:
+        logger.warning("Langfuse trace() failed: %s", exc)
+        yield None
+        return
     try:
         yield trace.id
     finally:
-        client.flush()
+        try:
+            client.flush()
+        except Exception as exc:
+            logger.warning("Langfuse flush() failed: %s", exc)

--- a/app/observability/cost.py
+++ b/app/observability/cost.py
@@ -1,0 +1,74 @@
+"""Per-call token + cost telemetry for the agent product (W0 §5).
+
+Wraps each LLM call so we get a single structured log line per request with
+model, tokens_in, tokens_out, est_cost_usd, latency_ms. Lives alongside
+Langfuse tracing — Langfuse gives the UI; this gives greppable Cloud Logging
+entries for cost dashboards and spot checks.
+
+Logs go to stdout, picked up by Cloud Run's log router. For dashboards, point
+Cloud Logging's log-based metrics at jsonPayload.est_cost_usd.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+logger = logging.getLogger("city_concierge.cost")
+
+# USD per 1M tokens. Update when prices change. Source of truth: each provider's
+# public pricing page. Treat these numbers as estimates and refresh quarterly.
+PRICING: dict[str, dict[str, float]] = {
+    "gpt-4o-mini": {"in": 0.15, "out": 0.60},
+    "gpt-4o": {"in": 2.50, "out": 10.00},
+    "claude-opus-4-7": {"in": 15.00, "out": 75.00},
+    "claude-sonnet-4-6": {"in": 3.00, "out": 15.00},
+    "claude-haiku-4-5": {"in": 0.80, "out": 4.00},
+    "gemini-2.5-flash": {"in": 0.075, "out": 0.30},
+    "text-embedding-3-small": {"in": 0.02, "out": 0.0},
+}
+
+
+@dataclass
+class CallRecord:
+    model: str
+    tokens_in: int
+    tokens_out: int
+    latency_ms: int
+
+    @property
+    def est_cost_usd(self) -> float:
+        p = PRICING.get(self.model)
+        if not p:
+            return 0.0
+        return (self.tokens_in / 1e6) * p["in"] + (self.tokens_out / 1e6) * p["out"]
+
+
+@contextmanager
+def record_llm_call(model: str, request_id: str | None = None) -> Iterator[CallRecord]:
+    """Time an LLM call and emit a structured cost log line on exit.
+
+    Caller is responsible for setting `tokens_in` / `tokens_out` on the yielded
+    record from the provider's response usage block. Latency is captured
+    automatically. The log line fires even if the wrapped block raises.
+    """
+    rec = CallRecord(model=model, tokens_in=0, tokens_out=0, latency_ms=0)
+    start = time.monotonic()
+    try:
+        yield rec
+    finally:
+        rec.latency_ms = int((time.monotonic() - start) * 1000)
+        logger.info(
+            "llm_call",
+            extra={
+                "model": rec.model,
+                "tokens_in": rec.tokens_in,
+                "tokens_out": rec.tokens_out,
+                "latency_ms": rec.latency_ms,
+                "est_cost_usd": round(rec.est_cost_usd, 6),
+                "request_id": request_id,
+            },
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -262,6 +262,18 @@ files = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 description = "Fast, simple object-to-object and broadcast signaling"
@@ -2426,6 +2438,33 @@ files = [
 
 [package.dependencies]
 langchain-core = ">=0.3.75,<2.0.0"
+
+[[package]]
+name = "langfuse"
+version = "2.60.10"
+description = "A client library for accessing langfuse"
+optional = false
+python-versions = "<4.0,>=3.9"
+groups = ["main"]
+files = [
+    {file = "langfuse-2.60.10-py3-none-any.whl", hash = "sha256:815c6369194aa5b2a24f88eb9952f7c3fc863272c41e90642a71f3bc76f4a11f"},
+    {file = "langfuse-2.60.10.tar.gz", hash = "sha256:a26d0d927a28ee01b2d12bb5b862590b643cc4e60a28de6e2b0c2cfff5dbfc6a"},
+]
+
+[package.dependencies]
+anyio = ">=4.4.0,<5.0.0"
+backoff = ">=1.10.0"
+httpx = ">=0.15.4,<1.0"
+idna = ">=3.7,<4.0"
+packaging = ">=23.2,<25.0"
+pydantic = ">=1.10.7,<3.0"
+requests = ">=2,<3"
+wrapt = ">=1.14,<2.0"
+
+[package.extras]
+langchain = ["langchain (>=0.0.309)"]
+llama-index = ["llama-index (>=0.10.12,<2.0.0)"]
+openai = ["openai (>=0.27.8)"]
 
 [[package]]
 name = "langsmith"
@@ -5841,6 +5880,97 @@ markupsafe = ">=2.1.1"
 watchdog = ["watchdog (>=2.3)"]
 
 [[package]]
+name = "wrapt"
+version = "1.17.3"
+description = "Module for decorators, wrappers and monkey patching."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04"},
+    {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2"},
+    {file = "wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c"},
+    {file = "wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775"},
+    {file = "wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd"},
+    {file = "wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05"},
+    {file = "wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418"},
+    {file = "wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390"},
+    {file = "wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6"},
+    {file = "wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18"},
+    {file = "wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7"},
+    {file = "wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85"},
+    {file = "wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f"},
+    {file = "wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311"},
+    {file = "wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1"},
+    {file = "wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5"},
+    {file = "wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2"},
+    {file = "wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89"},
+    {file = "wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77"},
+    {file = "wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a"},
+    {file = "wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0"},
+    {file = "wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba"},
+    {file = "wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd"},
+    {file = "wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828"},
+    {file = "wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9"},
+    {file = "wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396"},
+    {file = "wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc"},
+    {file = "wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe"},
+    {file = "wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c"},
+    {file = "wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6"},
+    {file = "wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0"},
+    {file = "wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77"},
+    {file = "wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7"},
+    {file = "wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277"},
+    {file = "wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d"},
+    {file = "wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa"},
+    {file = "wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050"},
+    {file = "wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8"},
+    {file = "wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb"},
+    {file = "wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16"},
+    {file = "wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39"},
+    {file = "wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235"},
+    {file = "wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c"},
+    {file = "wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b"},
+    {file = "wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa"},
+    {file = "wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7"},
+    {file = "wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4"},
+    {file = "wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10"},
+    {file = "wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6"},
+    {file = "wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58"},
+    {file = "wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a"},
+    {file = "wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067"},
+    {file = "wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454"},
+    {file = "wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e"},
+    {file = "wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f"},
+    {file = "wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056"},
+    {file = "wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804"},
+    {file = "wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977"},
+    {file = "wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116"},
+    {file = "wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6"},
+    {file = "wrapt-1.17.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:70d86fa5197b8947a2fa70260b48e400bf2ccacdcab97bb7de47e3d1e6312225"},
+    {file = "wrapt-1.17.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df7d30371a2accfe4013e90445f6388c570f103d61019b6b7c57e0265250072a"},
+    {file = "wrapt-1.17.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:caea3e9c79d5f0d2c6d9ab96111601797ea5da8e6d0723f77eabb0d4068d2b2f"},
+    {file = "wrapt-1.17.3-cp38-cp38-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:758895b01d546812d1f42204bd443b8c433c44d090248bf22689df673ccafe00"},
+    {file = "wrapt-1.17.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02b551d101f31694fc785e58e0720ef7d9a10c4e62c1c9358ce6f63f23e30a56"},
+    {file = "wrapt-1.17.3-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:656873859b3b50eeebe6db8b1455e99d90c26ab058db8e427046dbc35c3140a5"},
+    {file = "wrapt-1.17.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a9a2203361a6e6404f80b99234fe7fb37d1fc73487b5a78dc1aa5b97201e0f22"},
+    {file = "wrapt-1.17.3-cp38-cp38-win32.whl", hash = "sha256:55cbbc356c2842f39bcc553cf695932e8b30e30e797f961860afb308e6b1bb7c"},
+    {file = "wrapt-1.17.3-cp38-cp38-win_amd64.whl", hash = "sha256:ad85e269fe54d506b240d2d7b9f5f2057c2aa9a2ea5b32c66f8902f768117ed2"},
+    {file = "wrapt-1.17.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:30ce38e66630599e1193798285706903110d4f057aab3168a34b7fdc85569afc"},
+    {file = "wrapt-1.17.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:65d1d00fbfb3ea5f20add88bbc0f815150dbbde3b026e6c24759466c8b5a9ef9"},
+    {file = "wrapt-1.17.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a7c06742645f914f26c7f1fa47b8bc4c91d222f76ee20116c43d5ef0912bba2d"},
+    {file = "wrapt-1.17.3-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e18f01b0c3e4a07fe6dfdb00e29049ba17eadbc5e7609a2a3a4af83ab7d710a"},
+    {file = "wrapt-1.17.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f5f51a6466667a5a356e6381d362d259125b57f059103dd9fdc8c0cf1d14139"},
+    {file = "wrapt-1.17.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:59923aa12d0157f6b82d686c3fd8e1166fa8cdfb3e17b42ce3b6147ff81528df"},
+    {file = "wrapt-1.17.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:46acc57b331e0b3bcb3e1ca3b421d65637915cfcd65eb783cb2f78a511193f9b"},
+    {file = "wrapt-1.17.3-cp39-cp39-win32.whl", hash = "sha256:3e62d15d3cfa26e3d0788094de7b64efa75f3a53875cdbccdf78547aed547a81"},
+    {file = "wrapt-1.17.3-cp39-cp39-win_amd64.whl", hash = "sha256:1f23fa283f51c890eda8e34e4937079114c74b4c81d2b2f1f1d94948f5cc3d7f"},
+    {file = "wrapt-1.17.3-cp39-cp39-win_arm64.whl", hash = "sha256:24c2ed34dc222ed754247a2702b1e1e89fdbaa4016f324b4b8f1a802d4ffe87f"},
+    {file = "wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22"},
+    {file = "wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0"},
+]
+
+[[package]]
 name = "xxhash"
 version = "3.6.0"
 description = "Python binding for xxHash"
@@ -6268,4 +6398,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "bdb710a8b294af1bcde483e6a51291ab8bdff2b51df78502a00d4240091252ae"
+content-hash = "01ad613d5a53df03f1429fb5c4504c7f10e778091b831cff5cbff30abd55ff09"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ httpx = ">=0.27.0,<1.0.0"
 tenacity = ">=8.3.0,<9.0.0"
 pyyaml = ">=6.0.1,<7.0.0"
 
+# Observability — per-request tracing for the agent product (W0)
+langfuse = ">=2.0.0,<3.0.0"
+
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.2.0,<9.0.0"
 pytest-asyncio = ">=0.23.6,<1.0.0"

--- a/tests/integration/test_observability_tracing_integration.py
+++ b/tests/integration/test_observability_tracing_integration.py
@@ -1,0 +1,41 @@
+"""Integration test for app.observability.trace_request — hits real Langfuse.
+
+Gated on `APP_ENV=integration` AND on `LANGFUSE_SECRET_KEY`/`LANGFUSE_PUBLIC_KEY`
+being set to real (test-project) credentials. Skipped otherwise.
+
+Run locally with:
+    APP_ENV=integration \\
+    LANGFUSE_SECRET_KEY=sk-... LANGFUSE_PUBLIC_KEY=pk-... \\
+    LANGFUSE_HOST=https://cloud.langfuse.com \\
+    poetry run pytest tests/integration/test_observability_tracing_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.getenv("APP_ENV", "test") != "integration",
+        reason="Set APP_ENV=integration to run integration tests.",
+    ),
+    pytest.mark.skipif(
+        not (os.getenv("LANGFUSE_SECRET_KEY") and os.getenv("LANGFUSE_PUBLIC_KEY")),
+        reason="LANGFUSE_SECRET_KEY/LANGFUSE_PUBLIC_KEY must be set for live trace test.",
+    ),
+]
+
+
+def test_real_trace_emits_id_and_flushes() -> None:
+    """Submit a trace to the real Langfuse host; verify we get back a UUID-shaped id."""
+    from app.observability import trace_request
+
+    marker = f"w0-integration-{uuid.uuid4()}"
+    with trace_request("integration_smoke", marker=marker) as trace_id:
+        assert isinstance(trace_id, str)
+        # Langfuse trace ids are UUID-shaped; a length sanity check is enough — we
+        # don't assert exact format because the SDK may evolve.
+        assert len(trace_id) >= 16

--- a/tests/unit/test_observability_cost.py
+++ b/tests/unit/test_observability_cost.py
@@ -1,0 +1,175 @@
+"""Tests for app.observability.cost.
+
+Layers covered:
+  - smoke      → module imports, helpers callable.
+  - unit/mock  → cost math (known/unknown models, edge cases).
+  - functional → record_llm_call context-manager behavior end-to-end:
+                 latency capture, log line shape, fires on exception,
+                 zero-token calls still log, request_id propagation.
+
+No integration layer: cost.py has no external dependencies — it's pure
+math + stdlib logging — so an integration test would just re-run the
+functional layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from unittest.mock import patch
+
+import pytest
+
+from app.observability.cost import PRICING, CallRecord, record_llm_call
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+
+def test_module_exports() -> None:
+    assert callable(record_llm_call)
+    assert isinstance(PRICING, dict)
+    assert "gpt-4o-mini" in PRICING
+
+
+def test_callrecord_constructs_with_zero_tokens() -> None:
+    rec = CallRecord(model="gpt-4o-mini", tokens_in=0, tokens_out=0, latency_ms=0)
+    assert rec.est_cost_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unit — cost math
+# ---------------------------------------------------------------------------
+
+
+def test_cost_calculation_known_model() -> None:
+    rec = CallRecord(
+        model="gpt-4o-mini",
+        tokens_in=1_000_000,
+        tokens_out=500_000,
+        latency_ms=0,
+    )
+    # 0.15 * 1.0  +  0.60 * 0.5  =  0.45
+    assert abs(rec.est_cost_usd - 0.45) < 1e-9
+
+
+def test_cost_zero_for_unknown_model() -> None:
+    rec = CallRecord(model="never-heard-of-it", tokens_in=999, tokens_out=999, latency_ms=0)
+    assert rec.est_cost_usd == 0.0
+
+
+def test_cost_handles_embedding_model_no_output() -> None:
+    rec = CallRecord(
+        model="text-embedding-3-small",
+        tokens_in=1_000_000,
+        tokens_out=0,
+        latency_ms=0,
+    )
+    # 0.02 * 1.0 = 0.02
+    assert abs(rec.est_cost_usd - 0.02) < 1e-9
+
+
+def test_cost_scales_linearly_with_tokens() -> None:
+    rec_small = CallRecord(model="gpt-4o", tokens_in=1_000, tokens_out=1_000, latency_ms=0)
+    rec_big = CallRecord(model="gpt-4o", tokens_in=10_000, tokens_out=10_000, latency_ms=0)
+    assert abs(rec_big.est_cost_usd - 10 * rec_small.est_cost_usd) < 1e-9
+
+
+def test_pricing_table_has_required_columns() -> None:
+    """Every model in PRICING must have both 'in' and 'out' keys."""
+    for model, prices in PRICING.items():
+        assert "in" in prices, f"{model} missing 'in' price"
+        assert "out" in prices, f"{model} missing 'out' price"
+        assert prices["in"] >= 0, f"{model} has negative input price"
+        assert prices["out"] >= 0, f"{model} has negative output price"
+
+
+# ---------------------------------------------------------------------------
+# Functional — context-manager behavior end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_record_llm_call_logs_on_exit(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="city_concierge.cost")
+    with record_llm_call("gpt-4o-mini", request_id="r1") as rec:
+        rec.tokens_in = 100
+        rec.tokens_out = 50
+
+    matches = [r for r in caplog.records if r.message == "llm_call"]
+    assert len(matches) == 1
+    log = matches[0]
+    assert log.model == "gpt-4o-mini"
+    assert log.tokens_in == 100
+    assert log.tokens_out == 50
+    assert log.request_id == "r1"
+    # 0.15 * 100/1M + 0.60 * 50/1M = 0.000015 + 0.000030 = 0.000045
+    assert log.est_cost_usd == round(0.000045, 6)
+
+
+def test_record_llm_call_captures_latency(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="city_concierge.cost")
+
+    fake_now = [0.0]
+
+    def fake_monotonic() -> float:
+        return fake_now[0]
+
+    with (
+        patch("app.observability.cost.time.monotonic", side_effect=fake_monotonic),
+        record_llm_call("gpt-4o-mini") as rec,
+    ):
+        fake_now[0] = 1.234  # simulate 1.234s elapsed inside the block
+        rec.tokens_in = 1
+        rec.tokens_out = 1
+
+    matches = [r for r in caplog.records if r.message == "llm_call"]
+    assert len(matches) == 1
+    assert matches[0].latency_ms == 1234
+
+
+def test_record_llm_call_fires_log_on_exception(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="city_concierge.cost")
+    with (
+        pytest.raises(RuntimeError, match="provider down"),
+        record_llm_call("gpt-4o-mini", request_id="r-fail") as rec,
+    ):
+        rec.tokens_in = 7
+        raise RuntimeError("provider down")
+
+    matches = [r for r in caplog.records if r.message == "llm_call"]
+    assert len(matches) == 1
+    assert matches[0].tokens_in == 7
+    assert matches[0].request_id == "r-fail"
+
+
+def test_record_llm_call_zero_tokens_still_logs(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="city_concierge.cost")
+    with record_llm_call("gpt-4o-mini"):
+        pass
+
+    matches = [r for r in caplog.records if r.message == "llm_call"]
+    assert len(matches) == 1
+    assert matches[0].tokens_in == 0
+    assert matches[0].tokens_out == 0
+    assert matches[0].est_cost_usd == 0.0
+    assert matches[0].request_id is None
+
+
+def test_record_llm_call_unknown_model_logs_zero_cost(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="city_concierge.cost")
+    with record_llm_call("brand-new-model") as rec:
+        rec.tokens_in = 1_000_000
+        rec.tokens_out = 500_000
+
+    matches = [r for r in caplog.records if r.message == "llm_call"]
+    assert len(matches) == 1
+    assert matches[0].est_cost_usd == 0.0
+    assert matches[0].model == "brand-new-model"
+
+
+def test_record_llm_call_real_clock_yields_nonneg_latency() -> None:
+    """Functional sanity check using the real monotonic clock."""
+    with record_llm_call("gpt-4o-mini") as rec:
+        time.sleep(0.001)
+    assert rec.latency_ms >= 0

--- a/tests/unit/test_observability_tracing.py
+++ b/tests/unit/test_observability_tracing.py
@@ -13,6 +13,7 @@ and is gated on APP_ENV=integration.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -158,6 +159,108 @@ def test_trace_request_flushes_even_on_exception(monkeypatch: pytest.MonkeyPatch
             raise ValueError("boom")
 
     fake_client.flush.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Unit / mock — warn-once when env is set but package is missing
+# ---------------------------------------------------------------------------
+
+
+def test_warns_once_when_env_set_but_package_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+
+    import app.observability as obs
+
+    monkeypatch.setattr(obs, "Langfuse", None)
+    monkeypatch.setattr(obs, "CallbackHandler", None)
+    monkeypatch.setattr(obs, "_warned_missing_package", False)
+
+    caplog.set_level(logging.WARNING, logger="city_concierge.observability")
+
+    assert obs.get_client() is None
+    assert obs.langgraph_callbacks() == []
+    with obs.trace_request("x") as tid:
+        assert tid is None
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "langfuse" in warnings[0].message.lower()
+
+
+def test_no_warning_when_package_missing_and_env_unset(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+
+    import app.observability as obs
+
+    monkeypatch.setattr(obs, "Langfuse", None)
+    monkeypatch.setattr(obs, "_warned_missing_package", False)
+
+    caplog.set_level(logging.WARNING, logger="city_concierge.observability")
+
+    assert obs.get_client() is None
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+# ---------------------------------------------------------------------------
+# Functional — SDK failures must never escape into the request path
+# ---------------------------------------------------------------------------
+
+
+def test_get_client_returns_none_when_constructor_raises(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _set_langfuse_env(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="city_concierge.observability")
+
+    def boom(*_: object, **__: object) -> None:
+        raise RuntimeError("connection refused")
+
+    with patch("app.observability.Langfuse", side_effect=boom):
+        from app.observability import get_client
+
+        assert get_client() is None
+
+    assert any("construction failed" in r.message for r in caplog.records)
+
+
+def test_trace_request_swallows_trace_call_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _set_langfuse_env(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="city_concierge.observability")
+
+    fake_client = MagicMock()
+    fake_client.trace.side_effect = RuntimeError("auth rejected")
+
+    with patch("app.observability.Langfuse", return_value=fake_client):
+        from app.observability import trace_request
+
+        ran = False
+        with trace_request("chat") as trace_id:
+            ran = True
+            assert trace_id is None
+
+    assert ran, "user code inside `with` must still execute when SDK fails"
+    assert any("trace() failed" in r.message for r in caplog.records)
+
+
+def test_trace_request_swallows_flush_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_langfuse_env(monkeypatch)
+    fake_client = MagicMock()
+    fake_client.trace.return_value = MagicMock(id="t-1")
+    fake_client.flush.side_effect = RuntimeError("network gone")
+
+    with patch("app.observability.Langfuse", return_value=fake_client):
+        from app.observability import trace_request
+
+        with trace_request("chat") as trace_id:
+            assert trace_id == "t-1"
+        # flush failure must not propagate
 
 
 def test_trace_request_metadata_threaded_through(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_observability_tracing.py
+++ b/tests/unit/test_observability_tracing.py
@@ -1,0 +1,177 @@
+"""Tests for app.observability tracing helpers.
+
+Layers covered:
+  - unit/mock      → pure logic, Langfuse client mocked.
+  - smoke          → module imports, helpers callable without raising.
+  - functional     → context manager yields trace id from a stubbed client,
+                     flushes on exit, treats exceptions transparently.
+
+Integration test (real Langfuse Cloud) lives in
+  tests/integration/test_observability_tracing_integration.py
+and is gated on APP_ENV=integration.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+
+def test_module_imports_cleanly() -> None:
+    import app.observability as obs
+
+    assert hasattr(obs, "get_client")
+    assert hasattr(obs, "langgraph_callbacks")
+    assert hasattr(obs, "trace_request")
+
+
+def test_helpers_callable_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+
+    from app.observability import get_client, langgraph_callbacks, trace_request
+
+    assert get_client() is None
+    assert langgraph_callbacks() == []
+    with trace_request("smoke") as trace_id:
+        assert trace_id is None
+
+
+# ---------------------------------------------------------------------------
+# Unit / mock — no env
+# ---------------------------------------------------------------------------
+
+
+def test_get_client_returns_none_without_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    from app.observability import get_client
+
+    assert get_client() is None
+
+
+def test_langgraph_callbacks_empty_without_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    from app.observability import langgraph_callbacks
+
+    assert langgraph_callbacks() == []
+
+
+def test_trace_request_no_op_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    from app.observability import trace_request
+
+    with trace_request("test", metadata_key="value") as trace_id:
+        assert trace_id is None
+
+
+# ---------------------------------------------------------------------------
+# Unit / mock — env present, Langfuse client stubbed
+# ---------------------------------------------------------------------------
+
+
+def _set_langfuse_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:9999")
+
+
+def test_get_client_constructs_with_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_langfuse_env(monkeypatch)
+    fake_client = MagicMock(name="LangfuseClient")
+    fake_ctor = MagicMock(return_value=fake_client)
+
+    with patch("app.observability.Langfuse", fake_ctor):
+        from app.observability import get_client
+
+        client = get_client()
+
+    assert client is fake_client
+    fake_ctor.assert_called_once_with(
+        secret_key="sk-test",
+        public_key="pk-test",
+        host="http://localhost:9999",
+    )
+
+
+def test_get_client_default_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+
+    fake_ctor = MagicMock(return_value=MagicMock())
+    with patch("app.observability.Langfuse", fake_ctor):
+        from app.observability import get_client
+
+        get_client()
+
+    _, kwargs = fake_ctor.call_args
+    assert kwargs["host"] == "https://cloud.langfuse.com"
+
+
+def test_langgraph_callbacks_returns_handler_with_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_langfuse_env(monkeypatch)
+    sentinel = object()
+
+    with patch("app.observability.CallbackHandler", return_value=sentinel):
+        from app.observability import langgraph_callbacks
+
+        callbacks = langgraph_callbacks()
+
+    assert callbacks == [sentinel]
+
+
+# ---------------------------------------------------------------------------
+# Functional — context-manager behavior end-to-end through public API
+# ---------------------------------------------------------------------------
+
+
+def test_trace_request_yields_trace_id_and_flushes(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_langfuse_env(monkeypatch)
+    fake_trace = MagicMock(id="trace-abc-123")
+    fake_client = MagicMock()
+    fake_client.trace.return_value = fake_trace
+
+    with patch("app.observability.Langfuse", return_value=fake_client):
+        from app.observability import trace_request
+
+        with trace_request("chat", message="hello") as trace_id:
+            assert trace_id == "trace-abc-123"
+
+    fake_client.trace.assert_called_once_with(name="chat", metadata={"message": "hello"})
+    fake_client.flush.assert_called_once()
+
+
+def test_trace_request_flushes_even_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_langfuse_env(monkeypatch)
+    fake_client = MagicMock()
+    fake_client.trace.return_value = MagicMock(id="trace-exc")
+
+    with patch("app.observability.Langfuse", return_value=fake_client):
+        from app.observability import trace_request
+
+        with pytest.raises(ValueError, match="boom"), trace_request("chat"):
+            raise ValueError("boom")
+
+    fake_client.flush.assert_called_once()
+
+
+def test_trace_request_metadata_threaded_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_langfuse_env(monkeypatch)
+    fake_client = MagicMock()
+    fake_client.trace.return_value = MagicMock(id="trace-meta")
+
+    with patch("app.observability.Langfuse", return_value=fake_client):
+        from app.observability import trace_request
+
+        with trace_request("chat", user_id="u1", session_id="s1"):
+            pass
+
+    fake_client.trace.assert_called_once_with(
+        name="chat",
+        metadata={"user_id": "u1", "session_id": "s1"},
+    )


### PR DESCRIPTION
## Summary

W0 infrastructure for the agent product, in three parts:

- **W0 §1 — Cloud Run wiring** (`d5856e0`, `97affab`, `50aeda7`): tune sizing/concurrency, declare `EMBEDDING_TABLE`, and wire new agent secrets via Secret Manager (UPPERCASE naming to match existing convention).
- **W0 §2 — Per-request tracing** (`2c34c59`, `43c05c1`, `7921b2b`): Langfuse-backed `trace_request()` context manager; degrades to no-op without env vars. Hardened so SDK failures (bad host, version skew, network drop) and missing-package misconfig can't break the `/chat` request path.
- **W0 §5 — Cost telemetry** (`16cfa14`): `record_llm_call()` context manager emits one structured log line per LLM call (model, tokens, latency, est USD) for Cloud Logging dashboards.
- **Docs** (`7d3ad9f`): document new env vars in `.env.example`, aligned with W0a.

## Notes

Still deferred (per the W0 plan, intentionally):
- W0 §3 MLflow auth proxy (Path A) — token plumbing in place; proxy itself is a follow-up.
- Promoting `EMBEDDING_TABLE=place_embeddings_v2` — gated on W6 retrieval evals.
- Streaming responses, embedding cache, Cloud SQL private VPC audit, per-user rate limiting (all flagged in the plan's "Deferred" section).

## Tests

- 29 unit tests across `test_observability_tracing.py` (16) and `test_observability_cost.py` (13), covering smoke, unit/mock, and functional layers.
- Integration test at `tests/integration/test_observability_tracing_integration.py` hits real Langfuse Cloud; gated on `APP_ENV=integration` + real keys.
- Defensive paths covered: SDK construction failure, `client.trace()` failure, `client.flush()` failure, missing-package warn-once behavior.

## Test plan

- [x] CI runs `make test` and the full unit suite passes
- [x] `ruff check` and `ruff format --check` clean
- [ ] Cloud Run deploy picks up new env vars and the `EMBEDDING_TABLE` declaration without manual intervention
- [x] Optional: run integration test locally with `APP_ENV=integration` + Langfuse Cloud keys to confirm a real trace round-trips
- [ ] After merge: verify `llm_call` log entries appear in Cloud Logging with non-zero `est_cost_usd` on a real `/chat` request (once W2 wires the handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)