### PR TITLE
fix(alembic): load .env so make migrate works without exported env vars

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,10 +11,16 @@ from __future__ import annotations
 
 from logging.config import fileConfig
 
+from dotenv import load_dotenv
 from sqlalchemy import engine_from_config, pool
 
 from alembic import context
 from app.db_url import resolve_alembic_database_url
+
+# Load .env so `alembic <cmd>` works the same way `python scripts/*.py` does.
+# Every script in this repo calls load_dotenv(); Alembic must too, or
+# `make migrate` fails for users who put DATABASE_URL only in .env.
+load_dotenv()
 
 config = context.config
 


### PR DESCRIPTION
## Summary

- Follow-up to #63. Adds `load_dotenv()` to `alembic/env.py` so `alembic <cmd>` picks up `DATABASE_URL` from `.env` the same way every script in `scripts/` does.

## Context

After #63 merged, running `poetry run alembic stamp head` against a stock checkout (`DATABASE_URL` only in `.env`, not exported) failed with:

```
RuntimeError: Alembic could not resolve a database URL. Set DATABASE_URL or
the POSTGRES_* env vars (see app/config.py:resolve_database_url).
```

The resolver (`app/db_url.py`) is correct — it reads `os.environ`. But `alembic/env.py` never loaded `.env` into `os.environ`, so the variable was never visible. Every script in `scripts/` already calls `load_dotenv()`; Alembic was the one entry point that didn't.

## Verified locally

- ✅ `poetry run alembic current` against the local `city_concierge` DB returns `5187c6b09b25 (head)` after this change (failed before it).
- ✅ `poetry run pytest tests/unit/test_alembic_config.py` — 4 passed.
- ✅ Pre-commit (`ruff check`, `ruff format`) — clean.

## Test plan

- [x] Local verification above
- [x] CI green (lint, typecheck, test, migrations round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)