### PR TITLE
docs(plan): record W1 merge status

### DIFF
--- a/implementation_plan/james/README.md
+++ b/implementation_plan/james/README.md
@@ -21,7 +21,7 @@ Six workstreams that convert the system into a tool-calling agent grounded in yo
 |---|---|---|---|---|---|
 | W0  | Infra hardening (cold starts, tracing, secrets, MLflow auth, cost telemetry) | [w0_infra.md](w0_infra.md) | `feature/agent-w0-infra` | — | ✅ Merged ([#60](https://github.com/deshmukh-neel/mlops_city_concierge/pull/60)) — MLflow auth proxy (§3) deferred |
 | W0a | Cleaner embeddings on a parallel `place_embeddings_v2` table | [w0a_embeddings_v2.md](w0a_embeddings_v2.md) | `feature/agent-w0a-embeddings-v2` | — | ✅ Merged ([#58](https://github.com/deshmukh-neel/mlops_city_concierge/pull/58)) — promotion gated on W6 evals |
-| W1  | Unified place view + filterable retrieval tools | [w1_retrieval_tools.md](w1_retrieval_tools.md) | `feature/agent-w1-retrieval-tools` | W0a | 🚧 Not started |
+| W1  | Unified place view + filterable retrieval tools | [w1_retrieval_tools.md](w1_retrieval_tools.md) | `feature/agent-w1-retrieval-tools` | W0a | ✅ Merged ([#65](https://github.com/deshmukh-neel/mlops_city_concierge/pull/65)) — price_level enum hotfix in [#66](https://github.com/deshmukh-neel/mlops_city_concierge/pull/66) |
 | W2  | Agent loop + ItineraryState + `/chat` endpoint | [w2_agent_graph.md](w2_agent_graph.md) | `feature/agent-w2-agent-graph` | W1 (and ideally W0 for tracing) | 🚧 Not started |
 | W3  | Self-correction (within W2's graph) | [w3_self_correction.md](w3_self_correction.md) | `feature/agent-w3-self-correction` | W2 | 🚧 Not started |
 | W4  | Booking handoff stub (`propose_booking`) | [w4_booking_stub.md](w4_booking_stub.md) | `feature/agent-w4-booking-stub` | W2 | 🚧 Not started |

--- a/implementation_plan/james/w1_retrieval_tools.md
+++ b/implementation_plan/james/w1_retrieval_tools.md
@@ -776,3 +776,15 @@ Expected: 5 results in/near North Beach, all `rating >= 4.3`, all `price_level <
 - **Boolean amenity columns are computed in the view, not stored.** Each query re-evaluates the COALESCE casts. With ~5,800 rows this is fine. If we ever materialize the view or generate columns on `places_raw`, the cast logic moves with no other change.
 - **Two views (v1 + v2) double the migration surface.** Acceptable while we A/B v1 vs v2 in W6 evals. As soon as v2 wins, drop `place_documents` (v1) and rename `place_documents_v2` to `place_documents` in a small follow-up PR.
 - **Connection pooling.** `get_conn()` should use whatever pooling the app already does. If the existing retriever opens fresh connections per call, leave that alone in this PR; revisit pool config separately.
+
+---
+
+**Status:** ✅ Merged via [#65](https://github.com/deshmukh-neel/mlops_city_concierge/pull/65) on 2026-05-06. Followed by hotfix [#66](https://github.com/deshmukh-neel/mlops_city_concierge/pull/66) (`price_level` is a Google v1 enum string, not int — adds `price_level_rank()` migration and a `scripts/smoke_w1.py` end-to-end harness).
+
+Deferred / pending:
+
+- Pool integration. `get_conn()` opens fresh connections; PR #56 will swap the body to borrow from the shared pool with no caller change.
+- Editorial table `UNION ALL`. View definition gets a follow-up edit when the editorial schema lands; tools don't change.
+- HNSW recall over-fetch lever (`_OVERFETCH_FACTOR`) ships at `1`. Bump if W6 evals show recall regressing on tightly-filtered queries.
+- v1 retirement. Drop `place_documents` and rename `place_documents_v2 → place_documents` once W6 confirms v2 wins.
+- Multi-city. `place_is_open()` hardcodes `America/Los_Angeles`; expand to a `tz TEXT` argument when the app moves beyond SF.


### PR DESCRIPTION
## Summary

Per CLAUDE.md's Implementation plan tracking rule:
- Update `implementation_plan/james/README.md` status row for W1 (✅ Merged with PR links).
- Add a `**Status:**` footer at the bottom of `w1_retrieval_tools.md` linking PR #65 + the hotfix #66, with a list of what's still deferred (pool integration, editorial UNION, over-fetch lever, v1 retirement, multi-city tz).

No code changes.

## Test plan

- [x] Markdown renders as expected
- No CI impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)