### PR TITLE
fix(db_pool): two latent bugs found while reviewing PR #56 merge

### DIFF
--- a/app/db_pool.py
+++ b/app/db_pool.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 from threading import Lock
 
 from psycopg2.extensions import connection
 from psycopg2.pool import ThreadedConnectionPool
 
 from .config import get_settings
+
+logger = logging.getLogger(__name__)
 
 _pool: ThreadedConnectionPool | None = None
 _pool_config: tuple[str, int, int] | None = None
@@ -55,10 +58,23 @@ def get_connection() -> connection:
 
 
 def return_connection(conn: connection, *, close: bool = False) -> None:
-    """Return a borrowed connection to the shared pool."""
+    """Return a borrowed connection to the shared pool.
+
+    If the pool has already been closed (e.g. lifespan shutdown ran while a
+    request was in flight), close the connection directly. The bare close()
+    can still raise if psycopg2 already disposed of the underlying socket; we
+    swallow that — the connection is gone either way and the caller doesn't
+    benefit from a noisy traceback in shutdown logs.
+    """
     pool = _pool
     if pool is None:
-        conn.close()
+        try:
+            conn.close()
+        except Exception:
+            logger.debug(
+                "return_connection: pool already closed and conn.close() raised; ignoring.",
+                exc_info=True,
+            )
         return
 
     pool.putconn(conn, close=close)

--- a/app/db_pool.py
+++ b/app/db_pool.py
@@ -8,6 +8,7 @@ from psycopg2.pool import ThreadedConnectionPool
 from .config import get_settings
 
 _pool: ThreadedConnectionPool | None = None
+_pool_config: tuple[str, int, int] | None = None
 _pool_lock = Lock()
 
 
@@ -16,7 +17,12 @@ def init_db_pool(
     min_connections: int,
     max_connections: int,
 ) -> ThreadedConnectionPool:
-    """Create the process-local DB pool if it does not already exist."""
+    """Create the process-local DB pool if it does not already exist.
+
+    Raises if called a second time with a different (url, min, max) — silently
+    keeping the original pool would mean later callers think they're connected
+    to one database while actually borrowing from another.
+    """
     if min_connections < 0:
         raise ValueError("db_pool_min_connections must be greater than or equal to 0.")
     if max_connections < 1:
@@ -24,14 +30,22 @@ def init_db_pool(
     if min_connections > max_connections:
         raise ValueError("db_pool_min_connections cannot exceed db_pool_max_connections.")
 
-    global _pool
+    global _pool, _pool_config
     with _pool_lock:
-        if _pool is None:
-            _pool = ThreadedConnectionPool(
-                min_connections,
-                max_connections,
-                dsn=database_url,
-            )
+        requested = (database_url, min_connections, max_connections)
+        if _pool is not None:
+            if _pool_config != requested:
+                raise RuntimeError(
+                    "init_db_pool was called with different parameters than the "
+                    "existing pool. Call close_db_pool() before re-initialising."
+                )
+            return _pool
+        _pool = ThreadedConnectionPool(
+            min_connections,
+            max_connections,
+            dsn=database_url,
+        )
+        _pool_config = requested
         return _pool
 
 
@@ -52,11 +66,12 @@ def return_connection(conn: connection, *, close: bool = False) -> None:
 
 def close_db_pool() -> None:
     """Close every connection owned by the process-local pool."""
-    global _pool
+    global _pool, _pool_config
     with _pool_lock:
         if _pool is not None:
             _pool.closeall()
             _pool = None
+            _pool_config = None
 
 
 def _ensure_db_pool() -> ThreadedConnectionPool:

--- a/tests/unit/test_db_pool.py
+++ b/tests/unit/test_db_pool.py
@@ -110,6 +110,22 @@ def test_return_connection_closes_when_pool_is_missing(mocker) -> None:
     conn.close.assert_called_once_with()
 
 
+def test_return_connection_swallows_close_error_after_pool_shutdown(mocker) -> None:
+    """If the pool is closed mid-flight (lifespan shutdown), conn.close() can
+    raise on a connection psycopg2 has already disposed. Don't propagate that
+    — the connection is gone either way."""
+    import psycopg2  # noqa: PLC0415 — local import keeps the test self-contained
+
+    conn = mocker.Mock()
+    conn.close.side_effect = psycopg2.InterfaceError("connection already closed")
+    logger = mocker.patch("app.db_pool.logger")
+
+    return_connection(conn)  # must not raise
+
+    conn.close.assert_called_once_with()
+    logger.debug.assert_called_once()
+
+
 def test_close_db_pool_closes_all_connections(mocker) -> None:
     pool = mocker.Mock()
     mocker.patch("app.db_pool.ThreadedConnectionPool", return_value=pool)

--- a/tests/unit/test_db_pool.py
+++ b/tests/unit/test_db_pool.py
@@ -36,15 +36,25 @@ def test_init_db_pool_creates_threaded_pool(mocker) -> None:
     )
 
 
-def test_init_db_pool_reuses_existing_pool(mocker) -> None:
+def test_init_db_pool_reuses_existing_pool_when_params_match(mocker) -> None:
     pool = mocker.Mock()
     pool_cls = mocker.patch("app.db_pool.ThreadedConnectionPool", return_value=pool)
 
     first = init_db_pool("postgresql://example", 0, 10)
-    second = init_db_pool("postgresql://different", 0, 5)
+    second = init_db_pool("postgresql://example", 0, 10)
 
     assert first is second
     pool_cls.assert_called_once()
+
+
+def test_init_db_pool_raises_when_params_differ(mocker) -> None:
+    """A second init with different params would silently swap the database
+    underneath in-flight callers — refuse instead."""
+    mocker.patch("app.db_pool.ThreadedConnectionPool", return_value=mocker.Mock())
+
+    init_db_pool("postgresql://example", 0, 10)
+    with pytest.raises(RuntimeError, match="different parameters"):
+        init_db_pool("postgresql://different", 0, 5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

While reviewing the PR #56 merge into main (per the W1-pool-coordination question), I caught two latent bugs in `app/db_pool.py`. Both have low blast radius today but would cause real production incidents under predictable conditions.

## Bug #1 — `init_db_pool` silently accepts a different URL on the second call

```python
first  = init_db_pool("postgresql://example",   0, 10)
second = init_db_pool("postgresql://different", 0,  5)
assert first is second  # was: passed silently. now: RuntimeError.
```

If two callers ever disagree on which DB to point at, the second one silently keeps the first pool. Anyone reading the test suite would have thought this was by design — `tests/unit/test_db_pool.py:test_init_db_pool_reuses_existing_pool` asserted exactly this behavior.

**Fix:** track the `(url, min, max)` tuple alongside the pool. On re-call with mismatched params, raise `RuntimeError` instead of silently reusing.

**Test change:** `test_init_db_pool_reuses_existing_pool` renamed to `..._when_params_match` and updated to use identical params; new `test_init_db_pool_raises_when_params_differ` covers the mismatch case.

## Bug #4 — `return_connection()` can raise InterfaceError on shutdown

If `close_db_pool()` runs while a request is in flight (Cloud Run lifespan shutdown), the in-flight handler eventually calls `return_connection(conn)`, the helper sees `_pool is None`, and calls `conn.close()` on a connection whose underlying socket psycopg2 already disposed. That raises `psycopg2.InterfaceError` — not a correctness bug, but a noisy traceback in shutdown logs on every deploy.

**Fix:** wrap the bare `conn.close()` in a try/except, log at DEBUG (not WARNING — connection is gone either way and the pool's contract is already satisfied).

**New test:** `test_return_connection_swallows_close_error_after_pool_shutdown`.

## What I deliberately didn't fix

Three additional concerns I noted in the review, all flagged as not-bugs:

- `_ensure_db_pool` reads `_pool` outside the lock. Safe given current call sites; the unlocked read pattern is a smell but not a correctness problem.
- `db_pool_min_connections=0` default. Minor latency concern for Cloud Run; config choice, not a code bug.
- No real-DB integration test for the pool. All pool tests are mocked. Worth a follow-up but not load-bearing right now.

## Verified

- ✅ `pytest tests/unit/` — 120 passed (was 118; +2 new tests)
- ✅ `mypy app/` clean
- ✅ `ruff check .` clean
- ✅ `scripts/smoke_w1.py` against prod (Cloud SQL proxy) — all 5 scenarios pass through the fixed pool

## On "do we need to add these tests to CI?"

`.github/workflows/ci.yml:97` already runs `pytest tests/unit/` on every push and PR. The two new tests live in `tests/unit/test_db_pool.py` — automatically picked up. No workflow change needed; the test count will simply tick up on the next CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)