### PR TITLE
docs(plan): record W0/W0a merge status and codify the update rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,3 +69,12 @@ Cloud Run (`city-concierge-api`) is intentionally **not** managed by Terraform �
 - Integration tests are skipped unless `APP_ENV=integration` is set
 - Environment variables configured via `.env` (see `.env.example` for all required vars)
 - Docker Compose service names: `db` (Postgres), `app` (FastAPI)
+
+## Implementation plan tracking
+
+The agent product roadmap lives in `implementation_plan/james/` — one file per workstream (W0, W0a, W1…W7) plus a `README.md` index with a status table. When merging a PR that completes (or partially completes) a workstream, update **both**:
+
+1. The status column in `implementation_plan/james/README.md` (✅ Merged with PR link, or 🚧 In progress)
+2. A short `**Status:**` footer at the bottom of the relevant `wN_*.md` file (PR link, date, what's still deferred)
+
+Don't update mid-workstream — only on merge. If a workstream ships in multiple PRs, link the most recent one and note in the footer what's still pending.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,12 @@ Cloud Run (`city-concierge-api`) is intentionally **not** managed by Terraform �
 - Integration tests are skipped unless `APP_ENV=integration` is set
 - Environment variables configured via `.env` (see `.env.example` for all required vars)
 - Docker Compose service names: `db` (Postgres), `app` (FastAPI)
+
+## Implementation plan tracking
+
+The agent product roadmap lives in `implementation_plan/james/` — one file per workstream (W0, W0a, W1…W7) plus a `README.md` index with a status table. When merging a PR that completes (or partially completes) a workstream, update **both**:
+
+1. The status column in `implementation_plan/james/README.md` (✅ Merged with PR link, or 🚧 In progress)
+2. A short `**Status:**` footer at the bottom of the relevant `wN_*.md` file (PR link, date, what's still deferred)
+
+Don't update mid-workstream — only on merge. If a workstream ships in multiple PRs, link the most recent one and note in the footer what's still pending.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,12 @@ Cloud Run (`city-concierge-api`) is intentionally **not** managed by Terraform �
 - Integration tests are skipped unless `APP_ENV=integration` is set
 - Environment variables configured via `.env` (see `.env.example` for all required vars)
 - Docker Compose service names: `db` (Postgres), `app` (FastAPI)
+
+## Implementation plan tracking
+
+The agent product roadmap lives in `implementation_plan/james/` — one file per workstream (W0, W0a, W1…W7) plus a `README.md` index with a status table. When merging a PR that completes (or partially completes) a workstream, update **both**:
+
+1. The status column in `implementation_plan/james/README.md` (✅ Merged with PR link, or 🚧 In progress)
+2. A short `**Status:**` footer at the bottom of the relevant `wN_*.md` file (PR link, date, what's still deferred)
+
+Don't update mid-workstream — only on merge. If a workstream ships in multiple PRs, link the most recent one and note in the footer what's still pending.

--- a/implementation_plan/james/README.md
+++ b/implementation_plan/james/README.md
@@ -17,17 +17,17 @@ It is also indistinguishable from "Opus 4.7 + web search" on the tasks Opus is g
 
 Six workstreams that convert the system into a tool-calling agent grounded in your structured DB, with the MLOps loop that lets it improve over time. Each workstream is its own file, its own branch, its own PR.
 
-| # | Workstream | File | Branch | Depends on |
-|---|---|---|---|---|
-| W0  | Infra hardening (cold starts, tracing, secrets, MLflow auth, cost telemetry) | [w0_infra.md](w0_infra.md) | `feature/agent-w0-infra` | — |
-| W0a | Cleaner embeddings on a parallel `place_embeddings_v2` table | [w0a_embeddings_v2.md](w0a_embeddings_v2.md) | `feature/agent-w0a-embeddings-v2` | — |
-| W1  | Unified place view + filterable retrieval tools | [w1_retrieval_tools.md](w1_retrieval_tools.md) | `feature/agent-w1-retrieval-tools` | W0a |
-| W2  | Agent loop + ItineraryState + `/chat` endpoint | [w2_agent_graph.md](w2_agent_graph.md) | `feature/agent-w2-agent-graph` | W1 (and ideally W0 for tracing) |
-| W3  | Self-correction (within W2's graph) | [w3_self_correction.md](w3_self_correction.md) | `feature/agent-w3-self-correction` | W2 |
-| W4  | Booking handoff stub (`propose_booking`) | [w4_booking_stub.md](w4_booking_stub.md) | `feature/agent-w4-booking-stub` | W2 |
-| W5  | Coverage-gap ingestion agent | [w5_coverage_agent.md](w5_coverage_agent.md) | `feature/agent-w5-coverage-agent` | — (independent) |
-| W6  | Eval-loop agent (RAGAS retrieval + custom itinerary checks) | [w6_eval_agent.md](w6_eval_agent.md) | `feature/agent-w6-eval-agent` | W2 |
-| W7  | Knowledge graph (`place_relations`) + `kg_traverse` tool | [w7_knowledge_graph.md](w7_knowledge_graph.md) | `feature/agent-w7-knowledge-graph` | W0a, W1 |
+| # | Workstream | File | Branch | Depends on | Status |
+|---|---|---|---|---|---|
+| W0  | Infra hardening (cold starts, tracing, secrets, MLflow auth, cost telemetry) | [w0_infra.md](w0_infra.md) | `feature/agent-w0-infra` | — | ✅ Merged ([#60](https://github.com/deshmukh-neel/mlops_city_concierge/pull/60)) — MLflow auth proxy (§3) deferred |
+| W0a | Cleaner embeddings on a parallel `place_embeddings_v2` table | [w0a_embeddings_v2.md](w0a_embeddings_v2.md) | `feature/agent-w0a-embeddings-v2` | — | ✅ Merged ([#58](https://github.com/deshmukh-neel/mlops_city_concierge/pull/58)) — promotion gated on W6 evals |
+| W1  | Unified place view + filterable retrieval tools | [w1_retrieval_tools.md](w1_retrieval_tools.md) | `feature/agent-w1-retrieval-tools` | W0a | 🚧 Not started |
+| W2  | Agent loop + ItineraryState + `/chat` endpoint | [w2_agent_graph.md](w2_agent_graph.md) | `feature/agent-w2-agent-graph` | W1 (and ideally W0 for tracing) | 🚧 Not started |
+| W3  | Self-correction (within W2's graph) | [w3_self_correction.md](w3_self_correction.md) | `feature/agent-w3-self-correction` | W2 | 🚧 Not started |
+| W4  | Booking handoff stub (`propose_booking`) | [w4_booking_stub.md](w4_booking_stub.md) | `feature/agent-w4-booking-stub` | W2 | 🚧 Not started |
+| W5  | Coverage-gap ingestion agent | [w5_coverage_agent.md](w5_coverage_agent.md) | `feature/agent-w5-coverage-agent` | — (independent) | 🚧 Not started |
+| W6  | Eval-loop agent (RAGAS retrieval + custom itinerary checks) | [w6_eval_agent.md](w6_eval_agent.md) | `feature/agent-w6-eval-agent` | W2 | 🚧 Not started |
+| W7  | Knowledge graph (`place_relations`) + `kg_traverse` tool | [w7_knowledge_graph.md](w7_knowledge_graph.md) | `feature/agent-w7-knowledge-graph` | W0a, W1 | 🚧 Not started |
 
 Suggested merge order: **W0a → W0 → W1 → W2 → W3 → W4** (cleaner embeddings first so all downstream retrieval rides on better vectors; user-facing demo path with infra in front), then **W5, W6, W7** in any order (MLOps story + KG layer). W0 and W5 are independent of the agent code and can land any time. If W0 is delayed, W2's tracing wiring degrades gracefully to a no-op (Langfuse env vars unset → empty callbacks list). W7 is technically optional but cheap to land once W0a + W1 are in.
 

--- a/implementation_plan/james/w0_infra.md
+++ b/implementation_plan/james/w0_infra.md
@@ -16,7 +16,7 @@ After this PR:
 - Secrets live in GCP Secret Manager, not raw env vars.
 - Per-request token + cost telemetry lands in logs from day one.
 
-Items deferred (real, but not blocking the demo): streaming responses, embedding cache, Cloud SQL private VPC audit. Each is a one-paragraph follow-up; flagged at the end of this doc.
+Items deferred (real, but not blocking the demo): streaming responses, embedding cache, Cloud SQL private VPC audit, per-user rate limiting. Each is a one-paragraph follow-up; flagged at the end of this doc.
 
 ## Files
 
@@ -38,12 +38,12 @@ Add to the `gcloud run deploy` invocation:
       --cpu=2 --memory=2Gi \
       --timeout=120 \
       --service-account=$RUN_SA \
-      --set-secrets=OPENAI_API_KEY=openai-api-key:latest,\
-GEMINI_API_KEY=gemini-api-key:latest,\
-ANTHROPIC_API_KEY=anthropic-api-key:latest,\
-LANGFUSE_SECRET_KEY=langfuse-secret-key:latest,\
-LANGFUSE_PUBLIC_KEY=langfuse-public-key:latest,\
-MLFLOW_TRACKING_TOKEN=mlflow-tracking-token:latest \
+      --set-secrets=OPENAI_API_KEY=OPENAI_API_KEY:latest,\
+GEMINI_API_KEY=GEMINI_API_KEY:latest,\
+ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,\
+LANGFUSE_SECRET_KEY=LANGFUSE_SECRET_KEY:latest,\
+LANGFUSE_PUBLIC_KEY=LANGFUSE_PUBLIC_KEY:latest,\
+MLFLOW_TRACKING_TOKEN=MLFLOW_TRACKING_TOKEN:latest \
       --set-env-vars=MLFLOW_TRACKING_URI=$MLFLOW_TRACKING_URI,\
 MLFLOW_MODEL_NAME=$MLFLOW_MODEL_NAME,\
 LANGFUSE_HOST=$LANGFUSE_HOST,\
@@ -348,3 +348,7 @@ gcloud run services describe city-concierge-app --region=$REGION \
 - **Embedding cache** keyed on `(query, embedding_model)` in Redis or a Postgres table. High value once W6 evals run regularly — reduces eval cost dramatically.
 - **Cloud SQL private VPC audit.** Confirm Cloud Run reaches Cloud SQL via private VPC connector + cloud-sql-proxy, not over public IP. 30-second check, real security implication.
 - **Per-user rate limiting.** Once you have real users, an unbounded `/chat` endpoint is a wallet attack vector. Add an IP-based limit (Cloud Armor) or per-API-key quotas.
+
+---
+
+**Status:** Merged in [PR #60](https://github.com/deshmukh-neel/mlops_city_concierge/pull/60) (2026-05-06). MLflow auth proxy (§3) is the remaining piece from this plan and will land as a follow-up PR.

--- a/implementation_plan/james/w0a_embeddings_v2.md
+++ b/implementation_plan/james/w0a_embeddings_v2.md
@@ -518,3 +518,7 @@ While running `make embed-v2` end-to-end against Cloud SQL we hit three pre-exis
 1. **`ModuleNotFoundError: No module named 'app'`** when running scripts directly. Fixed by adding `scripts/__init__.py` and switching the Make targets to `poetry run python -m scripts.<name>`. Also corrects the manual-verification command above.
 2. **Single-batch run** — `run()` only embedded the first `BATCH_SIZE = 1000` places and exited. Replaced with a `while True` loop that re-fetches until empty; the fetch query already excludes up-to-date rows, so the loop terminates naturally.
 3. **Per-row commit bottleneck** — capped throughput at ~50 rows/min through the Cloud SQL proxy. Replaced the per-row `upsert_embedding` loop with `psycopg2.extras.execute_values` batching (one round-trip per ~1,000-row OpenAI batch). A full corpus re-embed dropped from ~75 minutes to ~3 minutes. Applied to v2 only; v1 left unchanged since it's being deprecated.
+
+---
+
+**Status:** Merged in [PR #58](https://github.com/deshmukh-neel/mlops_city_concierge/pull/58). `EMBEDDING_TABLE=place_embeddings_v2` promotion is gated on W6 retrieval evals and remains intentionally deferred.


### PR DESCRIPTION
## Summary

Docs-only follow-up to W0 / W0a — records progress and locks in a small convention so the plan files don't drift.

- **`implementation_plan/james/README.md`** — adds a Status column to the workstream table. W0 (#60) and W0a (#58) marked merged with PR links; W1–W7 marked not started.
- **`implementation_plan/james/w0_infra.md`** — fixes Secret Manager names from lowercase-hyphen (`langfuse-secret-key`) to UPPERCASE_UNDERSCORE (`LANGFUSE_SECRET_KEY`) to match the actual deploy YAML; adds per-user rate limiting to the deferred list to match the merged PR; appends a Status footer linking PR #60.
- **`implementation_plan/james/w0a_embeddings_v2.md`** — appends a Status footer linking PR #58 and noting v2 promotion is gated on W6 evals.
- **`CLAUDE.md` / `AGENTS.md` / `.github/copilot-instructions.md`** — adds an "Implementation plan tracking" section telling future contributors (human or agent) to update the status table and the per-workstream footer on PR merge. Mirrored across all three per the existing sync notice.

## Test plan

- [x] Status table renders correctly on GitHub
- [x] PR links in footers are clickable
- [x] CLAUDE.md / AGENTS.md / copilot-instructions.md remain in sync (diff the new section across all three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)