### PR TITLE
feat(agent): W2 agent graph + 16-issue review fixes

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Agentic core: state, tools registration, graph, and prompt."""

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -21,8 +21,60 @@ from langgraph.graph import END, StateGraph
 from pydantic import BaseModel
 
 from app.agent.prompts import SYSTEM_PROMPT
-from app.agent.state import ItineraryState, PlaceCard
-from app.agent.tools import all_tools
+from app.agent.state import ItineraryState, PlaceCard, Stop
+from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
+
+
+def _grounded_place_ids(scratch: dict[str, Any]) -> set[str]:
+    """All place_ids the agent has actually seen via prior tool results."""
+    grounded: set[str] = set()
+    for entries in scratch.values():
+        for entry in entries:
+            result = entry.get("result")
+            if isinstance(result, list):
+                for hit in result:
+                    pid = getattr(hit, "place_id", None) or (
+                        hit.get("place_id") if isinstance(hit, dict) else None
+                    )
+                    if pid:
+                        grounded.add(pid)
+            elif result is not None:
+                pid = getattr(result, "place_id", None) or (
+                    result.get("place_id") if isinstance(result, dict) else None
+                )
+                if pid:
+                    grounded.add(pid)
+    return grounded
+
+
+def _commit_stops(state: ItineraryState, raw_stops: Any) -> tuple[list[Stop], dict[str, Any]]:
+    """Validate and coerce LLM-supplied stops into Stop models.
+
+    Returns (committed_stops, tool_result_payload). The payload is what the
+    LLM sees back as the tool result; rejected place_ids surface there so the
+    model can self-correct in W3.
+    """
+    if not isinstance(raw_stops, list):
+        return [], {"error": "stops must be a list"}
+    grounded = _grounded_place_ids(state.scratch)
+    committed: list[Stop] = []
+    rejected: list[dict[str, Any]] = []
+    for raw in raw_stops:
+        if not isinstance(raw, dict):
+            rejected.append({"reason": "stop must be an object", "value": str(raw)})
+            continue
+        pid = raw.get("place_id")
+        if not pid or pid not in grounded:
+            rejected.append({"place_id": pid, "reason": "place_id not seen via prior tool result"})
+            continue
+        try:
+            committed.append(Stop(**raw))
+        except Exception as e:  # noqa: BLE001
+            rejected.append({"place_id": pid, "reason": f"invalid stop: {e}"})
+    return committed, {
+        "committed": [s.place_id for s in committed],
+        "rejected": rejected,
+    }
 
 
 def _serialize_tool_result(result: Any) -> str:
@@ -67,7 +119,20 @@ def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
 
         new_messages: list[BaseMessage] = []
         scratch_updates: dict[str, list[dict[str, Any]]] = {}
+        committed_stops: list[Stop] | None = None
+
         for tc in ai.tool_calls:
+            if tc["name"] == COMMIT_ITINERARY_TOOL_NAME:
+                stops, payload = _commit_stops(state, tc["args"].get("stops"))
+                committed_stops = stops
+                new_messages.append(
+                    ToolMessage(content=_serialize_tool_result(payload), tool_call_id=tc["id"])
+                )
+                scratch_updates.setdefault(tc["name"], []).append(
+                    {"args": tc["args"], "result": payload, "step": state.step_count}
+                )
+                continue
+
             tool = tool_by_name.get(tc["name"])
             if tool is None:
                 new_messages.append(
@@ -92,11 +157,14 @@ def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
         for name, entries in scratch_updates.items():
             merged_scratch[name] = [*merged_scratch.get(name, []), *entries]
 
-        return {
+        update: dict[str, Any] = {
             "messages": new_messages,
             "scratch": merged_scratch,
             "step_count": state.step_count + 1,
         }
+        if committed_stops is not None:
+            update["stops"] = committed_stops
+        return update
 
     def critique(state: ItineraryState) -> dict[str, Any]:
         # W3 fills this in. For W2, do the bare minimum: check loop bound and

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -1,0 +1,119 @@
+"""LangGraph StateGraph for the agent. Three nodes: plan, act, critique.
+
+plan      LLM proposes the next action: a tool call or `final`.
+act       Executes the tool. Tool result -> state.scratch[<tool>][<step>].
+critique  Deterministic + LLM check; can request `revise` (W3 expands this).
+
+Edge logic:
+  plan -> act (if tool call) | END (if final)
+  act  -> critique
+  critique -> plan (if revise or more work) | END (if good)
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+from langgraph.graph import END, StateGraph
+
+from app.agent.prompts import SYSTEM_PROMPT
+from app.agent.state import ItineraryState, PlaceCard
+from app.agent.tools import all_tools
+
+
+def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
+    tools = all_tools()
+    llm_with_tools = llm.bind_tools(tools)
+    tool_by_name = {t.name: t for t in tools}
+
+    def plan(state: ItineraryState) -> ItineraryState:
+        if state.step_count == 0 and not any(isinstance(m, SystemMessage) for m in state.messages):
+            state.messages.insert(0, SystemMessage(SYSTEM_PROMPT.format(max_steps=max_steps)))
+        ai = llm_with_tools.invoke(state.messages)
+        state.messages.append(ai)
+        return state
+
+    def act(state: ItineraryState) -> ItineraryState:
+        ai = state.messages[-1]
+        if not isinstance(ai, AIMessage) or not ai.tool_calls:
+            return state
+        for tc in ai.tool_calls:
+            tool = tool_by_name.get(tc["name"])
+            if tool is None:
+                state.messages.append(
+                    ToolMessage(
+                        content=f"unknown tool {tc['name']}",
+                        tool_call_id=tc["id"],
+                    )
+                )
+                continue
+            try:
+                result = tool.invoke(tc["args"])
+            except Exception as e:  # noqa: BLE001
+                result = {"error": str(e)}
+            state.messages.append(ToolMessage(content=str(result), tool_call_id=tc["id"]))
+            state.scratch.setdefault(tc["name"], []).append(
+                {
+                    "args": tc["args"],
+                    "result": result,
+                    "step": state.step_count,
+                }
+            )
+        state.step_count += 1
+        return state
+
+    def critique(state: ItineraryState) -> ItineraryState:
+        # W3 fills this in. For W2, do the bare minimum: check loop bound and
+        # whether the last AI message ended without a tool call.
+        last = state.messages[-1] if state.messages else None
+        if isinstance(last, AIMessage) and not last.tool_calls:
+            state.done = True
+            state.final_reply = state.final_reply or (
+                last.content if isinstance(last.content, str) else str(last.content)
+            )
+        if state.step_count >= max_steps and not state.done:
+            state.done = True
+            if not state.final_reply:
+                state.final_reply = (
+                    "I hit the planning step limit. Here is the best plan I had so far."
+                )
+        return state
+
+    def route_after_plan(state: ItineraryState) -> Literal["act", "critique"]:
+        last = state.messages[-1]
+        return "act" if isinstance(last, AIMessage) and last.tool_calls else "critique"
+
+    def route_after_critique(state: ItineraryState) -> str:
+        return END if state.done else "plan"
+
+    g = StateGraph(ItineraryState)
+    g.add_node("plan", plan)
+    g.add_node("act", act)
+    g.add_node("critique", critique)
+    g.set_entry_point("plan")
+    g.add_conditional_edges("plan", route_after_plan, {"act": "act", "critique": "critique"})
+    g.add_edge("act", "critique")
+    g.add_conditional_edges("critique", route_after_critique, {"plan": "plan", END: END})
+    return g.compile()
+
+
+def state_to_response(state: ItineraryState, rag_label: str) -> dict:
+    """Convert ItineraryState into the {reply, places, ragLabel} contract that
+    frontend/src/api/chat.js expects."""
+    cards = [
+        PlaceCard(
+            place_id=s.place_id,
+            name=s.name,
+            primary_type=s.primary_type,
+            arrival_time=s.arrival_time,
+            rationale=s.rationale,
+        ).model_dump(mode="json")
+        for s in state.stops
+    ]
+    return {
+        "reply": state.final_reply or "",
+        "places": cards,
+        "ragLabel": rag_label,
+    }

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -12,6 +12,7 @@ Edge logic:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any, Literal
 
@@ -77,6 +78,52 @@ def _commit_stops(state: ItineraryState, raw_stops: Any) -> tuple[list[Stop], di
     }
 
 
+_RECENT_TOOL_EXCHANGES_KEPT = 2
+
+
+def _prune_for_llm(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """Curate the message list sent to the LLM to keep token cost bounded.
+
+    Strategy: keep all SystemMessages and HumanMessages, plus the AIMessages.
+    For ToolMessages — which dominate token cost as the agent loops — keep
+    only those paired with the last `_RECENT_TOOL_EXCHANGES_KEPT` AIMessages
+    that issued tool_calls. Earlier tool results are dropped together with
+    their issuing AIMessage's tool_calls, so the LLM never sees an unanswered
+    tool_call (which would violate the OpenAI/Gemini conversation contract).
+    """
+    if not messages:
+        return messages
+
+    # Find indices of AIMessages that issued tool_calls.
+    tool_caller_indices = [
+        i for i, m in enumerate(messages) if isinstance(m, AIMessage) and m.tool_calls
+    ]
+    if len(tool_caller_indices) <= _RECENT_TOOL_EXCHANGES_KEPT:
+        return messages
+
+    # Cutoff: keep messages from this index onward in their original form.
+    keep_from = tool_caller_indices[-_RECENT_TOOL_EXCHANGES_KEPT]
+
+    # Before the cutoff: drop tool_calls from AIMessages and drop ToolMessages
+    # entirely. After: keep as-is.
+    pruned: list[BaseMessage] = []
+    for i, m in enumerate(messages):
+        if i >= keep_from:
+            pruned.append(m)
+            continue
+        if isinstance(m, ToolMessage):
+            continue
+        if isinstance(m, AIMessage) and m.tool_calls:
+            # Replace with a content-only AIMessage so we don't strand the
+            # LLM thinking it issued tool_calls that were never answered.
+            pruned.append(
+                AIMessage(content=m.content if isinstance(m.content, str) else str(m.content))
+            )
+            continue
+        pruned.append(m)
+    return pruned
+
+
 def _serialize_tool_result(result: Any) -> str:
     """Emit JSON the LLM can parse, regardless of underlying tool return type.
 
@@ -96,23 +143,25 @@ def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
     llm_with_tools = llm.bind_tools(tools)
     tool_by_name = {t.name: t for t in tools}
 
-    def plan(state: ItineraryState) -> dict[str, Any]:
+    async def plan(state: ItineraryState) -> dict[str, Any]:
         messages_in: list[BaseMessage] = list(state.messages)
         if state.step_count == 0 and not any(isinstance(m, SystemMessage) for m in messages_in):
             messages_in = [
                 SystemMessage(SYSTEM_PROMPT.format(max_steps=max_steps)),
                 *messages_in,
             ]
-        ai = llm_with_tools.invoke(messages_in)
-        # If we prepended a SystemMessage, surface it through the reducer too so
-        # downstream nodes see a consistent history.
+        # Send the LLM a curated view: keep only the most recent ToolMessage
+        # per tool name so token cost stays linear in tool *kinds*, not in
+        # tool *calls*. Full history is preserved on state.messages for tracing.
+        messages_for_llm = _prune_for_llm(messages_in)
+        ai = await llm_with_tools.ainvoke(messages_for_llm)
         new_messages: list[BaseMessage] = []
         if len(messages_in) > len(state.messages):
             new_messages.append(messages_in[0])
         new_messages.append(ai)
         return {"messages": new_messages}
 
-    def act(state: ItineraryState) -> dict[str, Any]:
+    async def act(state: ItineraryState) -> dict[str, Any]:
         ai = state.messages[-1]
         if not isinstance(ai, AIMessage) or not ai.tool_calls:
             return {}
@@ -143,7 +192,9 @@ def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
                 )
                 continue
             try:
-                result: Any = tool.invoke(tc["args"])
+                # psycopg2 + OpenAI are sync; offload to a worker thread so the
+                # event loop stays responsive while the tool blocks on I/O.
+                result: Any = await asyncio.to_thread(tool.invoke, tc["args"])
             except Exception as e:  # noqa: BLE001
                 result = {"error": str(e)}
             new_messages.append(

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -21,7 +21,7 @@ from langgraph.graph import END, StateGraph
 from pydantic import BaseModel
 
 from app.agent.prompts import SYSTEM_PROMPT
-from app.agent.state import ItineraryState, PlaceCard, Stop
+from app.agent.state import ItineraryState, Stop
 from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
 
 
@@ -200,23 +200,3 @@ def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
     g.add_edge("act", "critique")
     g.add_conditional_edges("critique", route_after_critique, {"plan": "plan", END: END})
     return g.compile()
-
-
-def state_to_response(state: ItineraryState, rag_label: str) -> dict:
-    """Convert ItineraryState into the {reply, places, ragLabel} contract that
-    frontend/src/api/chat.js expects."""
-    cards = [
-        PlaceCard(
-            place_id=s.place_id,
-            name=s.name,
-            primary_type=s.primary_type,
-            arrival_time=s.arrival_time,
-            rationale=s.rationale,
-        ).model_dump(mode="json")
-        for s in state.stops
-    ]
-    return {
-        "reply": state.final_reply or "",
-        "places": cards,
-        "ragLabel": rag_label,
-    }

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -12,15 +12,31 @@ Edge logic:
 
 from __future__ import annotations
 
-from typing import Literal
+import json
+from typing import Any, Literal
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, StateGraph
+from pydantic import BaseModel
 
 from app.agent.prompts import SYSTEM_PROMPT
 from app.agent.state import ItineraryState, PlaceCard
 from app.agent.tools import all_tools
+
+
+def _serialize_tool_result(result: Any) -> str:
+    """Emit JSON the LLM can parse, regardless of underlying tool return type.
+
+    Pydantic models -> model_dump(mode='json'). Lists of pydantic models too.
+    Dicts/primitives pass through json.dumps with default=str so non-JSON
+    types like datetime degrade gracefully.
+    """
+    if isinstance(result, BaseModel):
+        return json.dumps(result.model_dump(mode="json"))
+    if isinstance(result, list) and result and isinstance(result[0], BaseModel):
+        return json.dumps([m.model_dump(mode="json") for m in result])
+    return json.dumps(result, default=str)
 
 
 def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
@@ -28,21 +44,33 @@ def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
     llm_with_tools = llm.bind_tools(tools)
     tool_by_name = {t.name: t for t in tools}
 
-    def plan(state: ItineraryState) -> ItineraryState:
-        if state.step_count == 0 and not any(isinstance(m, SystemMessage) for m in state.messages):
-            state.messages.insert(0, SystemMessage(SYSTEM_PROMPT.format(max_steps=max_steps)))
-        ai = llm_with_tools.invoke(state.messages)
-        state.messages.append(ai)
-        return state
+    def plan(state: ItineraryState) -> dict[str, Any]:
+        messages_in: list[BaseMessage] = list(state.messages)
+        if state.step_count == 0 and not any(isinstance(m, SystemMessage) for m in messages_in):
+            messages_in = [
+                SystemMessage(SYSTEM_PROMPT.format(max_steps=max_steps)),
+                *messages_in,
+            ]
+        ai = llm_with_tools.invoke(messages_in)
+        # If we prepended a SystemMessage, surface it through the reducer too so
+        # downstream nodes see a consistent history.
+        new_messages: list[BaseMessage] = []
+        if len(messages_in) > len(state.messages):
+            new_messages.append(messages_in[0])
+        new_messages.append(ai)
+        return {"messages": new_messages}
 
-    def act(state: ItineraryState) -> ItineraryState:
+    def act(state: ItineraryState) -> dict[str, Any]:
         ai = state.messages[-1]
         if not isinstance(ai, AIMessage) or not ai.tool_calls:
-            return state
+            return {}
+
+        new_messages: list[BaseMessage] = []
+        scratch_updates: dict[str, list[dict[str, Any]]] = {}
         for tc in ai.tool_calls:
             tool = tool_by_name.get(tc["name"])
             if tool is None:
-                state.messages.append(
+                new_messages.append(
                     ToolMessage(
                         content=f"unknown tool {tc['name']}",
                         tool_call_id=tc["id"],
@@ -50,36 +78,43 @@ def build_agent_graph(llm: BaseChatModel, max_steps: int = 8):
                 )
                 continue
             try:
-                result = tool.invoke(tc["args"])
+                result: Any = tool.invoke(tc["args"])
             except Exception as e:  # noqa: BLE001
                 result = {"error": str(e)}
-            state.messages.append(ToolMessage(content=str(result), tool_call_id=tc["id"]))
-            state.scratch.setdefault(tc["name"], []).append(
-                {
-                    "args": tc["args"],
-                    "result": result,
-                    "step": state.step_count,
-                }
+            new_messages.append(
+                ToolMessage(content=_serialize_tool_result(result), tool_call_id=tc["id"])
             )
-        state.step_count += 1
-        return state
+            scratch_updates.setdefault(tc["name"], []).append(
+                {"args": tc["args"], "result": result, "step": state.step_count}
+            )
 
-    def critique(state: ItineraryState) -> ItineraryState:
+        merged_scratch = dict(state.scratch)
+        for name, entries in scratch_updates.items():
+            merged_scratch[name] = [*merged_scratch.get(name, []), *entries]
+
+        return {
+            "messages": new_messages,
+            "scratch": merged_scratch,
+            "step_count": state.step_count + 1,
+        }
+
+    def critique(state: ItineraryState) -> dict[str, Any]:
         # W3 fills this in. For W2, do the bare minimum: check loop bound and
         # whether the last AI message ended without a tool call.
         last = state.messages[-1] if state.messages else None
+        update: dict[str, Any] = {}
         if isinstance(last, AIMessage) and not last.tool_calls:
-            state.done = True
-            state.final_reply = state.final_reply or (
+            update["done"] = True
+            update["final_reply"] = state.final_reply or (
                 last.content if isinstance(last.content, str) else str(last.content)
             )
-        if state.step_count >= max_steps and not state.done:
-            state.done = True
-            if not state.final_reply:
-                state.final_reply = (
+        if state.step_count >= max_steps and not (state.done or update.get("done")):
+            update["done"] = True
+            if not state.final_reply and not update.get("final_reply"):
+                update["final_reply"] = (
                     "I hit the planning step limit. Here is the best plan I had so far."
                 )
-        return state
+        return update
 
     def route_after_plan(state: ItineraryState) -> Literal["act", "critique"]:
         last = state.messages[-1]

--- a/app/agent/io.py
+++ b/app/agent/io.py
@@ -9,6 +9,7 @@ stay in app.main and are stamped onto the response there.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any, Protocol
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -17,11 +18,13 @@ from app.agent.state import ItineraryState, PlaceCard
 
 
 class _RoleAndContent(Protocol):
-    role: str
-    content: str
+    @property
+    def role(self) -> str: ...
+    @property
+    def content(self) -> str: ...
 
 
-def messages_from_history(history: list[_RoleAndContent]) -> list[BaseMessage]:
+def messages_from_history(history: Iterable[_RoleAndContent]) -> list[BaseMessage]:
     """Map ChatMessage role/content pairs onto LangChain BaseMessages."""
     out: list[BaseMessage] = []
     for m in history:

--- a/app/agent/io.py
+++ b/app/agent/io.py
@@ -1,0 +1,46 @@
+"""Conversion between the agent's internal types and the wire contract.
+
+Inbound: ChatMessage (HTTP) -> list[BaseMessage] for the graph.
+Outbound: ItineraryState.stops -> list[PlaceCard] dicts for the frontend.
+
+The agent module owns the agent shapes; HTTP-layer concerns like rag_label
+stay in app.main and are stamped onto the response there.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+from app.agent.state import ItineraryState, PlaceCard
+
+
+class _RoleAndContent(Protocol):
+    role: str
+    content: str
+
+
+def messages_from_history(history: list[_RoleAndContent]) -> list[BaseMessage]:
+    """Map ChatMessage role/content pairs onto LangChain BaseMessages."""
+    out: list[BaseMessage] = []
+    for m in history:
+        if m.role == "user":
+            out.append(HumanMessage(content=m.content))
+        else:
+            out.append(AIMessage(content=m.content))
+    return out
+
+
+def state_to_cards(state: ItineraryState) -> list[dict[str, Any]]:
+    """Project committed stops into the PlaceCard shape the frontend renders."""
+    return [
+        PlaceCard(
+            place_id=s.place_id,
+            name=s.name,
+            primary_type=s.primary_type,
+            arrival_time=s.arrival_time,
+            rationale=s.rationale,
+        ).model_dump(mode="json")
+        for s in state.stops
+    ]

--- a/app/agent/planning.py
+++ b/app/agent/planning.py
@@ -1,0 +1,60 @@
+"""Pure helpers for itinerary planning math. No LLM, no DB."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from math import asin, cos, radians, sin, sqrt
+
+from app.agent.state import Stop
+
+WALKING_SPEED_M_PER_MIN = 80.0  # ~3 mph, casual pace
+
+
+def haversine_m(a: tuple[float, float], b: tuple[float, float]) -> float:
+    lat1, lon1 = map(radians, a)
+    lat2, lon2 = map(radians, b)
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    h = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    return 6371000 * 2 * asin(sqrt(h))
+
+
+def walking_time_min(a_lat: float, a_lng: float, b_lat: float, b_lng: float) -> float:
+    return haversine_m((a_lat, a_lng), (b_lat, b_lng)) / WALKING_SPEED_M_PER_MIN
+
+
+def next_arrival_time(prev_stop: Stop, next_lat: float, next_lng: float) -> datetime:
+    if prev_stop.arrival_time is None:
+        raise ValueError("prev_stop.arrival_time must be set before chaining")
+    if prev_stop.latitude is None or prev_stop.longitude is None:
+        raise ValueError("prev_stop coordinates must be set before chaining")
+    walk = walking_time_min(prev_stop.latitude, prev_stop.longitude, next_lat, next_lng)
+    return prev_stop.arrival_time + timedelta(minutes=prev_stop.planned_duration_min + walk)
+
+
+def remaining_walking_budget_m(state) -> float:
+    """How many meters of walking are left in the user's budget."""
+    return max(0.0, state.constraints.walking_budget_m - state.walked_meters_so_far)
+
+
+def suggested_radius_m(state, remaining_stops: int) -> int:
+    """Per-stop radius suggestion given how much walking budget is left."""
+    if remaining_stops <= 0:
+        return 0
+    budget = remaining_walking_budget_m(state)
+    return int(min(1500, max(300, budget / max(remaining_stops, 1))))
+
+
+def parse_stops_count(user_text: str, default: int = 3) -> int:
+    """Parse '2', 'just dinner', 'dinner + drinks', '3 spots' -> integer."""
+    text = user_text.lower().strip()
+    if "just dinner" in text or "only dinner" in text:
+        return 1
+    if "dinner and drinks" in text or "dinner + drinks" in text or "dinner then drinks" in text:
+        return 2
+    for token in text.split():
+        if token.isdigit():
+            n = int(token)
+            if 1 <= n <= 5:
+                return n
+    return default

--- a/app/agent/planning.py
+++ b/app/agent/planning.py
@@ -43,18 +43,3 @@ def suggested_radius_m(state, remaining_stops: int) -> int:
         return 0
     budget = remaining_walking_budget_m(state)
     return int(min(1500, max(300, budget / max(remaining_stops, 1))))
-
-
-def parse_stops_count(user_text: str, default: int = 3) -> int:
-    """Parse '2', 'just dinner', 'dinner + drinks', '3 spots' -> integer."""
-    text = user_text.lower().strip()
-    if "just dinner" in text or "only dinner" in text:
-        return 1
-    if "dinner and drinks" in text or "dinner + drinks" in text or "dinner then drinks" in text:
-        return 2
-    for token in text.split():
-        if token.isdigit():
-            n = int(token)
-            if 1 <= n <= 5:
-                return n
-    return default

--- a/app/agent/prompts.py
+++ b/app/agent/prompts.py
@@ -1,0 +1,74 @@
+SYSTEM_PROMPT = """You are City Concierge, an AI agent that plans dining and
+nightlife itineraries grounded in a structured database of real places.
+
+You have tools for retrieval; do not invent places, addresses, or hours. Every
+recommendation must come from a tool call.
+
+CRITICAL BEHAVIORS:
+
+1. PARSE constraints from the user message into structured filters before
+   searching. Time of day -> `open_at`. "Affordable" / "fancy" -> `price_level_max`.
+   "Walking distance" -> use the `nearby` tool, not text matching.
+
+2. PREFER structured filters over keyword stuffing. Don't search for
+   "italian under $$$ in north beach"; instead call:
+       semantic_search(query="romantic italian dinner",
+                       filters={{price_level_max: 3, neighborhood: "North Beach",
+                                open_at: <stop's arrival time>}})
+
+3. ITINERARY SHAPE - number of stops:
+   - If the user explicitly says "2 stops" / "dinner then drinks" / "3 spots",
+     respect it.
+   - If ambiguous ("plan me a date", "evening in the mission"), ASK the user
+     how many stops they want. Use a single short clarifying question and set
+     `awaiting_stops_count=True` in your response. Do not plan stops yet.
+   - If the user pushes back ("you decide"), default to 3 stops.
+
+4. PLAN MULTI-STOP itineraries as anchored search:
+   - Stop 1 = `semantic_search(...)` with shared constraints +
+     `open_at = constraints.when`.
+   - Stop K (K > 1) = `nearby(stop_{{K-1}}.place_id, radius_m, ...)` with shared
+     constraints + `open_at = arrival_K`, where
+        arrival_K = arrival_{{K-1}} + planned_duration_{{K-1}} + walking_time(K-1->K)
+        walking_time(a->b) = haversine_meters(a, b) / 80   # m/min
+   - SHARED constraints (price_level_max, min_rating, min_user_rating_count,
+     overall vibes) carry across every stop. Don't relax them per stop unless
+     the user says so or self-correction (W3) requires it.
+   - Use a default per-stop duration based on `primary_type`. The planning code
+     fills these in from DEFAULT_STOP_DURATION_MIN; surface them in your reply
+     so the user can override.
+
+5. WALKING BUDGET:
+   - Total walking across all stops should fit `constraints.walking_budget_m`
+     (default 2400m ~= 30 min). For each stop after the first, prefer
+     `radius_m` <= remaining budget / (remaining stops).
+   - You may use `kg_traverse(stop_K, relation_type='NEAR')` after W7 ships as
+     a cheaper substitute for `nearby` when you only need geographic neighbors.
+
+6. JUSTIFY every stop in 1-2 sentences referencing concrete attributes
+   (rating, price level, vibe from editorial_summary if present).
+
+7. If a tool returns empty or low-quality results, REVISE: drop the most
+   restrictive filter, expand the radius, or ask the user a clarifying
+   question. Do NOT pretend you found something you didn't. (Self-correction
+   logic in W3.)
+
+8. STOP after at most {max_steps} tool calls. If you don't have a confident
+   answer by then, return what you have with an explicit caveat.
+
+OUTPUT FORMAT (when finalizing):
+- Set `done=True` and `final_reply` to a 2-4 sentence summary the user reads.
+- Mention the planned arrival + duration for each stop ("Dinner at 7:00,
+  ~90 min") so the user can override if they want.
+- The structured `stops` list is rendered as cards in the UI; the user sees
+  both your prose and the cards.
+
+You are the reasoning model. Use your judgement. Tools are for grounding,
+not for thinking on your behalf.
+"""
+
+
+CLARIFYING_STOPS_COUNT_TEMPLATE = (
+    "How many stops would you like me to plan? (e.g. 'just dinner', "
+    "'dinner + drinks', or '3 spots'). I default to 3 if you'd rather I pick."
+)

--- a/app/agent/prompts.py
+++ b/app/agent/prompts.py
@@ -57,9 +57,14 @@ CRITICAL BEHAVIORS:
    answer by then, return what you have with an explicit caveat.
 
 OUTPUT FORMAT (when finalizing):
-- Set `done=True` and `final_reply` to a 2-4 sentence summary the user reads.
-- Mention the planned arrival + duration for each stop ("Dinner at 7:00,
-  ~90 min") so the user can override if they want.
+- Call the `commit_itinerary` tool exactly once with the chosen stops (each
+  with `place_id`, `name`, `rationale`, `source`, optional coordinates and
+  arrival_time). Every place_id MUST come from a prior tool result; the
+  graph will reject any unknown place_id and tell you which ones failed so
+  you can retry.
+- After commit_itinerary succeeds, return a 2-4 sentence summary as your
+  final reply (no more tool calls). Mention planned arrival + duration for
+  each stop ("Dinner at 7:00, ~90 min") so the user can override.
 - The structured `stops` list is rendered as cards in the UI; the user sees
   both your prose and the cards.
 

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -8,9 +8,10 @@ critique node do deterministic checks (geographic coherence, hours).
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any
 
 from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -85,7 +86,7 @@ class Stop(BaseModel):
 class ItineraryState(BaseModel):
     """The single piece of state passed through every graph node."""
 
-    messages: list[BaseMessage] = Field(default_factory=list)
+    messages: Annotated[list[BaseMessage], add_messages] = Field(default_factory=list)
     constraints: UserConstraints = Field(default_factory=UserConstraints)
     stops: list[Stop] = Field(default_factory=list)
     scratch: dict[str, Any] = Field(default_factory=dict)

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -1,0 +1,120 @@
+"""Structured state passed through every node of the agent graph.
+
+Keeping state as a Pydantic model (not just messages) lets the LLM revise
+specific stops or constraints without regenerating prose, and lets the
+critique node do deterministic checks (geographic coherence, hours).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from langchain_core.messages import BaseMessage
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UserConstraints(BaseModel):
+    """Parsed/inferred constraints from the user message.
+
+    These are SHARED across all stops: a "$$$" budget applies to dinner AND
+    drinks AND dessert. Per-stop constraints (cuisine, vibe) live on `Stop`.
+    """
+
+    party_size: int | None = None
+    budget_per_person_max: int | None = None  # USD
+    price_level_max: int | None = None  # 0-4 (Google)
+    min_rating: float | None = None
+    min_user_rating_count: int = 50  # quality floor (W1 default)
+    when: datetime | None = None  # arrival time for stop 1
+    neighborhood: str | None = None
+    vibes: list[str] = Field(default_factory=list)  # free-text tags
+    must_be_open: bool = True
+    num_stops: int | None = Field(
+        default=None,
+        description=(
+            "Total stops the user wants. None = ask. Default 3 if user "
+            "says 'plan a date/evening' without a count."
+        ),
+    )
+    walking_budget_m: int = Field(
+        default=2400,
+        description=(
+            "Total walking distance budget across the whole itinerary, "
+            "in meters. Default ~30 min total walking at 80 m/min."
+        ),
+    )
+
+
+DEFAULT_STOP_DURATION_MIN: dict[str, int] = {
+    "restaurant": 90,
+    "fine_dining_restaurant": 120,
+    "cafe": 45,
+    "coffee_shop": 45,
+    "bar": 60,
+    "wine_bar": 60,
+    "cocktail_bar": 60,
+    "bakery": 30,
+    "ice_cream_shop": 30,
+    "museum": 120,
+    "art_gallery": 60,
+    "park": 30,
+    "tourist_attraction": 60,
+}
+DEFAULT_STOP_DURATION_MIN_FALLBACK = 60
+
+
+def default_duration_for(primary_type: str | None) -> int:
+    if not primary_type:
+        return DEFAULT_STOP_DURATION_MIN_FALLBACK
+    return DEFAULT_STOP_DURATION_MIN.get(primary_type.lower(), DEFAULT_STOP_DURATION_MIN_FALLBACK)
+
+
+class Stop(BaseModel):
+    place_id: str
+    name: str
+    arrival_time: datetime | None = None
+    planned_duration_min: int = DEFAULT_STOP_DURATION_MIN_FALLBACK
+    rationale: str
+    source: str  # 'google_places' | 'editorial'
+    latitude: float | None = None
+    longitude: float | None = None
+    primary_type: str | None = None
+
+
+class ItineraryState(BaseModel):
+    """The single piece of state passed through every graph node."""
+
+    messages: list[BaseMessage] = Field(default_factory=list)
+    constraints: UserConstraints = Field(default_factory=UserConstraints)
+    stops: list[Stop] = Field(default_factory=list)
+    scratch: dict[str, Any] = Field(default_factory=dict)
+    step_count: int = 0
+    done: bool = False
+    final_reply: str | None = None
+    awaiting_stops_count: bool = Field(
+        default=False,
+        description=(
+            "True after the agent asked the user how many stops they "
+            "want. The /chat handler echoes the question and the next "
+            "turn parses the answer back into constraints.num_stops."
+        ),
+    )
+    walked_meters_so_far: float = 0.0
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class PlaceCard(BaseModel):
+    """Frontend-facing place shape. Matches what frontend/src/api/chat.js
+    renders. Derived from ItineraryState.stops at response time."""
+
+    place_id: str
+    name: str
+    address: str | None = None
+    rating: float | None = None
+    price_level: int | None = None
+    primary_type: str | None = None
+    arrival_time: datetime | None = None
+    rationale: str
+    booking_url: str | None = None  # populated by W4

--- a/app/agent/tools.py
+++ b/app/agent/tools.py
@@ -1,15 +1,16 @@
-"""Tool definitions. We author tools with Pydantic AI for type safety, and
-expose them as LangChain Tool instances so LangGraph's plan() node can bind
-them to the LLM. Underlying Python functions remain importable from
-app.tools.* for eval (W6) and tests."""
+"""Tool definitions exposed to the LLM via LangChain's StructuredTool.
+
+The underlying retrieval functions remain importable from app.tools.* for
+eval (W6) and tests; this module is the thin LLM-facing wrapper.
+"""
 
 from __future__ import annotations
 
 import inspect
+from typing import Any, get_type_hints
 
 from langchain_core.tools import StructuredTool
 from pydantic import create_model
-from pydantic_ai import RunContext
 
 from app.tools.filters import SearchFilters
 from app.tools.retrieval import (
@@ -28,7 +29,6 @@ from app.tools.retrieval import (
 
 
 def semantic_search(
-    ctx: RunContext[None],
     query: str,
     filters: SearchFilters | None = None,
     k: int = 8,
@@ -43,7 +43,6 @@ def semantic_search(
 
 
 def nearby(
-    ctx: RunContext[None],
     place_id: str,
     radius_m: int = 800,
     filters: SearchFilters | None = None,
@@ -54,12 +53,12 @@ def nearby(
     return _nearby(place_id=place_id, radius_m=radius_m, filters=filters, k=k)
 
 
-def get_details(ctx: RunContext[None], place_id: str) -> PlaceDetails | None:
+def get_details(place_id: str) -> PlaceDetails | None:
     """Fetch the full record for a place: hours, website, ratings count, types."""
     return _get_details(place_id=place_id)
 
 
-def kg_traverse(ctx: RunContext[None], place_id: str, relation: str = "co_mentioned") -> dict:
+def kg_traverse(place_id: str, relation: str = "co_mentioned") -> dict:
     """Traverse the editorial knowledge graph from `place_id`. NOT YET AVAILABLE.
 
     Stub: the KG lands in a future PR after the editorial scrape is done.
@@ -71,36 +70,42 @@ def kg_traverse(ctx: RunContext[None], place_id: str, relation: str = "co_mentio
     }
 
 
-def _args_schema_for(fn):
-    """Reuse the tool function's annotations as a Pydantic args schema. Keeps
-    a single source of truth for arg validation."""
+def _args_schema_for(fn: Any):
+    """Build a Pydantic args schema from the function's annotations.
+
+    Resolved via typing.get_type_hints so PEP 563 / `from __future__ import
+    annotations` strings are evaluated, and raises loudly on any missing
+    annotation so a forgotten type hint can't ship a malformed tool surface.
+    """
     sig = inspect.signature(fn)
-    fields = {}
+    hints = get_type_hints(fn)
+    fields: dict[str, tuple[Any, Any]] = {}
     for pname, param in sig.parameters.items():
-        if pname == "ctx":
-            continue
-        ann = param.annotation if param.annotation is not inspect._empty else str
-        default = param.default if param.default is not inspect._empty else ...
-        fields[pname] = (ann, default)
+        if pname not in hints:
+            raise TypeError(
+                f"tool {fn.__name__!r}: parameter {pname!r} is missing a type annotation"
+            )
+        default = param.default if param.default is not inspect.Parameter.empty else ...
+        fields[pname] = (hints[pname], default)
     return create_model(f"{fn.__name__}_args", **fields)
 
 
-def _to_lc_tool(name: str, description: str, fn) -> StructuredTool:
-    def _runner(**kwargs):
-        return fn(None, **kwargs)
-
+def _to_lc_tool(name: str, description: str, fn: Any) -> StructuredTool:
     return StructuredTool.from_function(
         name=name,
         description=description or "",
-        func=_runner,
+        func=fn,
         args_schema=_args_schema_for(fn),
     )
 
 
+_TOOLS: list[StructuredTool] = [
+    _to_lc_tool("semantic_search", semantic_search.__doc__ or "", semantic_search),
+    _to_lc_tool("nearby", nearby.__doc__ or "", nearby),
+    _to_lc_tool("get_details", get_details.__doc__ or "", get_details),
+    _to_lc_tool("kg_traverse", kg_traverse.__doc__ or "", kg_traverse),
+]
+
+
 def all_tools() -> list[StructuredTool]:
-    return [
-        _to_lc_tool("semantic_search", semantic_search.__doc__ or "", semantic_search),
-        _to_lc_tool("nearby", nearby.__doc__ or "", nearby),
-        _to_lc_tool("get_details", get_details.__doc__ or "", get_details),
-        _to_lc_tool("kg_traverse", kg_traverse.__doc__ or "", kg_traverse),
-    ]
+    return list(_TOOLS)

--- a/app/agent/tools.py
+++ b/app/agent/tools.py
@@ -1,0 +1,106 @@
+"""Tool definitions. We author tools with Pydantic AI for type safety, and
+expose them as LangChain Tool instances so LangGraph's plan() node can bind
+them to the LLM. Underlying Python functions remain importable from
+app.tools.* for eval (W6) and tests."""
+
+from __future__ import annotations
+
+import inspect
+
+from langchain_core.tools import StructuredTool
+from pydantic import create_model
+from pydantic_ai import RunContext
+
+from app.tools.filters import SearchFilters
+from app.tools.retrieval import (
+    PlaceDetails,
+    PlaceHit,
+)
+from app.tools.retrieval import (
+    get_details as _get_details,
+)
+from app.tools.retrieval import (
+    nearby as _nearby,
+)
+from app.tools.retrieval import (
+    semantic_search as _semantic_search,
+)
+
+
+def semantic_search(
+    ctx: RunContext[None],
+    query: str,
+    filters: SearchFilters | None = None,
+    k: int = 8,
+) -> list[PlaceHit]:
+    """Search for places by meaning + structured filters.
+
+    Use this for queries like "romantic italian in north beach under $$$ open
+    Sunday at 7pm". Prefer the structured `filters` argument over packing
+    constraints into `query`.
+    """
+    return _semantic_search(query=query, filters=filters, k=k)
+
+
+def nearby(
+    ctx: RunContext[None],
+    place_id: str,
+    radius_m: int = 800,
+    filters: SearchFilters | None = None,
+    k: int = 8,
+) -> list[PlaceHit]:
+    """Find places within radius_m meters of an anchor place. Call this AFTER
+    you've picked a first stop and need a second stop within walking distance."""
+    return _nearby(place_id=place_id, radius_m=radius_m, filters=filters, k=k)
+
+
+def get_details(ctx: RunContext[None], place_id: str) -> PlaceDetails | None:
+    """Fetch the full record for a place: hours, website, ratings count, types."""
+    return _get_details(place_id=place_id)
+
+
+def kg_traverse(ctx: RunContext[None], place_id: str, relation: str = "co_mentioned") -> dict:
+    """Traverse the editorial knowledge graph from `place_id`. NOT YET AVAILABLE.
+
+    Stub: the KG lands in a future PR after the editorial scrape is done.
+    The tool exists now so the agent's tool surface is stable.
+    """
+    return {
+        "available": False,
+        "reason": "knowledge graph not yet built; use semantic_search instead",
+    }
+
+
+def _args_schema_for(fn):
+    """Reuse the tool function's annotations as a Pydantic args schema. Keeps
+    a single source of truth for arg validation."""
+    sig = inspect.signature(fn)
+    fields = {}
+    for pname, param in sig.parameters.items():
+        if pname == "ctx":
+            continue
+        ann = param.annotation if param.annotation is not inspect._empty else str
+        default = param.default if param.default is not inspect._empty else ...
+        fields[pname] = (ann, default)
+    return create_model(f"{fn.__name__}_args", **fields)
+
+
+def _to_lc_tool(name: str, description: str, fn) -> StructuredTool:
+    def _runner(**kwargs):
+        return fn(None, **kwargs)
+
+    return StructuredTool.from_function(
+        name=name,
+        description=description or "",
+        func=_runner,
+        args_schema=_args_schema_for(fn),
+    )
+
+
+def all_tools() -> list[StructuredTool]:
+    return [
+        _to_lc_tool("semantic_search", semantic_search.__doc__ or "", semantic_search),
+        _to_lc_tool("nearby", nearby.__doc__ or "", nearby),
+        _to_lc_tool("get_details", get_details.__doc__ or "", get_details),
+        _to_lc_tool("kg_traverse", kg_traverse.__doc__ or "", kg_traverse),
+    ]

--- a/app/agent/tools.py
+++ b/app/agent/tools.py
@@ -94,7 +94,7 @@ def _args_schema_for(fn: Any):
     """
     sig = inspect.signature(fn)
     hints = get_type_hints(fn)
-    fields: dict[str, tuple[Any, Any]] = {}
+    fields: dict[str, Any] = {}
     for pname, param in sig.parameters.items():
         if pname not in hints:
             raise TypeError(

--- a/app/agent/tools.py
+++ b/app/agent/tools.py
@@ -12,6 +12,7 @@ from typing import Any, get_type_hints
 from langchain_core.tools import StructuredTool
 from pydantic import create_model
 
+from app.agent.state import Stop
 from app.tools.filters import SearchFilters
 from app.tools.retrieval import (
     PlaceDetails,
@@ -26,6 +27,8 @@ from app.tools.retrieval import (
 from app.tools.retrieval import (
     semantic_search as _semantic_search,
 )
+
+COMMIT_ITINERARY_TOOL_NAME = "commit_itinerary"
 
 
 def semantic_search(
@@ -56,6 +59,18 @@ def nearby(
 def get_details(place_id: str) -> PlaceDetails | None:
     """Fetch the full record for a place: hours, website, ratings count, types."""
     return _get_details(place_id=place_id)
+
+
+def commit_itinerary(stops: list[Stop]) -> dict:
+    """Finalize the itinerary by committing the chosen stops to state.
+
+    Call this exactly once, after retrieval is complete and before your final
+    reply. Every stop's place_id MUST come from a prior tool result — the
+    graph rejects unknown place_ids to prevent hallucination. The agent's
+    `act` node intercepts this call and writes `state.stops`; the return
+    value here is only the bookkeeping payload the LLM sees.
+    """
+    return {"committed": [s.place_id for s in stops]}
 
 
 def kg_traverse(place_id: str, relation: str = "co_mentioned") -> dict:
@@ -103,6 +118,7 @@ _TOOLS: list[StructuredTool] = [
     _to_lc_tool("semantic_search", semantic_search.__doc__ or "", semantic_search),
     _to_lc_tool("nearby", nearby.__doc__ or "", nearby),
     _to_lc_tool("get_details", get_details.__doc__ or "", get_details),
+    _to_lc_tool(COMMIT_ITINERARY_TOOL_NAME, commit_itinerary.__doc__ or "", commit_itinerary),
     _to_lc_tool("kg_traverse", kg_traverse.__doc__ or "", kg_traverse),
 ]
 

--- a/app/chain.py
+++ b/app/chain.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from langchain.chains import RetrievalQA
 from langchain_core.language_models import BaseChatModel
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -10,6 +12,12 @@ from .config import get_settings
 from .retriever import PgVectorRetriever
 
 
+@dataclass
+class BuiltChain:
+    chain: RetrievalQA
+    llm: BaseChatModel
+
+
 def build_rag_chain(
     connection_string: str,
     api_key: str,
@@ -17,7 +25,7 @@ def build_rag_chain(
     chat_model: str,
     k: int,
     temperature: float = 0.0,
-) -> RetrievalQA:
+) -> BuiltChain:
     settings = get_settings()
     retriever = PgVectorRetriever(
         connection_string=connection_string,
@@ -39,9 +47,10 @@ def build_rag_chain(
     else:
         raise ValueError(f"Unsupported llm_provider: {llm_provider}")
 
-    return RetrievalQA.from_chain_type(
+    chain = RetrievalQA.from_chain_type(
         llm=llm,
         chain_type="stuff",
         retriever=retriever,
         return_source_documents=True,
     )
+    return BuiltChain(chain=chain, llm=llm)

--- a/app/main.py
+++ b/app/main.py
@@ -9,11 +9,12 @@ import mlflow
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import HumanMessage
 from psycopg2.extensions import connection
 from pydantic import BaseModel, Field
 
-from .agent.graph import build_agent_graph, state_to_response
+from .agent.graph import build_agent_graph
+from .agent.io import messages_from_history, state_to_cards
 from .agent.state import ItineraryState
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
@@ -172,16 +173,6 @@ def serialize_sources(source_documents: list[Any], limit: int) -> list[Recommend
     return sources
 
 
-def _history_to_messages(history: list[ChatMessage]) -> list[Any]:
-    out: list[Any] = []
-    for m in history:
-        if m.role == "user":
-            out.append(HumanMessage(content=m.content))
-        else:
-            out.append(AIMessage(content=m.content))
-    return out
-
-
 def _rag_label_for(config: ActiveModelConfig | None) -> str:
     if config is None:
         return "unknown"
@@ -291,7 +282,7 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
     with trace_request("chat", message=req.message[:200]) as trace_id:
         state = ItineraryState(
             messages=[
-                *_history_to_messages(req.history),
+                *messages_from_history(req.history),
                 HumanMessage(content=req.message),
             ]
         )
@@ -303,8 +294,11 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
             },
         )
     final_state = raw if isinstance(raw, ItineraryState) else ItineraryState(**raw)
-    payload = state_to_response(final_state, rag_label)
-    return ChatResponse(**payload)
+    return ChatResponse(
+        reply=final_state.final_reply or "",
+        places=state_to_cards(final_state),
+        ragLabel=rag_label,
+    )
 
 
 @app.post("/predict", response_model=RecommendationResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -309,31 +309,13 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
 
 @app.post("/predict", response_model=RecommendationResponse)
 async def predict(request_body: RecommendationRequest, request: Request) -> RecommendationResponse:
-    graph = getattr(request.app.state, "agent_graph", None)
-    if graph is None:
-        # Fall back to the legacy chain if the agent isn't available so existing
-        # callers keep working in degraded mode.
-        rag_chain = getattr(request.app.state, "rag_chain", None)
-        if rag_chain is None:
-            raise HTTPException(status_code=503, detail=RAG_UNAVAILABLE_DETAIL)
-        result = rag_chain.invoke({"query": request_body.query})
-        response_text = result.get("result") or result.get("response") or ""
-        source_documents = result.get("source_documents") or []
-        return RecommendationResponse(
-            response=response_text,
-            sources=serialize_sources(source_documents, request_body.limit),
-        )
-
-    chat_resp = await chat(ChatRequest(message=request_body.query, history=[]), request)
-    sources = [
-        RecommendationSource(
-            place_id=p.get("place_id"),
-            name=p.get("name"),
-            rating=p.get("rating"),
-            address=p.get("address"),
-            primary_type=p.get("primary_type"),
-            similarity=0.0,
-        )
-        for p in chat_resp.places[: request_body.limit]
-    ]
-    return RecommendationResponse(response=chat_resp.reply, sources=sources)
+    rag_chain = getattr(request.app.state, "rag_chain", None)
+    if rag_chain is None:
+        raise HTTPException(status_code=503, detail=RAG_UNAVAILABLE_DETAIL)
+    result = rag_chain.invoke({"query": request_body.query})
+    response_text = result.get("result") or result.get("response") or ""
+    source_documents = result.get("source_documents") or []
+    return RecommendationResponse(
+        response=response_text,
+        sources=serialize_sources(source_documents, request_body.limit),
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -2,23 +2,33 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import mlflow
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage
 from psycopg2.extensions import connection
 from pydantic import BaseModel, Field
 
+from .agent.graph import build_agent_graph, state_to_response
+from .agent.state import ItineraryState
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
 from .db import get_db
 from .db_pool import close_db_pool, init_db_pool
+from .observability import langgraph_callbacks, trace_request
 
 logger = logging.getLogger(__name__)
 
 RAG_UNAVAILABLE_DETAIL = (
     "RAG chain unavailable: MLflow registry could not be reached at startup. "
+    "Ensure the MLflow IAP tunnel is open and restart the app."
+)
+AGENT_UNAVAILABLE_DETAIL = (
+    "Agent graph unavailable: MLflow registry could not be reached at startup. "
     "Ensure the MLflow IAP tunnel is open and restart the app."
 )
 
@@ -43,6 +53,8 @@ class RecommendationSource(BaseModel):
     rating: float | None = None
     address: str | None = None
     similarity: float | None = None
+    place_id: str | None = None
+    primary_type: str | None = None
 
 
 class RecommendationResponse(BaseModel):
@@ -57,6 +69,30 @@ class ActiveModelConfig(BaseModel):
     temperature: float = 0.0
     run_id: str | None = None
     model_version: str | None = None
+
+
+class ChatMessage(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class ChatRequest(BaseModel):
+    message: str
+    history: list[ChatMessage] = Field(default_factory=list)
+
+
+class ChatResponse(BaseModel):
+    # Field name matches the frontend contract (frontend/src/api/chat.js).
+    reply: str
+    places: list[dict]
+    ragLabel: str  # noqa: N815
+
+
+@dataclass
+class LoadedConfig:
+    chain: Any
+    llm: BaseChatModel
+    params: ActiveModelConfig
 
 
 def parse_active_model_config(
@@ -81,7 +117,7 @@ def parse_active_model_config(
     )
 
 
-def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
+def load_registered_rag_chain() -> LoadedConfig:
     settings = get_settings()
     tracking_uri = settings.mlflow_tracking_uri
 
@@ -108,7 +144,7 @@ def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
     database_url = settings.resolved_database_url
     if not database_url:
         raise RuntimeError("Missing DATABASE_URL or POSTGRES_* database settings.")
-    chain = build_rag_chain(
+    built = build_rag_chain(
         connection_string=database_url,
         api_key=resolve_llm_api_key(config.llm_provider),
         llm_provider=config.llm_provider,
@@ -116,7 +152,7 @@ def load_registered_rag_chain() -> tuple[Any, ActiveModelConfig]:
         k=config.k,
         temperature=config.temperature,
     )
-    return chain, config
+    return LoadedConfig(chain=built.chain, llm=built.llm, params=config)
 
 
 def serialize_sources(source_documents: list[Any], limit: int) -> list[RecommendationSource]:
@@ -129,9 +165,27 @@ def serialize_sources(source_documents: list[Any], limit: int) -> list[Recommend
                 rating=metadata.get("rating"),
                 address=metadata.get("address"),
                 similarity=metadata.get("similarity"),
+                place_id=metadata.get("place_id"),
+                primary_type=metadata.get("primary_type"),
             )
         )
     return sources
+
+
+def _history_to_messages(history: list[ChatMessage]) -> list[Any]:
+    out: list[Any] = []
+    for m in history:
+        if m.role == "user":
+            out.append(HumanMessage(content=m.content))
+        else:
+            out.append(AIMessage(content=m.content))
+    return out
+
+
+def _rag_label_for(config: ActiveModelConfig | None) -> str:
+    if config is None:
+        return "unknown"
+    return f"{config.llm_provider}:{config.chat_model}"
 
 
 @asynccontextmanager
@@ -148,17 +202,33 @@ async def lifespan(app: FastAPI):
     )
     try:
         try:
-            rag_chain, model_config = load_registered_rag_chain()
+            loaded = load_registered_rag_chain()
         except Exception:
             logger.warning(
                 "Failed to load RAG chain from MLflow registry — app will boot in "
                 "degraded mode and RAG endpoints will return 503.",
                 exc_info=True,
             )
-            rag_chain = None
-            model_config = None
-        app.state.rag_chain = rag_chain
-        app.state.active_model_config = model_config
+            loaded = None
+
+        if loaded is None:
+            app.state.rag_chain = None
+            app.state.active_model_config = None
+            app.state.agent_graph = None
+            app.state.rag_label = _rag_label_for(None)
+        else:
+            app.state.rag_chain = loaded.chain
+            app.state.active_model_config = loaded.params
+            try:
+                app.state.agent_graph = build_agent_graph(loaded.llm)
+            except Exception:
+                logger.warning(
+                    "Failed to build agent graph — /chat will return 503; "
+                    "/predict falls back to the legacy RAG chain.",
+                    exc_info=True,
+                )
+                app.state.agent_graph = None
+            app.state.rag_label = _rag_label_for(loaded.params)
         yield
     finally:
         close_db_pool()
@@ -211,17 +281,59 @@ def health_db(conn: connection = db_connection_dependency) -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest, request: Request) -> ChatResponse:
+    graph = getattr(request.app.state, "agent_graph", None)
+    if graph is None:
+        raise HTTPException(status_code=503, detail=AGENT_UNAVAILABLE_DETAIL)
+
+    rag_label = getattr(request.app.state, "rag_label", _rag_label_for(None))
+    with trace_request("chat", message=req.message[:200]) as trace_id:
+        state = ItineraryState(
+            messages=[
+                *_history_to_messages(req.history),
+                HumanMessage(content=req.message),
+            ]
+        )
+        raw = await graph.ainvoke(
+            state,
+            config={
+                "callbacks": langgraph_callbacks(),
+                "metadata": {"trace_id": trace_id},
+            },
+        )
+    final_state = raw if isinstance(raw, ItineraryState) else ItineraryState(**raw)
+    payload = state_to_response(final_state, rag_label)
+    return ChatResponse(**payload)
+
+
 @app.post("/predict", response_model=RecommendationResponse)
-def predict(request_body: RecommendationRequest, request: Request) -> RecommendationResponse:
-    rag_chain = getattr(request.app.state, "rag_chain", None)
-    if rag_chain is None:
-        raise HTTPException(status_code=503, detail=RAG_UNAVAILABLE_DETAIL)
+async def predict(request_body: RecommendationRequest, request: Request) -> RecommendationResponse:
+    graph = getattr(request.app.state, "agent_graph", None)
+    if graph is None:
+        # Fall back to the legacy chain if the agent isn't available so existing
+        # callers keep working in degraded mode.
+        rag_chain = getattr(request.app.state, "rag_chain", None)
+        if rag_chain is None:
+            raise HTTPException(status_code=503, detail=RAG_UNAVAILABLE_DETAIL)
+        result = rag_chain.invoke({"query": request_body.query})
+        response_text = result.get("result") or result.get("response") or ""
+        source_documents = result.get("source_documents") or []
+        return RecommendationResponse(
+            response=response_text,
+            sources=serialize_sources(source_documents, request_body.limit),
+        )
 
-    result = rag_chain.invoke({"query": request_body.query})
-    response_text = result.get("result") or result.get("response") or ""
-    source_documents = result.get("source_documents") or []
-
-    return RecommendationResponse(
-        response=response_text,
-        sources=serialize_sources(source_documents, request_body.limit),
-    )
+    chat_resp = await chat(ChatRequest(message=request_body.query, history=[]), request)
+    sources = [
+        RecommendationSource(
+            place_id=p.get("place_id"),
+            name=p.get("name"),
+            rating=p.get("rating"),
+            address=p.get("address"),
+            primary_type=p.get("primary_type"),
+            similarity=0.0,
+        )
+        for p in chat_resp.places[: request_body.limit]
+    ]
+    return RecommendationResponse(response=chat_resp.reply, sources=sources)

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from functools import lru_cache
+
 import psycopg2
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
@@ -14,16 +16,29 @@ def vector_to_pg(embedding: list[float]) -> str:
     return "[" + ",".join(f"{value:.8f}" for value in embedding) + "]"
 
 
+@lru_cache(maxsize=4096)
+def _embed_cached(query: str, embedding_model: str, api_key: str) -> tuple[float, ...]:
+    """Cache OpenAI embeddings keyed on (query, model). The api_key is part of
+    the key only for safety; it doesn't affect output for a given (query, model).
+    Returns a tuple so the cached value is immutable."""
+    embeddings = OpenAIEmbeddings(model=embedding_model, api_key=SecretStr(api_key))
+    return tuple(embeddings.embed_query(query))
+
+
 def build_embedding(
     query: str, embedding_model: str, openai_api_key: str | None = None
 ) -> list[float]:
-    """Generate an OpenAI embedding for a query string. Reused by agent tools."""
+    """Generate an OpenAI embedding for a query string. Reused by agent tools.
+
+    Embeddings are deterministic per (query, model), so we cache them via
+    _embed_cached to skip duplicate OpenAI round-trips within and across
+    sessions.
+    """
     settings = get_settings()
     api_key = openai_api_key or settings.openai_api_key
     if not api_key:
         raise RuntimeError("Missing OPENAI_API_KEY for query embedding generation.")
-    embeddings = OpenAIEmbeddings(model=embedding_model, api_key=SecretStr(api_key))
-    return embeddings.embed_query(query)
+    return list(_embed_cached(query, embedding_model, api_key))
 
 
 class PgVectorRetriever(BaseRetriever):

--- a/poetry.lock
+++ b/poetry.lock
@@ -217,6 +217,36 @@ files = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.100.0"
+description = "The official Python library for the anthropic API"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d"},
+    {file = "anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+docstring-parser = ">=0.15,<1"
+httpx = ">=0.25.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+typing-extensions = ">=4.14,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
+aws = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+mcp = ["mcp (>=1.0) ; python_version >= \"3.10\""]
+vertex = ["google-auth[requests] (>=2,<3)"]
+webhooks = ["standardwebhooks (>=1.0.1,<2)"]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
@@ -235,6 +265,21 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.32.0)"]
+
+[[package]]
+name = "argcomplete"
+version = "3.6.3"
+description = "Bash tab completion for argparse"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce"},
+    {file = "argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c"},
+]
+
+[package.extras]
+test = ["coverage", "mypy", "pexpect", "ruff", "wheel"]
 
 [[package]]
 name = "async-timeout"
@@ -284,6 +329,46 @@ files = [
     {file = "blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"},
     {file = "blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf"},
 ]
+
+[[package]]
+name = "boto3"
+version = "1.43.5"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "boto3-1.43.5-py3-none-any.whl", hash = "sha256:aa8a296c8db55d812767b282cfe4c7977f0b0eeaa709abdaeb368b9c738e901f"},
+    {file = "boto3-1.43.5.tar.gz", hash = "sha256:414be7868f25c3b6a0232301c8ab40347911b6b191926b61f00a63f89b97b2bc"},
+]
+
+[package.dependencies]
+botocore = ">=1.43.5,<1.44.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.17.0,<0.18.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.43.5"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "botocore-1.43.5-py3-none-any.whl", hash = "sha256:a1df6e0c6346735936f42e6b99f3b28f1e9397731c0bc2563c617df7965a0dc0"},
+    {file = "botocore-1.43.5.tar.gz", hash = "sha256:5c7207816ab5e48382adcb2a64db388fa4abe9ee1d23f72c82ae62c51a0bc84e"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
+
+[package.extras]
+crt = ["awscrt (==0.32.2)"]
 
 [[package]]
 name = "cachetools"
@@ -586,6 +671,33 @@ files = [
 ]
 
 [[package]]
+name = "cohere"
+version = "6.1.0"
+description = ""
+optional = false
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+markers = "platform_system != \"Emscripten\""
+files = [
+    {file = "cohere-6.1.0-py3-none-any.whl", hash = "sha256:ad286b3af2583c75ba93624e6f680603d3578a3d73704f997430260b87537ac7"},
+    {file = "cohere-6.1.0.tar.gz", hash = "sha256:6a52bb459b71b5e79735412ee1a8e87028c5b3afba050c39815fe03c083249b3"},
+]
+
+[package.dependencies]
+fastavro = ">=1.9.4,<2.0.0"
+httpx = ">=0.21.2"
+pydantic = ">=1.9.2"
+pydantic-core = ">=2.18.2,<2.44.0"
+requests = ">=2.0.0,<3.0.0"
+tokenizers = ">=0.15,<1"
+types-requests = ">=2.0.0,<3.0.0"
+typing_extensions = ">=4.0.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.10.0,<4)", "httpx-aiohttp (==0.1.8)"]
+oci = ["oci (>=2.165.0,<3.0.0)"]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -596,7 +708,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+markers = {dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "contourpy"
@@ -1066,6 +1178,38 @@ ssh = ["paramiko (>=2.4.3)"]
 websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"},
+    {file = "docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"},
+]
+
+[package.extras]
+dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
+docs = ["pydoctor (>=25.4.0)"]
+test = ["pytest"]
+
+[[package]]
+name = "eval-type-backport"
+version = "0.3.1"
+description = "Like `typing._eval_type`, but lets older Python versions use newer typing features."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "eval_type_backport-0.3.1-py3-none-any.whl", hash = "sha256:279ab641905e9f11129f56a8a78f493518515b83402b860f6f06dd7c011fdfa8"},
+    {file = "eval_type_backport-0.3.1.tar.gz", hash = "sha256:57e993f7b5b69d271e37482e62f74e76a0276c82490cf8e4f0dffeb6b332d5ed"},
+]
+
+[package.extras]
+tests = ["pytest"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -1122,6 +1266,26 @@ tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 tzdata = ["tzdata"]
 
 [[package]]
+name = "fasta2a"
+version = "0.2.4"
+description = "Convert an AI Agent into a A2A server! ✨"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "fasta2a-0.2.4-py3-none-any.whl", hash = "sha256:3d8b71124739030512c6880d8a78d37bd6c9a099b42d3a772f62747ecef829e9"},
+    {file = "fasta2a-0.2.4.tar.gz", hash = "sha256:7afa3fd3205ce3f299b68b2705d285380328a7a4cbd2d230230e66b4701743e8"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.28.0"
+pydantic = ">=2.10"
+starlette = ">0.29.0"
+
+[package.extras]
+logfire = ["logfire (>=2.3)"]
+
+[[package]]
 name = "fastapi"
 version = "0.135.2"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -1146,16 +1310,84 @@ standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "htt
 standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "fastavro"
+version = "1.12.2"
+description = "Fast read/write of AVRO files"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "platform_system != \"Emscripten\""
+files = [
+    {file = "fastavro-1.12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c7c6d26c731a0e1e8e7d4ae8f13ae524eb6ec0e90d99c8147a19fdbae14eb807"},
+    {file = "fastavro-1.12.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7caeecf519eff50f007ca4bee16b6e0a8252e5fe682c94432192a20867239888"},
+    {file = "fastavro-1.12.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:731aefe6c4bf2bafa0798ef83927676d06e44d1d18202cfb56d63b40422ab900"},
+    {file = "fastavro-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f089f24225a28ddafa5cfad7c41cfa84db1a55f2d473370769a95c0e3bac60c9"},
+    {file = "fastavro-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:653c4f90dd21d8a1e74309919e08934e420d9aef51d051d14bf5a1c0e8293c22"},
+    {file = "fastavro-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:030f17eb4c7978538a31b55dea451ceace851a88dc9816b1923f8fb8a260db4c"},
+    {file = "fastavro-1.12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d48cd7094598a7e9d4297e8bf4bbe0dc9dc2ba4367d83dbb603e3b3c6aa35566"},
+    {file = "fastavro-1.12.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:070c6134604bd7b6fd44409406ac50445339682b2e872885db2e859f92d22e93"},
+    {file = "fastavro-1.12.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b73d50978d5e57416fa68461f9f3c8f39ea39e761cb1e12f919745adefe26a7"},
+    {file = "fastavro-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c57a9920400166398695d92580eca21fd7a79f3c67d691ac7e20a7d1b5300735"},
+    {file = "fastavro-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:81f6108f3ac292fb6cd05758c9e531389d8fc5e94e8c949b9298f4fb0a239662"},
+    {file = "fastavro-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:eec44256856fd59d29d1f1d0950ace18a58e4228e7d49de5d5e1b1875b227dde"},
+    {file = "fastavro-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:ecd1b23ea7f9af09c865ac8503d07afd7e6bf782d76bb83cbbdba15b7a0db807"},
+    {file = "fastavro-1.12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e331896e8efffc72fa03e63b87ebfc37960113127da8e0f5152d91664ffed68"},
+    {file = "fastavro-1.12.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f01ebaada59d74fdf6d28e5031a961a413b3752e9edb0c03866fa18480cf4c8"},
+    {file = "fastavro-1.12.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25ef6855935f67582740ffa6bb978e40ec51be876117a3555c36fa2488dcdf25"},
+    {file = "fastavro-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:84a4f76a0aece0aa72b5ed8162ba2ff8c78908b8361b5a5d92ddd161977ccb74"},
+    {file = "fastavro-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81e8da77d201916f6771fc357fda8267c2a256d7aa11923d43bc5f2fc155878b"},
+    {file = "fastavro-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:1924349c74666c89417bd5cc2749f598e2f15f1d56ee81428b2317ab02c88aae"},
+    {file = "fastavro-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:4c346cf449baf3b113e997c34151ad205e7135bc429469b005b180ade7e65e28"},
+    {file = "fastavro-1.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704"},
+    {file = "fastavro-1.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0"},
+    {file = "fastavro-1.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e"},
+    {file = "fastavro-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea"},
+    {file = "fastavro-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e"},
+    {file = "fastavro-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39"},
+    {file = "fastavro-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36"},
+    {file = "fastavro-1.12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31"},
+    {file = "fastavro-1.12.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef"},
+    {file = "fastavro-1.12.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397"},
+    {file = "fastavro-1.12.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff"},
+    {file = "fastavro-1.12.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423"},
+    {file = "fastavro-1.12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8d37c87826ae7195cfbd20fcd448801f2f563bb38f2691ec6574e39cb9eca6c8"},
+    {file = "fastavro-1.12.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c463a3701f293e30d3d62e71e1989f112028d07f87432baf4507eeb57ec3831"},
+    {file = "fastavro-1.12.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f604ba83498e209fff4c7ecc5063a39421dc538dace694bc592f9f338254f3dc"},
+    {file = "fastavro-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bfac2dada8ddc002e8b7d8289d6fad4f070bc1fec20371cec684a7d10d932e96"},
+    {file = "fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c"},
+    {file = "fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f"},
+    {file = "fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a"},
+    {file = "fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa"},
+    {file = "fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282"},
+    {file = "fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370"},
+    {file = "fastavro-1.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:afede7324822800e4f90e96b9514188a237a60f35e8e7a10b2129c10c78f6e4d"},
+    {file = "fastavro-1.12.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b5539711dfa1ec8f3eca57482b93a48a165af4a99e9d5f41e3af3fb913aadf92"},
+    {file = "fastavro-1.12.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c01b0f0ce030a7b89263c0236ca77923eae352c5f35ecf214b04d3aaea8eb2c3"},
+    {file = "fastavro-1.12.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:742d93f2ca835e4fa83a3ae9ed2bce8b28029ed62ac730f339a37685c23075cd"},
+    {file = "fastavro-1.12.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ae60df21cc7059e2f3b1928ad2c0b75c6b26f9ada79d992f87b6fc3f50d3877e"},
+    {file = "fastavro-1.12.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:03614131093a32c90c8fd95ff356c316752b8850cb8a770bc96cef17a003e2fc"},
+    {file = "fastavro-1.12.2-cp39-cp39-win_amd64.whl", hash = "sha256:e235dfdabb51993bcd4a8f45c3a54f21a782f7f92b3def0648b0ace45a1b1ac7"},
+    {file = "fastavro-1.12.2.tar.gz", hash = "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab"},
+]
+
+[package.extras]
+codecs = ["backports.zstd ; python_version < \"3.14\"", "cramjam", "lz4"]
+lz4 = ["lz4"]
+snappy = ["cramjam"]
+zstandard = ["backports.zstd ; python_version < \"3.14\""]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"},
     {file = "filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90"},
 ]
+markers = {main = "platform_system != \"Emscripten\""}
 
 [[package]]
 name = "filetype"
@@ -1405,6 +1637,47 @@ files = [
     {file = "frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d"},
     {file = "frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad"},
 ]
+
+[[package]]
+name = "fsspec"
+version = "2026.4.0"
+description = "File-system specification"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_system != \"Emscripten\""
+files = [
+    {file = "fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2"},
+    {file = "fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4"},
+]
+
+[package.extras]
+abfs = ["adlfs"]
+adl = ["adlfs"]
+arrow = ["pyarrow (>=1)"]
+dask = ["dask", "distributed"]
+dev = ["pre-commit", "ruff (>=0.5)"]
+doc = ["numpydoc", "sphinx", "sphinx-design", "sphinx-rtd-theme", "yarl"]
+dropbox = ["dropbox", "dropboxdrivefs", "requests"]
+full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "dask", "distributed", "dropbox", "dropboxdrivefs", "fusepy", "gcsfs (>2024.2.0)", "libarchive-c", "ocifs", "panel", "paramiko", "pyarrow (>=1)", "pygit2", "requests", "s3fs (>2024.2.0)", "smbprotocol", "tqdm"]
+fuse = ["fusepy"]
+gcs = ["gcsfs (>2024.2.0)"]
+git = ["pygit2"]
+github = ["requests"]
+gs = ["gcsfs"]
+gui = ["panel"]
+hdfs = ["pyarrow (>=1)"]
+http = ["aiohttp (!=4.0.0a0,!=4.0.0a1)"]
+libarchive = ["libarchive-c"]
+oci = ["ocifs"]
+s3 = ["s3fs (>2024.2.0)"]
+sftp = ["paramiko"]
+smb = ["smbprotocol"]
+ssh = ["paramiko"]
+test = ["aiohttp (!=4.0.0a0,!=4.0.0a1)", "numpy", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "requests"]
+test-downstream = ["aiobotocore (>=2.5.4,<3.0.0)", "dask[dataframe,test]", "moto[server] (>4,<5)", "pytest-timeout", "xarray"]
+test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "backports-zstd ; python_version < \"3.14\"", "cloudpickle", "dask", "distributed", "dropbox", "dropboxdrivefs", "fastparquet", "fusepy", "gcsfs", "jinja2", "kerchunk", "libarchive-c", "lz4", "notebook", "numpy", "ocifs", "pandas (<3.0.0)", "panel", "paramiko", "pyarrow", "pyarrow (>=1)", "pyftpdlib", "pygit2", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "python-snappy", "requests", "smbprotocol", "tqdm", "urllib3", "zarr", "zstandard ; python_version < \"3.14\""]
+tqdm = ["tqdm"]
 
 [[package]]
 name = "gitdb"
@@ -1683,6 +1956,79 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil", "setuptools"]
 
 [[package]]
+name = "griffe"
+version = "2.0.2"
+description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "griffe-2.0.2-py3-none-any.whl", hash = "sha256:2b31816460aee1996af26050a1fc6927a2e5936486856707f55508e4c9b5960b"},
+    {file = "griffe-2.0.2.tar.gz", hash = "sha256:c5d56326d159f274492e9bf93a9895cec101155d944caa66d0fc4e0c13751b92"},
+]
+
+[package.dependencies]
+griffecli = "2.0.2"
+griffelib = "2.0.2"
+
+[package.extras]
+pypi = ["griffelib[pypi] (==2.0.2)"]
+
+[[package]]
+name = "griffecli"
+version = "2.0.2"
+description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "griffecli-2.0.2-py3-none-any.whl", hash = "sha256:0d44d39e59afa81e288a3e1c3bf352cc4fa537483326ac06b8bb6a51fd8303a0"},
+    {file = "griffecli-2.0.2.tar.gz", hash = "sha256:40a1ad4181fc39685d025e119ae2c5b669acdc1f19b705fb9bf971f4e6f6dffb"},
+]
+
+[package.dependencies]
+colorama = ">=0.4"
+griffelib = "2.0.2"
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1"},
+    {file = "griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e"},
+]
+
+[package.extras]
+pypi = ["pip (>=24.0)", "platformdirs (>=4.2)", "wheel (>=0.42)"]
+
+[[package]]
+name = "groq"
+version = "1.2.0"
+description = "The official Python library for the groq API"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "groq-1.2.0-py3-none-any.whl", hash = "sha256:1002060a743b27c8f86765e1bc9749c98498e961d9fe2e4902bf7804a71c3c84"},
+    {file = "groq-1.2.0.tar.gz", hash = "sha256:85459e27c9c17f22404349c785cd08680362cfe85e07cc060be46c4832f108c3"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+typing-extensions = ">=4.14,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
+
+[[package]]
 name = "grpcio"
 version = "1.80.0"
 description = "HTTP/2-based RPC framework"
@@ -1812,6 +2158,45 @@ files = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.0"
+description = "Fast transfer of large files with the Hugging Face Hub."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "(platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and platform_system != \"Emscripten\""
+files = [
+    {file = "hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c"},
+    {file = "hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42"},
+    {file = "hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a"},
+    {file = "hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480"},
+    {file = "hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216"},
+    {file = "hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60"},
+    {file = "hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d"},
+    {file = "hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4"},
+    {file = "hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c"},
+    {file = "hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73"},
+    {file = "hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682"},
+    {file = "hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761"},
+    {file = "hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded"},
+    {file = "hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702"},
+    {file = "hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e"},
+    {file = "hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0"},
+    {file = "hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56"},
+    {file = "hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a"},
+    {file = "hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949"},
+    {file = "hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b"},
+    {file = "hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18"},
+    {file = "hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690"},
+    {file = "hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4"},
+    {file = "hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be"},
+    {file = "hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948"},
+]
+
+[package.extras]
+tests = ["pytest"]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -1924,6 +2309,43 @@ files = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.14.0"
+description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
+optional = false
+python-versions = ">=3.10.0"
+groups = ["main"]
+markers = "platform_system != \"Emscripten\""
+files = [
+    {file = "huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8"},
+    {file = "huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2"},
+]
+
+[package.dependencies]
+filelock = ">=3.10.0"
+fsspec = ">=2023.5.0"
+hf-xet = {version = ">=1.4.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
+httpx = ">=0.23.0,<1"
+packaging = ">=20.9"
+pyyaml = ">=5.1"
+tqdm = ">=4.42.1"
+typer = ">=0.20.0"
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+all = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0)", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+dev = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0)", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
+gradio = ["gradio (>=5.0.0)", "requests"]
+hf-xet = ["hf-xet (>=1.4.3,<2.0.0)"]
+mcp = ["mcp (>=1.8.0)"]
+oauth = ["authlib (>=1.3.2)", "fastapi", "httpx", "itsdangerous"]
+quality = ["libcst (>=1.4.0)", "mypy (==1.15.0)", "ruff (>=0.9.0)", "ty"]
+testing = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
+torch = ["safetensors[torch]", "torch"]
+typing = ["types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 description = "File identification library for Python"
@@ -1987,6 +2409,18 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
+name = "invoke"
+version = "2.2.1"
+description = "Pythonic task execution"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8"},
+    {file = "invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707"},
 ]
 
 [[package]]
@@ -2132,6 +2566,18 @@ files = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
+    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 description = "Lightweight pipelining with Python functions"
@@ -2169,6 +2615,43 @@ files = [
     {file = "jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca"},
     {file = "jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900"},
 ]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+description = "An implementation of JSON Schema validation for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
+    {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+jsonschema-specifications = ">=2023.03.6"
+referencing = ">=0.28.4"
+rpds-py = ">=0.25.0"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "rfc3987-syntax (>=1.1.0)", "uri-template", "webcolors (>=24.6.0)"]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
+    {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
+]
+
+[package.dependencies]
+referencing = ">=0.31.0"
 
 [[package]]
 name = "kiwisolver"
@@ -2467,6 +2950,74 @@ llama-index = ["llama-index (>=0.10.12,<2.0.0)"]
 openai = ["openai (>=0.27.8)"]
 
 [[package]]
+name = "langgraph"
+version = "0.6.11"
+description = "Building stateful, multi-actor applications with LLMs"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "langgraph-0.6.11-py3-none-any.whl", hash = "sha256:49268de69d85b7db3da9e2ca582a474516421c1c44be5cff390416cfa6967faa"},
+    {file = "langgraph-0.6.11.tar.gz", hash = "sha256:cd5373d0a59701ab39c9f8af33a33c5704553de815318387fa7f240511e0efd7"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.1"
+langgraph-checkpoint = ">=2.1.0,<4.0.0"
+langgraph-prebuilt = ">=0.6.0,<0.7.0"
+langgraph-sdk = ">=0.2.2,<0.3.0"
+pydantic = ">=2.7.4"
+xxhash = ">=3.5.0"
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "3.0.1"
+description = "Library with base interfaces for LangGraph checkpoint savers."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langgraph_checkpoint-3.0.1-py3-none-any.whl", hash = "sha256:9b04a8d0edc0474ce4eaf30c5d731cee38f11ddff50a6177eead95b5c4e4220b"},
+    {file = "langgraph_checkpoint-3.0.1.tar.gz", hash = "sha256:59222f875f85186a22c494aedc65c4e985a3df27e696e5016ba0b98a5ed2cee0"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.2.38"
+ormsgpack = ">=1.12.0"
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "0.6.5"
+description = "Library with high-level APIs for creating and executing LangGraph agents and tools."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "langgraph_prebuilt-0.6.5-py3-none-any.whl", hash = "sha256:b6ceb5db31c16a30a3ee3c0b923667f02e7c9e27852621abf9d5bd5603534141"},
+    {file = "langgraph_prebuilt-0.6.5.tar.gz", hash = "sha256:9c63e9e867e62b345805fd1e8ea5c2df5cc112e939d714f277af84f2afe5950d"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.3.67"
+langgraph-checkpoint = ">=2.1.0,<4.0.0"
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.2.15"
+description = "SDK for interacting with LangGraph API"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langgraph_sdk-0.2.15-py3-none-any.whl", hash = "sha256:746566a5d89aa47160eccc17d71682a78771c754126f6c235a68353d61ed7462"},
+    {file = "langgraph_sdk-0.2.15.tar.gz", hash = "sha256:8faaafe2c1193b89f782dd66c591060cd67862aa6aaf283749b7846f331d5334"},
+]
+
+[package.dependencies]
+httpx = ">=0.25.2"
+orjson = ">=3.10.1"
+
+[[package]]
 name = "langsmith"
 version = "0.7.30"
 description = "Client library to connect to the LangSmith Observability and Evaluation Platform."
@@ -2601,6 +3152,18 @@ files = [
 ]
 
 [[package]]
+name = "logfire-api"
+version = "4.32.1"
+description = "Shim for the Logfire SDK which does nothing unless Logfire is installed"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "logfire_api-4.32.1-py3-none-any.whl", hash = "sha256:4b4c27cf6e27e8e26ef4b22a77f2a2988dd1d07e2d24ee70673ef34b234fb8a5"},
+    {file = "logfire_api-4.32.1.tar.gz", hash = "sha256:5e8714b2bb5fb5d1f4a4a833941e4ca711b75d2c1f98e76c5ad680fe6991af6a"},
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
@@ -2635,6 +3198,30 @@ files = [
 [package.extras]
 docs = ["mdx_gh_links (>=0.2)", "mkdocs (>=1.6)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python] (>=0.28.3)"]
 testing = ["coverage", "pyyaml"]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.1.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "markdown_it_py-4.1.0-py3-none-any.whl", hash = "sha256:d4939a62a2dd0cd9cb80a191a711ba1d39bac8ed5ef9e9966895b0171c01c46d"},
+    {file = "markdown_it_py-4.1.0.tar.gz", hash = "sha256:760e3f87b2787c044c5138a5ba107b7c2be26c03b13cc7f8fe42756b65b1df6c"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "markdown-it-pyrs", "mistletoe (>=1.0,<2.0)", "mistune (>=3.0,<4.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins (>=0.5.0)"]
+profiling = ["gprof2dot"]
+rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "pytest-timeout", "requests"]
 
 [[package]]
 name = "markupsafe"
@@ -2833,6 +3420,80 @@ python-dateutil = ">=2.7"
 
 [package.extras]
 dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setuptools (>=64)", "setuptools_scm (>=7)"]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+description = "Model Context Protocol SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741"},
+    {file = "mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83"},
+]
+
+[package.dependencies]
+anyio = ">=4.5"
+httpx = ">=0.27.1"
+httpx-sse = ">=0.4"
+jsonschema = ">=4.20.0"
+pydantic = ">=2.11.0,<3.0.0"
+pydantic-settings = ">=2.5.2"
+pyjwt = {version = ">=2.10.1", extras = ["crypto"]}
+python-multipart = ">=0.0.9"
+pywin32 = {version = ">=310", markers = "sys_platform == \"win32\""}
+sse-starlette = ">=1.6.1"
+starlette = ">=0.27"
+typing-extensions = ">=4.9.0"
+typing-inspection = ">=0.4.1"
+uvicorn = {version = ">=0.31.1", markers = "sys_platform != \"emscripten\""}
+
+[package.extras]
+cli = ["python-dotenv (>=1.0.0)", "typer (>=0.16.0)"]
+rich = ["rich (>=13.9.4)"]
+ws = ["websockets (>=15.0.1)"]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "mistralai"
+version = "1.12.4"
+description = "Python Client SDK for the Mistral AI API."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "mistralai-1.12.4-py3-none-any.whl", hash = "sha256:7b69fcbc306436491ad3377fbdead527c9f3a0ce145ec029bf04c6308ff2cca6"},
+    {file = "mistralai-1.12.4.tar.gz", hash = "sha256:e52b53bab58025dcd208eeac13e3c3df5778d4112eeca1f08124096c7738929f"},
+]
+
+[package.dependencies]
+eval-type-backport = ">=0.2.0"
+httpx = ">=0.28.1"
+invoke = ">=2.2.0,<3.0.0"
+opentelemetry-api = ">=1.33.1,<2.0.0"
+opentelemetry-exporter-otlp-proto-http = ">=1.37.0,<2.0.0"
+opentelemetry-sdk = ">=1.33.1,<2.0.0"
+pydantic = ">=2.10.3"
+python-dateutil = ">=2.8.2"
+pyyaml = ">=6.0.2,<7.0.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+agents = ["authlib (>=1.5.2,<2.0)", "griffe (>=1.7.3,<2.0)", "mcp (>=1.0,<2.0)"]
+gcp = ["google-auth (>=2.27.0)", "requests (>=2.32.3)"]
+realtime = ["websockets (>=13.0)"]
 
 [[package]]
 name = "mlflow"
@@ -3363,6 +4024,60 @@ importlib-metadata = ">=6.0,<8.8.0"
 typing-extensions = ">=4.5.0"
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+description = "OpenTelemetry Protobuf encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149"},
+    {file = "opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa"},
+]
+
+[package.dependencies]
+opentelemetry-proto = "1.40.0"
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.40.0"
+description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069"},
+    {file = "opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c"},
+]
+
+[package.dependencies]
+googleapis-common-protos = ">=1.52,<2.0"
+opentelemetry-api = ">=1.15,<2.0"
+opentelemetry-exporter-otlp-proto-common = "1.40.0"
+opentelemetry-proto = "1.40.0"
+opentelemetry-sdk = ">=1.40.0,<1.41.0"
+requests = ">=2.7,<3.0"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+gcp-auth = ["opentelemetry-exporter-credential-provider-gcp (>=0.59b0)"]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+description = "OpenTelemetry Python Proto"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f"},
+    {file = "opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd"},
+]
+
+[package.dependencies]
+protobuf = ">=5.0,<7.0"
+
+[[package]]
 name = "opentelemetry-sdk"
 version = "1.40.0"
 description = "OpenTelemetry Python SDK"
@@ -3402,7 +4117,6 @@ description = "Fast, correct Python JSON library supporting dataclasses, datetim
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "orjson-3.11.8-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e6693ff90018600c72fd18d3d22fa438be26076cd3c823da5f63f7bab28c11cb"},
     {file = "orjson-3.11.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93de06bc920854552493c81f1f729fab7213b7db4b8195355db5fda02c7d1363"},
@@ -3478,6 +4192,65 @@ files = [
     {file = "orjson-3.11.8-cp314-cp314-win_amd64.whl", hash = "sha256:735e2262363dcbe05c35e3a8869898022af78f89dde9e256924dc02e99fe69ca"},
     {file = "orjson-3.11.8-cp314-cp314-win_arm64.whl", hash = "sha256:6ccdea2c213cf9f3d9490cbd5d427693c870753df41e6cb375bd79bcbafc8817"},
     {file = "orjson-3.11.8.tar.gz", hash = "sha256:96163d9cdc5a202703e9ad1b9ae757d5f0ca62f4fa0cc93d1f27b0e180cc404e"},
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+description = "Fast, correct Python msgpack library supporting dataclasses, datetimes, and numpy"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "ormsgpack-1.12.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c1429217f8f4d7fcb053523bbbac6bed5e981af0b85ba616e6df7cce53c19657"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f13034dc6c84a6280c6c33db7ac420253852ea233fc3ee27c8875f8dd651163"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:59f5da97000c12bc2d50e988bdc8576b21f6ab4e608489879d35b2c07a8ab51a"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e4459c3f27066beadb2b81ea48a076a417aafffff7df1d3c11c519190ed44f2"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a1c460655d7288407ffa09065e322a7231997c0d62ce914bf3a96ad2dc6dedd"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:458e4568be13d311ef7d8877275e7ccbe06c0e01b39baaac874caaa0f46d826c"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8cde5eaa6c6cbc8622db71e4a23de56828e3d876aeb6460ffbcb5b8aff91093b"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:dc7a33be14c347893edbb1ceda89afbf14c467d593a5ee92c11de4f1666b4d4f"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c"},
+    {file = "ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8"},
+    {file = "ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033"},
+    {file = "ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d"},
+    {file = "ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2"},
+    {file = "ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33"},
 ]
 
 [[package]]
@@ -3780,6 +4553,21 @@ identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+description = "Library for building powerful interactive command lines in Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
+    {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
+]
+
+[package.dependencies]
+wcwidth = "*"
 
 [[package]]
 name = "propcache"
@@ -4146,6 +4934,77 @@ email = ["email-validator (>=2.0.0)"]
 timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows\""]
 
 [[package]]
+name = "pydantic-ai"
+version = "0.2.4"
+description = "Agent Framework / shim to use Pydantic with LLMs"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_ai-0.2.4-py3-none-any.whl", hash = "sha256:557b75f2dbc016e80364c55932f628d91747bf4173b50fb815d9d8e60dc7e4b4"},
+    {file = "pydantic_ai-0.2.4.tar.gz", hash = "sha256:f80820f4b84d35c9155cf5bd79881576eca141f7b7a232ed840811a4307ee0ea"},
+]
+
+[package.dependencies]
+pydantic-ai-slim = {version = "0.2.4", extras = ["a2a", "anthropic", "bedrock", "cli", "cohere", "evals", "groq", "mcp", "mistral", "openai", "vertexai"]}
+
+[package.extras]
+examples = ["pydantic-ai-examples (==0.2.4)"]
+logfire = ["logfire (>=3.11.0)"]
+
+[[package]]
+name = "pydantic-ai-slim"
+version = "0.2.4"
+description = "Agent Framework / shim to use Pydantic with LLMs, slim package"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_ai_slim-0.2.4-py3-none-any.whl", hash = "sha256:dfa4e3ebc559c6d6f84556cba8883dea7e5a8715ca97211d49fdc02d121d8300"},
+    {file = "pydantic_ai_slim-0.2.4.tar.gz", hash = "sha256:498ab56e6b00ce2cc28c7c6da536c78a7665ef1345330bfe025e8376529bd296"},
+]
+
+[package.dependencies]
+anthropic = {version = ">=0.49.0", optional = true, markers = "extra == \"anthropic\""}
+argcomplete = {version = ">=3.5.0", optional = true, markers = "extra == \"cli\""}
+boto3 = {version = ">=1.35.74", optional = true, markers = "extra == \"bedrock\""}
+cohere = {version = ">=5.13.11", optional = true, markers = "platform_system != \"Emscripten\" and extra == \"cohere\""}
+eval-type-backport = ">=0.2.0"
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+fasta2a = {version = "0.2.4", optional = true, markers = "extra == \"a2a\""}
+google-auth = {version = ">=2.36.0", optional = true, markers = "extra == \"vertexai\""}
+griffe = ">=1.3.2"
+groq = {version = ">=0.15.0", optional = true, markers = "extra == \"groq\""}
+httpx = ">=0.27"
+mcp = {version = ">=1.6.0", optional = true, markers = "python_version >= \"3.10\" and extra == \"mcp\""}
+mistralai = {version = ">=1.2.5", optional = true, markers = "extra == \"mistral\""}
+openai = {version = ">=1.75.0", optional = true, markers = "extra == \"openai\""}
+opentelemetry-api = ">=1.28.0"
+prompt-toolkit = {version = ">=3", optional = true, markers = "extra == \"cli\""}
+pydantic = ">=2.10"
+pydantic-evals = {version = "0.2.4", optional = true, markers = "extra == \"evals\""}
+pydantic-graph = "0.2.4"
+requests = {version = ">=2.32.2", optional = true, markers = "extra == \"vertexai\""}
+rich = {version = ">=13", optional = true, markers = "extra == \"cli\""}
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+a2a = ["fasta2a (==0.2.4)"]
+anthropic = ["anthropic (>=0.49.0)"]
+bedrock = ["boto3 (>=1.35.74)"]
+cli = ["argcomplete (>=3.5.0)", "prompt-toolkit (>=3)", "rich (>=13)"]
+cohere = ["cohere (>=5.13.11) ; platform_system != \"Emscripten\""]
+duckduckgo = ["duckduckgo-search (>=7.0.0)"]
+evals = ["pydantic-evals (==0.2.4)"]
+groq = ["groq (>=0.15.0)"]
+logfire = ["logfire (>=3.11.0)"]
+mcp = ["mcp (>=1.6.0) ; python_version >= \"3.10\""]
+mistral = ["mistralai (>=1.2.5)"]
+openai = ["openai (>=1.75.0)"]
+tavily = ["tavily-python (>=0.5.0)"]
+vertexai = ["google-auth (>=2.36.0)", "requests (>=2.32.2)"]
+
+[[package]]
 name = "pydantic-core"
 version = "2.41.5"
 description = "Core functionality for Pydantic validation and serialization"
@@ -4280,6 +5139,48 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pydantic-evals"
+version = "0.2.4"
+description = "Framework for evaluating stochastic code execution, especially code making use of LLMs"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_evals-0.2.4-py3-none-any.whl", hash = "sha256:623bbaead093477def3d6b4c145a6255d20713f5cf2a2402f5ecf76032fc26fd"},
+    {file = "pydantic_evals-0.2.4.tar.gz", hash = "sha256:a5b21e6235975a4b3d40d33c7a76234d6435de07bd6709a2296452933f8ba111"},
+]
+
+[package.dependencies]
+anyio = ">=0"
+eval-type-backport = {version = ">=0", markers = "python_version < \"3.11\""}
+logfire-api = ">=1.2.0"
+pydantic = ">=2.10"
+pydantic-ai-slim = "0.2.4"
+pyyaml = ">=6.0.2"
+rich = ">=13.9.4"
+
+[package.extras]
+logfire = ["logfire (>=2.3)"]
+
+[[package]]
+name = "pydantic-graph"
+version = "0.2.4"
+description = "Graph and state machine library"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_graph-0.2.4-py3-none-any.whl", hash = "sha256:5462205ac7f735190177ee37fb689dd9b8cdc35386a68212518167ec61705eb5"},
+    {file = "pydantic_graph-0.2.4.tar.gz", hash = "sha256:e01cec584b7d53186ff58e0c673d8d55244b87783932028e4b0f49a5800a1e8c"},
+]
+
+[package.dependencies]
+httpx = ">=0.27"
+logfire-api = ">=1.2.0"
+pydantic = ">=2.10"
+typing-inspection = ">=0.4.0"
+
+[[package]]
 name = "pydantic-settings"
 version = "2.13.1"
 description = "Settings management using Pydantic"
@@ -4309,7 +5210,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -4317,6 +5218,28 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pyparsing"
@@ -4464,6 +5387,18 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.27"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"},
+    {file = "python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602"},
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 description = "World timezone definitions, modern and historical"
@@ -4588,6 +5523,23 @@ files = [
     {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
 ]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+description = "JSON Referencing + Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
+    {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+rpds-py = ">=0.7.0"
+typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "regex"
@@ -4751,6 +5703,150 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.9.0"
+groups = ["main"]
+files = [
+    {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
+    {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+description = "Python bindings to Rust's persistent data structures (rpds)"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
+    {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139"},
+    {file = "rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464"},
+    {file = "rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169"},
+    {file = "rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425"},
+    {file = "rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229"},
+    {file = "rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad"},
+    {file = "rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e"},
+    {file = "rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2"},
+    {file = "rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d"},
+    {file = "rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0"},
+    {file = "rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e"},
+    {file = "rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84"},
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.8"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -4777,6 +5873,24 @@ files = [
     {file = "ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2"},
     {file = "ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e"},
 ]
+
+[[package]]
+name = "s3transfer"
+version = "0.17.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20"},
+    {file = "s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
 name = "scikit-learn"
@@ -5044,6 +6158,19 @@ doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx
 test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja ; sys_platform != \"emscripten\"", "pooch", "pytest (>=8.0.0)", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "platform_system != \"Emscripten\""
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -5199,6 +6326,29 @@ dev = ["build"]
 doc = ["sphinx"]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.2"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "sse_starlette-3.4.2-py3-none-any.whl", hash = "sha256:6ea5d35b7ce979a3de5a0db5f77fe886b1616e4b3e1ad93fba502bd9b5fb662f"},
+    {file = "sse_starlette-3.4.2.tar.gz", hash = "sha256:2f9a7f51ed84395a0427fb9f66cb1ec11f7899d977a72cbc9070b962a2e14489"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+starlette = ">=0.49.1"
+
+[package.extras]
+daphne = ["daphne (>=4.2.0)"]
+examples = ["fastapi (>=0.115.12)", "pydantic (>=2)", "uvicorn (>=0.34.0)"]
+examples-db = ["aiosqlite (>=0.21.0)", "sqlalchemy[asyncio] (>=2.0.41)"]
+granian = ["granian (>=2.3.1)"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 description = "The little ASGI library that shines."
@@ -5320,6 +6470,42 @@ requests = ">=2.26.0"
 blobfile = ["blobfile (>=2)"]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+description = ""
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_system != \"Emscripten\""
+files = [
+    {file = "tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224"},
+    {file = "tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e"},
+    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3"},
+    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6"},
+    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959"},
+    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51"},
+    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a"},
+    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4"},
+    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a"},
+    {file = "tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e"},
+    {file = "tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288"},
+    {file = "tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4"},
+    {file = "tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96"},
+    {file = "tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948"},
+    {file = "tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7"},
+    {file = "tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9"},
+    {file = "tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa"},
+]
+
+[package.dependencies]
+huggingface-hub = ">=0.16.4,<2.0"
+
+[package.extras]
+dev = ["tokenizers[testing]"]
+docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
+testing = ["datasets", "numpy", "pytest", "pytest-asyncio", "requests", "ruff", "ty"]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 description = "A lil' TOML parser"
@@ -5400,6 +6586,25 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "typer"
+version = "0.25.1"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_system != \"Emscripten\""
+files = [
+    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
+    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
+]
+
+[package.dependencies]
+annotated-doc = ">=0.0.2"
+click = ">=8.2.1"
+rich = ">=13.8.0"
+shellingham = ">=1.3.0"
+
+[[package]]
 name = "types-psycopg2"
 version = "2.9.21.20260422"
 description = "Typing stubs for psycopg2"
@@ -5417,7 +6622,7 @@ version = "2.33.0.20260327"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "types_requests-2.33.0.20260327-py3-none-any.whl", hash = "sha256:fde0712be6d7c9a4d490042d6323115baf872d9a71a22900809d0432de15776e"},
     {file = "types_requests-2.33.0.20260327.tar.gz", hash = "sha256:f4f74f0b44f059e3db420ff17bd1966e3587cdd34062fe38a23cda97868f8dd8"},
@@ -5781,6 +6986,18 @@ files = [
 
 [package.dependencies]
 anyio = ">=3.0.0"
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2"},
+    {file = "wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"},
+]
 
 [[package]]
 name = "websockets"
@@ -6398,4 +7615,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "01ad613d5a53df03f1429fb5c4504c7f10e778091b831cff5cbff30abd55ff09"
+content-hash = "c04ae8435283bd515edd514b3acbf8ccab5e562d4ca4207e9aef52de2ea71a65"

--- a/poetry.lock
+++ b/poetry.lock
@@ -217,36 +217,6 @@ files = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.100.0"
-description = "The official Python library for the anthropic API"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d"},
-    {file = "anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a"},
-]
-
-[package.dependencies]
-anyio = ">=3.5.0,<5"
-distro = ">=1.7.0,<2"
-docstring-parser = ">=0.15,<1"
-httpx = ">=0.25.0,<1"
-jiter = ">=0.4.0,<1"
-pydantic = ">=1.9.0,<3"
-sniffio = "*"
-typing-extensions = ">=4.14,<5"
-
-[package.extras]
-aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
-aws = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
-bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
-mcp = ["mcp (>=1.0) ; python_version >= \"3.10\""]
-vertex = ["google-auth[requests] (>=2,<3)"]
-webhooks = ["standardwebhooks (>=1.0.1,<2)"]
-
-[[package]]
 name = "anyio"
 version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
@@ -265,21 +235,6 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.32.0)"]
-
-[[package]]
-name = "argcomplete"
-version = "3.6.3"
-description = "Bash tab completion for argparse"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce"},
-    {file = "argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c"},
-]
-
-[package.extras]
-test = ["coverage", "mypy", "pexpect", "ruff", "wheel"]
 
 [[package]]
 name = "async-timeout"
@@ -329,46 +284,6 @@ files = [
     {file = "blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"},
     {file = "blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf"},
 ]
-
-[[package]]
-name = "boto3"
-version = "1.43.5"
-description = "The AWS SDK for Python"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "boto3-1.43.5-py3-none-any.whl", hash = "sha256:aa8a296c8db55d812767b282cfe4c7977f0b0eeaa709abdaeb368b9c738e901f"},
-    {file = "boto3-1.43.5.tar.gz", hash = "sha256:414be7868f25c3b6a0232301c8ab40347911b6b191926b61f00a63f89b97b2bc"},
-]
-
-[package.dependencies]
-botocore = ">=1.43.5,<1.44.0"
-jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.17.0,<0.18.0"
-
-[package.extras]
-crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
-
-[[package]]
-name = "botocore"
-version = "1.43.5"
-description = "Low-level, data-driven core of boto 3."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "botocore-1.43.5-py3-none-any.whl", hash = "sha256:a1df6e0c6346735936f42e6b99f3b28f1e9397731c0bc2563c617df7965a0dc0"},
-    {file = "botocore-1.43.5.tar.gz", hash = "sha256:5c7207816ab5e48382adcb2a64db388fa4abe9ee1d23f72c82ae62c51a0bc84e"},
-]
-
-[package.dependencies]
-jmespath = ">=0.7.1,<2.0.0"
-python-dateutil = ">=2.1,<3.0.0"
-urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
-
-[package.extras]
-crt = ["awscrt (==0.32.2)"]
 
 [[package]]
 name = "cachetools"
@@ -671,33 +586,6 @@ files = [
 ]
 
 [[package]]
-name = "cohere"
-version = "6.1.0"
-description = ""
-optional = false
-python-versions = "<4.0,>=3.10"
-groups = ["main"]
-markers = "platform_system != \"Emscripten\""
-files = [
-    {file = "cohere-6.1.0-py3-none-any.whl", hash = "sha256:ad286b3af2583c75ba93624e6f680603d3578a3d73704f997430260b87537ac7"},
-    {file = "cohere-6.1.0.tar.gz", hash = "sha256:6a52bb459b71b5e79735412ee1a8e87028c5b3afba050c39815fe03c083249b3"},
-]
-
-[package.dependencies]
-fastavro = ">=1.9.4,<2.0.0"
-httpx = ">=0.21.2"
-pydantic = ">=1.9.2"
-pydantic-core = ">=2.18.2,<2.44.0"
-requests = ">=2.0.0,<3.0.0"
-tokenizers = ">=0.15,<1"
-types-requests = ">=2.0.0,<3.0.0"
-typing_extensions = ">=4.0.0"
-
-[package.extras]
-aiohttp = ["aiohttp (>=3.10.0,<4)", "httpx-aiohttp (==0.1.8)"]
-oci = ["oci (>=2.165.0,<3.0.0)"]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -708,7 +596,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {dev = "sys_platform == \"win32\""}
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "contourpy"
@@ -1178,38 +1066,6 @@ ssh = ["paramiko (>=2.4.3)"]
 websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
-name = "docstring-parser"
-version = "0.18.0"
-description = "Parse Python docstrings in reST, Google and Numpydoc format"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"},
-    {file = "docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"},
-]
-
-[package.extras]
-dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
-docs = ["pydoctor (>=25.4.0)"]
-test = ["pytest"]
-
-[[package]]
-name = "eval-type-backport"
-version = "0.3.1"
-description = "Like `typing._eval_type`, but lets older Python versions use newer typing features."
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "eval_type_backport-0.3.1-py3-none-any.whl", hash = "sha256:279ab641905e9f11129f56a8a78f493518515b83402b860f6f06dd7c011fdfa8"},
-    {file = "eval_type_backport-0.3.1.tar.gz", hash = "sha256:57e993f7b5b69d271e37482e62f74e76a0276c82490cf8e4f0dffeb6b332d5ed"},
-]
-
-[package.extras]
-tests = ["pytest"]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -1266,26 +1122,6 @@ tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 tzdata = ["tzdata"]
 
 [[package]]
-name = "fasta2a"
-version = "0.2.4"
-description = "Convert an AI Agent into a A2A server! ✨"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "fasta2a-0.2.4-py3-none-any.whl", hash = "sha256:3d8b71124739030512c6880d8a78d37bd6c9a099b42d3a772f62747ecef829e9"},
-    {file = "fasta2a-0.2.4.tar.gz", hash = "sha256:7afa3fd3205ce3f299b68b2705d285380328a7a4cbd2d230230e66b4701743e8"},
-]
-
-[package.dependencies]
-opentelemetry-api = ">=1.28.0"
-pydantic = ">=2.10"
-starlette = ">0.29.0"
-
-[package.extras]
-logfire = ["logfire (>=2.3)"]
-
-[[package]]
 name = "fastapi"
 version = "0.135.2"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -1310,84 +1146,16 @@ standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "htt
 standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
-name = "fastavro"
-version = "1.12.2"
-description = "Fast read/write of AVRO files"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "platform_system != \"Emscripten\""
-files = [
-    {file = "fastavro-1.12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c7c6d26c731a0e1e8e7d4ae8f13ae524eb6ec0e90d99c8147a19fdbae14eb807"},
-    {file = "fastavro-1.12.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7caeecf519eff50f007ca4bee16b6e0a8252e5fe682c94432192a20867239888"},
-    {file = "fastavro-1.12.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:731aefe6c4bf2bafa0798ef83927676d06e44d1d18202cfb56d63b40422ab900"},
-    {file = "fastavro-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f089f24225a28ddafa5cfad7c41cfa84db1a55f2d473370769a95c0e3bac60c9"},
-    {file = "fastavro-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:653c4f90dd21d8a1e74309919e08934e420d9aef51d051d14bf5a1c0e8293c22"},
-    {file = "fastavro-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:030f17eb4c7978538a31b55dea451ceace851a88dc9816b1923f8fb8a260db4c"},
-    {file = "fastavro-1.12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d48cd7094598a7e9d4297e8bf4bbe0dc9dc2ba4367d83dbb603e3b3c6aa35566"},
-    {file = "fastavro-1.12.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:070c6134604bd7b6fd44409406ac50445339682b2e872885db2e859f92d22e93"},
-    {file = "fastavro-1.12.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b73d50978d5e57416fa68461f9f3c8f39ea39e761cb1e12f919745adefe26a7"},
-    {file = "fastavro-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c57a9920400166398695d92580eca21fd7a79f3c67d691ac7e20a7d1b5300735"},
-    {file = "fastavro-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:81f6108f3ac292fb6cd05758c9e531389d8fc5e94e8c949b9298f4fb0a239662"},
-    {file = "fastavro-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:eec44256856fd59d29d1f1d0950ace18a58e4228e7d49de5d5e1b1875b227dde"},
-    {file = "fastavro-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:ecd1b23ea7f9af09c865ac8503d07afd7e6bf782d76bb83cbbdba15b7a0db807"},
-    {file = "fastavro-1.12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e331896e8efffc72fa03e63b87ebfc37960113127da8e0f5152d91664ffed68"},
-    {file = "fastavro-1.12.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f01ebaada59d74fdf6d28e5031a961a413b3752e9edb0c03866fa18480cf4c8"},
-    {file = "fastavro-1.12.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25ef6855935f67582740ffa6bb978e40ec51be876117a3555c36fa2488dcdf25"},
-    {file = "fastavro-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:84a4f76a0aece0aa72b5ed8162ba2ff8c78908b8361b5a5d92ddd161977ccb74"},
-    {file = "fastavro-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81e8da77d201916f6771fc357fda8267c2a256d7aa11923d43bc5f2fc155878b"},
-    {file = "fastavro-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:1924349c74666c89417bd5cc2749f598e2f15f1d56ee81428b2317ab02c88aae"},
-    {file = "fastavro-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:4c346cf449baf3b113e997c34151ad205e7135bc429469b005b180ade7e65e28"},
-    {file = "fastavro-1.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704"},
-    {file = "fastavro-1.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0"},
-    {file = "fastavro-1.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e"},
-    {file = "fastavro-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea"},
-    {file = "fastavro-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e"},
-    {file = "fastavro-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39"},
-    {file = "fastavro-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36"},
-    {file = "fastavro-1.12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31"},
-    {file = "fastavro-1.12.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef"},
-    {file = "fastavro-1.12.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397"},
-    {file = "fastavro-1.12.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff"},
-    {file = "fastavro-1.12.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423"},
-    {file = "fastavro-1.12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8d37c87826ae7195cfbd20fcd448801f2f563bb38f2691ec6574e39cb9eca6c8"},
-    {file = "fastavro-1.12.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c463a3701f293e30d3d62e71e1989f112028d07f87432baf4507eeb57ec3831"},
-    {file = "fastavro-1.12.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f604ba83498e209fff4c7ecc5063a39421dc538dace694bc592f9f338254f3dc"},
-    {file = "fastavro-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bfac2dada8ddc002e8b7d8289d6fad4f070bc1fec20371cec684a7d10d932e96"},
-    {file = "fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c"},
-    {file = "fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f"},
-    {file = "fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a"},
-    {file = "fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa"},
-    {file = "fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282"},
-    {file = "fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370"},
-    {file = "fastavro-1.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:afede7324822800e4f90e96b9514188a237a60f35e8e7a10b2129c10c78f6e4d"},
-    {file = "fastavro-1.12.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b5539711dfa1ec8f3eca57482b93a48a165af4a99e9d5f41e3af3fb913aadf92"},
-    {file = "fastavro-1.12.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c01b0f0ce030a7b89263c0236ca77923eae352c5f35ecf214b04d3aaea8eb2c3"},
-    {file = "fastavro-1.12.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:742d93f2ca835e4fa83a3ae9ed2bce8b28029ed62ac730f339a37685c23075cd"},
-    {file = "fastavro-1.12.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ae60df21cc7059e2f3b1928ad2c0b75c6b26f9ada79d992f87b6fc3f50d3877e"},
-    {file = "fastavro-1.12.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:03614131093a32c90c8fd95ff356c316752b8850cb8a770bc96cef17a003e2fc"},
-    {file = "fastavro-1.12.2-cp39-cp39-win_amd64.whl", hash = "sha256:e235dfdabb51993bcd4a8f45c3a54f21a782f7f92b3def0648b0ace45a1b1ac7"},
-    {file = "fastavro-1.12.2.tar.gz", hash = "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab"},
-]
-
-[package.extras]
-codecs = ["backports.zstd ; python_version < \"3.14\"", "cramjam", "lz4"]
-lz4 = ["lz4"]
-snappy = ["cramjam"]
-zstandard = ["backports.zstd ; python_version < \"3.14\""]
-
-[[package]]
 name = "filelock"
 version = "3.29.0"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"},
     {file = "filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90"},
 ]
-markers = {main = "platform_system != \"Emscripten\""}
 
 [[package]]
 name = "filetype"
@@ -1637,47 +1405,6 @@ files = [
     {file = "frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d"},
     {file = "frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad"},
 ]
-
-[[package]]
-name = "fsspec"
-version = "2026.4.0"
-description = "File-system specification"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "platform_system != \"Emscripten\""
-files = [
-    {file = "fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2"},
-    {file = "fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4"},
-]
-
-[package.extras]
-abfs = ["adlfs"]
-adl = ["adlfs"]
-arrow = ["pyarrow (>=1)"]
-dask = ["dask", "distributed"]
-dev = ["pre-commit", "ruff (>=0.5)"]
-doc = ["numpydoc", "sphinx", "sphinx-design", "sphinx-rtd-theme", "yarl"]
-dropbox = ["dropbox", "dropboxdrivefs", "requests"]
-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "dask", "distributed", "dropbox", "dropboxdrivefs", "fusepy", "gcsfs (>2024.2.0)", "libarchive-c", "ocifs", "panel", "paramiko", "pyarrow (>=1)", "pygit2", "requests", "s3fs (>2024.2.0)", "smbprotocol", "tqdm"]
-fuse = ["fusepy"]
-gcs = ["gcsfs (>2024.2.0)"]
-git = ["pygit2"]
-github = ["requests"]
-gs = ["gcsfs"]
-gui = ["panel"]
-hdfs = ["pyarrow (>=1)"]
-http = ["aiohttp (!=4.0.0a0,!=4.0.0a1)"]
-libarchive = ["libarchive-c"]
-oci = ["ocifs"]
-s3 = ["s3fs (>2024.2.0)"]
-sftp = ["paramiko"]
-smb = ["smbprotocol"]
-ssh = ["paramiko"]
-test = ["aiohttp (!=4.0.0a0,!=4.0.0a1)", "numpy", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "requests"]
-test-downstream = ["aiobotocore (>=2.5.4,<3.0.0)", "dask[dataframe,test]", "moto[server] (>4,<5)", "pytest-timeout", "xarray"]
-test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "backports-zstd ; python_version < \"3.14\"", "cloudpickle", "dask", "distributed", "dropbox", "dropboxdrivefs", "fastparquet", "fusepy", "gcsfs", "jinja2", "kerchunk", "libarchive-c", "lz4", "notebook", "numpy", "ocifs", "pandas (<3.0.0)", "panel", "paramiko", "pyarrow", "pyarrow (>=1)", "pyftpdlib", "pygit2", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "python-snappy", "requests", "smbprotocol", "tqdm", "urllib3", "zarr", "zstandard ; python_version < \"3.14\""]
-tqdm = ["tqdm"]
 
 [[package]]
 name = "gitdb"
@@ -1956,79 +1683,6 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil", "setuptools"]
 
 [[package]]
-name = "griffe"
-version = "2.0.2"
-description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "griffe-2.0.2-py3-none-any.whl", hash = "sha256:2b31816460aee1996af26050a1fc6927a2e5936486856707f55508e4c9b5960b"},
-    {file = "griffe-2.0.2.tar.gz", hash = "sha256:c5d56326d159f274492e9bf93a9895cec101155d944caa66d0fc4e0c13751b92"},
-]
-
-[package.dependencies]
-griffecli = "2.0.2"
-griffelib = "2.0.2"
-
-[package.extras]
-pypi = ["griffelib[pypi] (==2.0.2)"]
-
-[[package]]
-name = "griffecli"
-version = "2.0.2"
-description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "griffecli-2.0.2-py3-none-any.whl", hash = "sha256:0d44d39e59afa81e288a3e1c3bf352cc4fa537483326ac06b8bb6a51fd8303a0"},
-    {file = "griffecli-2.0.2.tar.gz", hash = "sha256:40a1ad4181fc39685d025e119ae2c5b669acdc1f19b705fb9bf971f4e6f6dffb"},
-]
-
-[package.dependencies]
-colorama = ">=0.4"
-griffelib = "2.0.2"
-
-[[package]]
-name = "griffelib"
-version = "2.0.2"
-description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1"},
-    {file = "griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e"},
-]
-
-[package.extras]
-pypi = ["pip (>=24.0)", "platformdirs (>=4.2)", "wheel (>=0.42)"]
-
-[[package]]
-name = "groq"
-version = "1.2.0"
-description = "The official Python library for the groq API"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "groq-1.2.0-py3-none-any.whl", hash = "sha256:1002060a743b27c8f86765e1bc9749c98498e961d9fe2e4902bf7804a71c3c84"},
-    {file = "groq-1.2.0.tar.gz", hash = "sha256:85459e27c9c17f22404349c785cd08680362cfe85e07cc060be46c4832f108c3"},
-]
-
-[package.dependencies]
-anyio = ">=3.5.0,<5"
-distro = ">=1.7.0,<2"
-httpx = ">=0.23.0,<1"
-pydantic = ">=1.9.0,<3"
-sniffio = "*"
-typing-extensions = ">=4.14,<5"
-
-[package.extras]
-aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
-
-[[package]]
 name = "grpcio"
 version = "1.80.0"
 description = "HTTP/2-based RPC framework"
@@ -2158,45 +1812,6 @@ files = [
 ]
 
 [[package]]
-name = "hf-xet"
-version = "1.5.0"
-description = "Fast transfer of large files with the Hugging Face Hub."
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "(platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and platform_system != \"Emscripten\""
-files = [
-    {file = "hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c"},
-    {file = "hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42"},
-    {file = "hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a"},
-    {file = "hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480"},
-    {file = "hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216"},
-    {file = "hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60"},
-    {file = "hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d"},
-    {file = "hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4"},
-    {file = "hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c"},
-    {file = "hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73"},
-    {file = "hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682"},
-    {file = "hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761"},
-    {file = "hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded"},
-    {file = "hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702"},
-    {file = "hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e"},
-    {file = "hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0"},
-    {file = "hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56"},
-    {file = "hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a"},
-    {file = "hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949"},
-    {file = "hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b"},
-    {file = "hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18"},
-    {file = "hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690"},
-    {file = "hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4"},
-    {file = "hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be"},
-    {file = "hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948"},
-]
-
-[package.extras]
-tests = ["pytest"]
-
-[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -2309,43 +1924,6 @@ files = [
 ]
 
 [[package]]
-name = "huggingface-hub"
-version = "1.14.0"
-description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
-optional = false
-python-versions = ">=3.10.0"
-groups = ["main"]
-markers = "platform_system != \"Emscripten\""
-files = [
-    {file = "huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8"},
-    {file = "huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2"},
-]
-
-[package.dependencies]
-filelock = ">=3.10.0"
-fsspec = ">=2023.5.0"
-hf-xet = {version = ">=1.4.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
-httpx = ">=0.23.0,<1"
-packaging = ">=20.9"
-pyyaml = ">=5.1"
-tqdm = ">=4.42.1"
-typer = ">=0.20.0"
-typing-extensions = ">=4.1.0"
-
-[package.extras]
-all = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0)", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
-dev = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0)", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
-fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
-gradio = ["gradio (>=5.0.0)", "requests"]
-hf-xet = ["hf-xet (>=1.4.3,<2.0.0)"]
-mcp = ["mcp (>=1.8.0)"]
-oauth = ["authlib (>=1.3.2)", "fastapi", "httpx", "itsdangerous"]
-quality = ["libcst (>=1.4.0)", "mypy (==1.15.0)", "ruff (>=0.9.0)", "ty"]
-testing = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
-torch = ["safetensors[torch]", "torch"]
-typing = ["types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
-
-[[package]]
 name = "identify"
 version = "2.6.19"
 description = "File identification library for Python"
@@ -2409,18 +1987,6 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
-]
-
-[[package]]
-name = "invoke"
-version = "2.2.1"
-description = "Pythonic task execution"
-optional = false
-python-versions = ">=3.6"
-groups = ["main"]
-files = [
-    {file = "invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8"},
-    {file = "invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707"},
 ]
 
 [[package]]
@@ -2566,18 +2132,6 @@ files = [
 ]
 
 [[package]]
-name = "jmespath"
-version = "1.1.0"
-description = "JSON Matching Expressions"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
-    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
-]
-
-[[package]]
 name = "joblib"
 version = "1.5.3"
 description = "Lightweight pipelining with Python functions"
@@ -2615,43 +2169,6 @@ files = [
     {file = "jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca"},
     {file = "jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900"},
 ]
-
-[[package]]
-name = "jsonschema"
-version = "4.26.0"
-description = "An implementation of JSON Schema validation for Python"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
-    {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-jsonschema-specifications = ">=2023.03.6"
-referencing = ">=0.28.4"
-rpds-py = ">=0.25.0"
-
-[package.extras]
-format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "rfc3987-syntax (>=1.1.0)", "uri-template", "webcolors (>=24.6.0)"]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2025.9.1"
-description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
-    {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
-]
-
-[package.dependencies]
-referencing = ">=0.31.0"
 
 [[package]]
 name = "kiwisolver"
@@ -3152,18 +2669,6 @@ files = [
 ]
 
 [[package]]
-name = "logfire-api"
-version = "4.32.1"
-description = "Shim for the Logfire SDK which does nothing unless Logfire is installed"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "logfire_api-4.32.1-py3-none-any.whl", hash = "sha256:4b4c27cf6e27e8e26ef4b22a77f2a2988dd1d07e2d24ee70673ef34b234fb8a5"},
-    {file = "logfire_api-4.32.1.tar.gz", hash = "sha256:5e8714b2bb5fb5d1f4a4a833941e4ca711b75d2c1f98e76c5ad680fe6991af6a"},
-]
-
-[[package]]
 name = "mako"
 version = "1.3.10"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
@@ -3198,30 +2703,6 @@ files = [
 [package.extras]
 docs = ["mdx_gh_links (>=0.2)", "mkdocs (>=1.6)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python] (>=0.28.3)"]
 testing = ["coverage", "pyyaml"]
-
-[[package]]
-name = "markdown-it-py"
-version = "4.1.0"
-description = "Python port of markdown-it. Markdown parsing, done right!"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "markdown_it_py-4.1.0-py3-none-any.whl", hash = "sha256:d4939a62a2dd0cd9cb80a191a711ba1d39bac8ed5ef9e9966895b0171c01c46d"},
-    {file = "markdown_it_py-4.1.0.tar.gz", hash = "sha256:760e3f87b2787c044c5138a5ba107b7c2be26c03b13cc7f8fe42756b65b1df6c"},
-]
-
-[package.dependencies]
-mdurl = ">=0.1,<1.0"
-
-[package.extras]
-benchmarking = ["psutil", "pytest", "pytest-benchmark"]
-compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "markdown-it-pyrs", "mistletoe (>=1.0,<2.0)", "mistune (>=3.0,<4.0)", "panflute (>=2.3,<3.0)"]
-linkify = ["linkify-it-py (>=1,<3)"]
-plugins = ["mdit-py-plugins (>=0.5.0)"]
-profiling = ["gprof2dot"]
-rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
-testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "pytest-timeout", "requests"]
 
 [[package]]
 name = "markupsafe"
@@ -3420,80 +2901,6 @@ python-dateutil = ">=2.7"
 
 [package.extras]
 dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setuptools (>=64)", "setuptools_scm (>=7)"]
-
-[[package]]
-name = "mcp"
-version = "1.27.0"
-description = "Model Context Protocol SDK"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741"},
-    {file = "mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83"},
-]
-
-[package.dependencies]
-anyio = ">=4.5"
-httpx = ">=0.27.1"
-httpx-sse = ">=0.4"
-jsonschema = ">=4.20.0"
-pydantic = ">=2.11.0,<3.0.0"
-pydantic-settings = ">=2.5.2"
-pyjwt = {version = ">=2.10.1", extras = ["crypto"]}
-python-multipart = ">=0.0.9"
-pywin32 = {version = ">=310", markers = "sys_platform == \"win32\""}
-sse-starlette = ">=1.6.1"
-starlette = ">=0.27"
-typing-extensions = ">=4.9.0"
-typing-inspection = ">=0.4.1"
-uvicorn = {version = ">=0.31.1", markers = "sys_platform != \"emscripten\""}
-
-[package.extras]
-cli = ["python-dotenv (>=1.0.0)", "typer (>=0.16.0)"]
-rich = ["rich (>=13.9.4)"]
-ws = ["websockets (>=15.0.1)"]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-description = "Markdown URL utilities"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
-    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
-]
-
-[[package]]
-name = "mistralai"
-version = "1.12.4"
-description = "Python Client SDK for the Mistral AI API."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "mistralai-1.12.4-py3-none-any.whl", hash = "sha256:7b69fcbc306436491ad3377fbdead527c9f3a0ce145ec029bf04c6308ff2cca6"},
-    {file = "mistralai-1.12.4.tar.gz", hash = "sha256:e52b53bab58025dcd208eeac13e3c3df5778d4112eeca1f08124096c7738929f"},
-]
-
-[package.dependencies]
-eval-type-backport = ">=0.2.0"
-httpx = ">=0.28.1"
-invoke = ">=2.2.0,<3.0.0"
-opentelemetry-api = ">=1.33.1,<2.0.0"
-opentelemetry-exporter-otlp-proto-http = ">=1.37.0,<2.0.0"
-opentelemetry-sdk = ">=1.33.1,<2.0.0"
-pydantic = ">=2.10.3"
-python-dateutil = ">=2.8.2"
-pyyaml = ">=6.0.2,<7.0.0"
-typing-inspection = ">=0.4.0"
-
-[package.extras]
-agents = ["authlib (>=1.5.2,<2.0)", "griffe (>=1.7.3,<2.0)", "mcp (>=1.0,<2.0)"]
-gcp = ["google-auth (>=2.27.0)", "requests (>=2.32.3)"]
-realtime = ["websockets (>=13.0)"]
 
 [[package]]
 name = "mlflow"
@@ -4024,60 +3431,6 @@ importlib-metadata = ">=6.0,<8.8.0"
 typing-extensions = ">=4.5.0"
 
 [[package]]
-name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.40.0"
-description = "OpenTelemetry Protobuf encoding"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149"},
-    {file = "opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa"},
-]
-
-[package.dependencies]
-opentelemetry-proto = "1.40.0"
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.40.0"
-description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069"},
-    {file = "opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c"},
-]
-
-[package.dependencies]
-googleapis-common-protos = ">=1.52,<2.0"
-opentelemetry-api = ">=1.15,<2.0"
-opentelemetry-exporter-otlp-proto-common = "1.40.0"
-opentelemetry-proto = "1.40.0"
-opentelemetry-sdk = ">=1.40.0,<1.41.0"
-requests = ">=2.7,<3.0"
-typing-extensions = ">=4.5.0"
-
-[package.extras]
-gcp-auth = ["opentelemetry-exporter-credential-provider-gcp (>=0.59b0)"]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "1.40.0"
-description = "OpenTelemetry Python Proto"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f"},
-    {file = "opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd"},
-]
-
-[package.dependencies]
-protobuf = ">=5.0,<7.0"
-
-[[package]]
 name = "opentelemetry-sdk"
 version = "1.40.0"
 description = "OpenTelemetry Python SDK"
@@ -4555,21 +3908,6 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
-name = "prompt-toolkit"
-version = "3.0.52"
-description = "Library for building powerful interactive command lines in Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
-    {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
-]
-
-[package.dependencies]
-wcwidth = "*"
-
-[[package]]
 name = "propcache"
 version = "0.4.1"
 description = "Accelerated property cache"
@@ -4934,77 +4272,6 @@ email = ["email-validator (>=2.0.0)"]
 timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows\""]
 
 [[package]]
-name = "pydantic-ai"
-version = "0.2.4"
-description = "Agent Framework / shim to use Pydantic with LLMs"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "pydantic_ai-0.2.4-py3-none-any.whl", hash = "sha256:557b75f2dbc016e80364c55932f628d91747bf4173b50fb815d9d8e60dc7e4b4"},
-    {file = "pydantic_ai-0.2.4.tar.gz", hash = "sha256:f80820f4b84d35c9155cf5bd79881576eca141f7b7a232ed840811a4307ee0ea"},
-]
-
-[package.dependencies]
-pydantic-ai-slim = {version = "0.2.4", extras = ["a2a", "anthropic", "bedrock", "cli", "cohere", "evals", "groq", "mcp", "mistral", "openai", "vertexai"]}
-
-[package.extras]
-examples = ["pydantic-ai-examples (==0.2.4)"]
-logfire = ["logfire (>=3.11.0)"]
-
-[[package]]
-name = "pydantic-ai-slim"
-version = "0.2.4"
-description = "Agent Framework / shim to use Pydantic with LLMs, slim package"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "pydantic_ai_slim-0.2.4-py3-none-any.whl", hash = "sha256:dfa4e3ebc559c6d6f84556cba8883dea7e5a8715ca97211d49fdc02d121d8300"},
-    {file = "pydantic_ai_slim-0.2.4.tar.gz", hash = "sha256:498ab56e6b00ce2cc28c7c6da536c78a7665ef1345330bfe025e8376529bd296"},
-]
-
-[package.dependencies]
-anthropic = {version = ">=0.49.0", optional = true, markers = "extra == \"anthropic\""}
-argcomplete = {version = ">=3.5.0", optional = true, markers = "extra == \"cli\""}
-boto3 = {version = ">=1.35.74", optional = true, markers = "extra == \"bedrock\""}
-cohere = {version = ">=5.13.11", optional = true, markers = "platform_system != \"Emscripten\" and extra == \"cohere\""}
-eval-type-backport = ">=0.2.0"
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
-fasta2a = {version = "0.2.4", optional = true, markers = "extra == \"a2a\""}
-google-auth = {version = ">=2.36.0", optional = true, markers = "extra == \"vertexai\""}
-griffe = ">=1.3.2"
-groq = {version = ">=0.15.0", optional = true, markers = "extra == \"groq\""}
-httpx = ">=0.27"
-mcp = {version = ">=1.6.0", optional = true, markers = "python_version >= \"3.10\" and extra == \"mcp\""}
-mistralai = {version = ">=1.2.5", optional = true, markers = "extra == \"mistral\""}
-openai = {version = ">=1.75.0", optional = true, markers = "extra == \"openai\""}
-opentelemetry-api = ">=1.28.0"
-prompt-toolkit = {version = ">=3", optional = true, markers = "extra == \"cli\""}
-pydantic = ">=2.10"
-pydantic-evals = {version = "0.2.4", optional = true, markers = "extra == \"evals\""}
-pydantic-graph = "0.2.4"
-requests = {version = ">=2.32.2", optional = true, markers = "extra == \"vertexai\""}
-rich = {version = ">=13", optional = true, markers = "extra == \"cli\""}
-typing-inspection = ">=0.4.0"
-
-[package.extras]
-a2a = ["fasta2a (==0.2.4)"]
-anthropic = ["anthropic (>=0.49.0)"]
-bedrock = ["boto3 (>=1.35.74)"]
-cli = ["argcomplete (>=3.5.0)", "prompt-toolkit (>=3)", "rich (>=13)"]
-cohere = ["cohere (>=5.13.11) ; platform_system != \"Emscripten\""]
-duckduckgo = ["duckduckgo-search (>=7.0.0)"]
-evals = ["pydantic-evals (==0.2.4)"]
-groq = ["groq (>=0.15.0)"]
-logfire = ["logfire (>=3.11.0)"]
-mcp = ["mcp (>=1.6.0) ; python_version >= \"3.10\""]
-mistral = ["mistralai (>=1.2.5)"]
-openai = ["openai (>=1.75.0)"]
-tavily = ["tavily-python (>=0.5.0)"]
-vertexai = ["google-auth (>=2.36.0)", "requests (>=2.32.2)"]
-
-[[package]]
 name = "pydantic-core"
 version = "2.41.5"
 description = "Core functionality for Pydantic validation and serialization"
@@ -5139,48 +4406,6 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
-name = "pydantic-evals"
-version = "0.2.4"
-description = "Framework for evaluating stochastic code execution, especially code making use of LLMs"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "pydantic_evals-0.2.4-py3-none-any.whl", hash = "sha256:623bbaead093477def3d6b4c145a6255d20713f5cf2a2402f5ecf76032fc26fd"},
-    {file = "pydantic_evals-0.2.4.tar.gz", hash = "sha256:a5b21e6235975a4b3d40d33c7a76234d6435de07bd6709a2296452933f8ba111"},
-]
-
-[package.dependencies]
-anyio = ">=0"
-eval-type-backport = {version = ">=0", markers = "python_version < \"3.11\""}
-logfire-api = ">=1.2.0"
-pydantic = ">=2.10"
-pydantic-ai-slim = "0.2.4"
-pyyaml = ">=6.0.2"
-rich = ">=13.9.4"
-
-[package.extras]
-logfire = ["logfire (>=2.3)"]
-
-[[package]]
-name = "pydantic-graph"
-version = "0.2.4"
-description = "Graph and state machine library"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "pydantic_graph-0.2.4-py3-none-any.whl", hash = "sha256:5462205ac7f735190177ee37fb689dd9b8cdc35386a68212518167ec61705eb5"},
-    {file = "pydantic_graph-0.2.4.tar.gz", hash = "sha256:e01cec584b7d53186ff58e0c673d8d55244b87783932028e4b0f49a5800a1e8c"},
-]
-
-[package.dependencies]
-httpx = ">=0.27"
-logfire-api = ">=1.2.0"
-pydantic = ">=2.10"
-typing-inspection = ">=0.4.0"
-
-[[package]]
 name = "pydantic-settings"
 version = "2.13.1"
 description = "Settings management using Pydantic"
@@ -5210,7 +4435,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -5218,28 +4443,6 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
-
-[[package]]
-name = "pyjwt"
-version = "2.12.1"
-description = "JSON Web Token implementation in Python"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
-    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
-]
-
-[package.dependencies]
-cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
-typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
-
-[package.extras]
-crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pyparsing"
@@ -5387,18 +4590,6 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
-name = "python-multipart"
-version = "0.0.27"
-description = "A streaming multipart parser for Python"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"},
-    {file = "python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602"},
-]
-
-[[package]]
 name = "pytz"
 version = "2026.1.post1"
 description = "World timezone definitions, modern and historical"
@@ -5523,23 +4714,6 @@ files = [
     {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
 ]
-
-[[package]]
-name = "referencing"
-version = "0.37.0"
-description = "JSON Referencing + Python"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
-    {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-rpds-py = ">=0.7.0"
-typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "regex"
@@ -5703,150 +4877,6 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
-name = "rich"
-version = "15.0.0"
-description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-optional = false
-python-versions = ">=3.9.0"
-groups = ["main"]
-files = [
-    {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
-    {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
-]
-
-[package.dependencies]
-markdown-it-py = ">=2.2.0"
-pygments = ">=2.13.0,<3.0.0"
-
-[package.extras]
-jupyter = ["ipywidgets (>=7.5.1,<9)"]
-
-[[package]]
-name = "rpds-py"
-version = "0.30.0"
-description = "Python bindings to Rust's persistent data structures (rpds)"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
-    {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
-    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6"},
-    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7"},
-    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324"},
-    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df"},
-    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3"},
-    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221"},
-    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7"},
-    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff"},
-    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7"},
-    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139"},
-    {file = "rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464"},
-    {file = "rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169"},
-    {file = "rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425"},
-    {file = "rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d"},
-    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4"},
-    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f"},
-    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4"},
-    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97"},
-    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89"},
-    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d"},
-    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038"},
-    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7"},
-    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed"},
-    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85"},
-    {file = "rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c"},
-    {file = "rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825"},
-    {file = "rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229"},
-    {file = "rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad"},
-    {file = "rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05"},
-    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28"},
-    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd"},
-    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f"},
-    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1"},
-    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23"},
-    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6"},
-    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51"},
-    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5"},
-    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e"},
-    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394"},
-    {file = "rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf"},
-    {file = "rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b"},
-    {file = "rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e"},
-    {file = "rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2"},
-    {file = "rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8"},
-    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4"},
-    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136"},
-    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7"},
-    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2"},
-    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6"},
-    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e"},
-    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d"},
-    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7"},
-    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31"},
-    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95"},
-    {file = "rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d"},
-    {file = "rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15"},
-    {file = "rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6"},
-    {file = "rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d"},
-    {file = "rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0"},
-    {file = "rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be"},
-    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f"},
-    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f"},
-    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87"},
-    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18"},
-    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad"},
-    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07"},
-    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f"},
-    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65"},
-    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f"},
-    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53"},
-    {file = "rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed"},
-    {file = "rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950"},
-    {file = "rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0"},
-    {file = "rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4"},
-    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e"},
-    {file = "rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84"},
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.8"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -5873,24 +4903,6 @@ files = [
     {file = "ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2"},
     {file = "ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e"},
 ]
-
-[[package]]
-name = "s3transfer"
-version = "0.17.0"
-description = "An Amazon S3 Transfer Manager"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20"},
-    {file = "s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a"},
-]
-
-[package.dependencies]
-botocore = ">=1.37.4,<2.0a.0"
-
-[package.extras]
-crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
 name = "scikit-learn"
@@ -6158,19 +5170,6 @@ doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx
 test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja ; sys_platform != \"emscripten\"", "pooch", "pytest (>=8.0.0)", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-description = "Tool to Detect Surrounding Shell"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-markers = "platform_system != \"Emscripten\""
-files = [
-    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
-    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -6326,29 +5325,6 @@ dev = ["build"]
 doc = ["sphinx"]
 
 [[package]]
-name = "sse-starlette"
-version = "3.4.2"
-description = "SSE plugin for Starlette"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "sse_starlette-3.4.2-py3-none-any.whl", hash = "sha256:6ea5d35b7ce979a3de5a0db5f77fe886b1616e4b3e1ad93fba502bd9b5fb662f"},
-    {file = "sse_starlette-3.4.2.tar.gz", hash = "sha256:2f9a7f51ed84395a0427fb9f66cb1ec11f7899d977a72cbc9070b962a2e14489"},
-]
-
-[package.dependencies]
-anyio = ">=4.7.0"
-starlette = ">=0.49.1"
-
-[package.extras]
-daphne = ["daphne (>=4.2.0)"]
-examples = ["fastapi (>=0.115.12)", "pydantic (>=2)", "uvicorn (>=0.34.0)"]
-examples-db = ["aiosqlite (>=0.21.0)", "sqlalchemy[asyncio] (>=2.0.41)"]
-granian = ["granian (>=2.3.1)"]
-uvicorn = ["uvicorn (>=0.34.0)"]
-
-[[package]]
 name = "starlette"
 version = "1.0.0"
 description = "The little ASGI library that shines."
@@ -6470,42 +5446,6 @@ requests = ">=2.26.0"
 blobfile = ["blobfile (>=2)"]
 
 [[package]]
-name = "tokenizers"
-version = "0.23.1"
-description = ""
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "platform_system != \"Emscripten\""
-files = [
-    {file = "tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224"},
-    {file = "tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e"},
-    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3"},
-    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6"},
-    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959"},
-    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51"},
-    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a"},
-    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4"},
-    {file = "tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a"},
-    {file = "tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e"},
-    {file = "tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288"},
-    {file = "tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4"},
-    {file = "tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96"},
-    {file = "tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948"},
-    {file = "tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7"},
-    {file = "tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9"},
-    {file = "tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa"},
-]
-
-[package.dependencies]
-huggingface-hub = ">=0.16.4,<2.0"
-
-[package.extras]
-dev = ["tokenizers[testing]"]
-docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
-testing = ["datasets", "numpy", "pytest", "pytest-asyncio", "requests", "ruff", "ty"]
-
-[[package]]
 name = "tomli"
 version = "2.4.1"
 description = "A lil' TOML parser"
@@ -6586,25 +5526,6 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
-name = "typer"
-version = "0.25.1"
-description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "platform_system != \"Emscripten\""
-files = [
-    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
-    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
-]
-
-[package.dependencies]
-annotated-doc = ">=0.0.2"
-click = ">=8.2.1"
-rich = ">=13.8.0"
-shellingham = ">=1.3.0"
-
-[[package]]
 name = "types-psycopg2"
 version = "2.9.21.20260422"
 description = "Typing stubs for psycopg2"
@@ -6622,7 +5543,7 @@ version = "2.33.0.20260327"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "types_requests-2.33.0.20260327-py3-none-any.whl", hash = "sha256:fde0712be6d7c9a4d490042d6323115baf872d9a71a22900809d0432de15776e"},
     {file = "types_requests-2.33.0.20260327.tar.gz", hash = "sha256:f4f74f0b44f059e3db420ff17bd1966e3587cdd34062fe38a23cda97868f8dd8"},
@@ -6986,18 +5907,6 @@ files = [
 
 [package.dependencies]
 anyio = ">=3.0.0"
-
-[[package]]
-name = "wcwidth"
-version = "0.7.0"
-description = "Measures the displayed width of unicode strings in a terminal"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2"},
-    {file = "wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"},
-]
 
 [[package]]
 name = "websockets"
@@ -7615,4 +6524,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "c04ae8435283bd515edd514b3acbf8ccab5e562d4ca4207e9aef52de2ea71a65"
+content-hash = "4ea19ffcb9fab83cb9737da700f08dae4ae85f2b3203c2aec2293a227c509a48"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ langchain-community = ">=0.2.0,<1.0.0"
 langchain-google-genai = ">=1.0.0,<3.0.0"
 langchain-openai = ">=0.1.0,<1.0.0"
 langgraph = ">=0.2.0,<1.0.0"
-pydantic-ai = ">=0.0.40,<1.0.0"
 mlflow = ">=2.12.0,<3.0.0"
 tiktoken = ">=0.7.0,<1.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ langchain = ">=0.2.0,<1.0.0"
 langchain-community = ">=0.2.0,<1.0.0"
 langchain-google-genai = ">=1.0.0,<3.0.0"
 langchain-openai = ">=0.1.0,<1.0.0"
+langgraph = ">=0.2.0,<1.0.0"
+pydantic-ai = ">=0.0.40,<1.0.0"
 mlflow = ">=2.12.0,<3.0.0"
 tiktoken = ">=0.7.0,<1.0.0"
 

--- a/tests/integration/test_agent_graph.py
+++ b/tests/integration/test_agent_graph.py
@@ -1,0 +1,79 @@
+"""Integration test for the agent graph.
+
+Exercises the agent against the real Postgres + pgvector retrieval stack. The
+LLM is still stubbed because we don't want to spend real tokens / require an
+API key in CI; the point of this test is that the *retrieval* tools query a
+live database successfully.
+
+Run with:
+    make db-up
+    APP_ENV=integration poetry run pytest tests/integration/test_agent_graph.py
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("APP_ENV", "test") != "integration",
+    reason="Set APP_ENV=integration and provide a real DATABASE_URL to run integration tests.",
+)
+
+from langchain_core.callbacks import CallbackManagerForLLMRun  # noqa: E402
+from langchain_core.language_models.chat_models import BaseChatModel  # noqa: E402
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage  # noqa: E402
+from langchain_core.outputs import ChatGeneration, ChatResult  # noqa: E402
+
+from app.agent.graph import build_agent_graph  # noqa: E402
+from app.agent.state import ItineraryState  # noqa: E402
+
+
+class _SemanticSearchOnceLLM(BaseChatModel):
+    """Issues one semantic_search call against the real DB, then finalizes."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "semantic-search-once"
+
+    _step: int = 0
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self._step == 0:
+            self._step += 1
+            msg = AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "semantic_search",
+                        "id": "call-1",
+                        "args": {"query": "cocktail bar in San Francisco", "k": 3},
+                    }
+                ],
+            )
+        else:
+            msg = AIMessage(content="Done.", tool_calls=[])
+        return ChatResult(generations=[ChatGeneration(message=msg)])
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> _SemanticSearchOnceLLM:
+        return self
+
+
+def test_agent_graph_against_real_database() -> None:
+    graph = build_agent_graph(_SemanticSearchOnceLLM(), max_steps=4)
+    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="cocktail bar tonight")]))
+    assert out["done"] is True
+    # Whatever the DB returns (could be empty if seed not run), the scratch
+    # entry exists and either holds rows or an error dict — never silent loss.
+    assert "semantic_search" in out["scratch"]
+    entry = out["scratch"]["semantic_search"][0]
+    assert entry["args"]["query"] == "cocktail bar in San Francisco"
+    assert "result" in entry

--- a/tests/integration/test_agent_graph.py
+++ b/tests/integration/test_agent_graph.py
@@ -67,9 +67,11 @@ class _SemanticSearchOnceLLM(BaseChatModel):
         return self
 
 
-def test_agent_graph_against_real_database() -> None:
+async def test_agent_graph_against_real_database() -> None:
     graph = build_agent_graph(_SemanticSearchOnceLLM(), max_steps=4)
-    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="cocktail bar tonight")]))
+    out = await graph.ainvoke(
+        ItineraryState(messages=[HumanMessage(content="cocktail bar tonight")])
+    )
     assert out["done"] is True
     # Whatever the DB returns (could be empty if seed not run), the scratch
     # entry exists and either holds rows or an error dict — never silent loss.

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -1,0 +1,173 @@
+"""Integration of the graph with a fake LLM that emits a scripted sequence
+of tool calls. Verifies plan->act->critique loops correctly and terminates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from app.agent.graph import build_agent_graph
+from app.agent.state import ItineraryState
+from app.tools.retrieval import PlaceHit
+
+
+class _ScriptedLLM(BaseChatModel):
+    """Test double that returns scripted AIMessages in order."""
+
+    scripted: list[AIMessage]
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted"
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if not self.scripted:
+            raise RuntimeError("scripted responses exhausted")
+        msg = self.scripted.pop(0)
+        return ChatResult(generations=[ChatGeneration(message=msg)])
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> _ScriptedLLM:
+        return self
+
+
+def _make_fake(scripted: list[AIMessage]) -> _ScriptedLLM:
+    return _ScriptedLLM(scripted=list(scripted))
+
+
+def test_graph_terminates_on_no_tool_call() -> None:
+    fake = _make_fake([AIMessage(content="here is your plan", tool_calls=[])])
+    graph = build_agent_graph(fake, max_steps=4)
+    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    assert out["done"] is True
+    assert out["final_reply"] == "here is your plan"
+
+
+def test_graph_executes_tool_and_continues(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.agent.tools._semantic_search",
+        lambda **kw: [
+            PlaceHit(
+                place_id="p1",
+                name="X",
+                source="google_places",
+                similarity=0.9,
+                latitude=None,
+                longitude=None,
+                rating=4.5,
+                price_level="PRICE_LEVEL_MODERATE",
+                business_status="OPERATIONAL",
+                primary_type="restaurant",
+                formatted_address="123 Main",
+                snippet=None,
+            )
+        ],
+    )
+    fake = _make_fake(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "semantic_search",
+                        "id": "1",
+                        "args": {"query": "italian", "k": 3},
+                    }
+                ],
+            ),
+            AIMessage(content="found one place", tool_calls=[]),
+        ]
+    )
+    graph = build_agent_graph(fake, max_steps=4)
+    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="italian please")]))
+    assert out["step_count"] == 1
+    assert "semantic_search" in out["scratch"]
+    assert out["scratch"]["semantic_search"][0]["args"] == {"query": "italian", "k": 3}
+    assert out["done"] is True
+
+
+def test_graph_respects_max_steps() -> None:
+    looping = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "semantic_search",
+                    "id": str(i),
+                    "args": {"query": "x"},
+                }
+            ],
+        )
+        for i in range(20)
+    ]
+    fake = _make_fake(looping)
+    graph = build_agent_graph(fake, max_steps=3)
+    # Patch the underlying retrieval so the tool calls don't hit the DB.
+    import app.agent.tools as tools_mod
+
+    tools_mod._semantic_search = lambda **kw: []  # type: ignore[assignment]
+
+    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="x")]))
+    assert out["step_count"] == 3
+    assert out["done"] is True
+    assert out["final_reply"]
+
+
+def test_graph_handles_unknown_tool_name(monkeypatch) -> None:
+    fake = _make_fake(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "not_a_real_tool",
+                        "id": "1",
+                        "args": {},
+                    }
+                ],
+            ),
+            AIMessage(content="recovered", tool_calls=[]),
+        ]
+    )
+    graph = build_agent_graph(fake, max_steps=4)
+    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    assert out["done"] is True
+    assert out["final_reply"] == "recovered"
+
+
+def test_graph_records_tool_exception_in_scratch(monkeypatch) -> None:
+    def _boom(**kw):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("app.agent.tools._semantic_search", _boom)
+
+    fake = _make_fake(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "semantic_search",
+                        "id": "1",
+                        "args": {"query": "italian"},
+                    }
+                ],
+            ),
+            AIMessage(content="apologies, retrieval failed", tool_calls=[]),
+        ]
+    )
+    graph = build_agent_graph(fake, max_steps=4)
+    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    scratch = out["scratch"]["semantic_search"][0]
+    assert "error" in scratch["result"]
+    assert "db down" in scratch["result"]["error"]
+    assert out["done"] is True

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -7,10 +7,10 @@ from typing import Any
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 
-from app.agent.graph import build_agent_graph
+from app.agent.graph import _prune_for_llm, build_agent_graph
 from app.agent.state import ItineraryState
 from app.tools.retrieval import PlaceHit
 
@@ -44,15 +44,15 @@ def _make_fake(scripted: list[AIMessage]) -> _ScriptedLLM:
     return _ScriptedLLM(scripted=list(scripted))
 
 
-def test_graph_terminates_on_no_tool_call() -> None:
+async def test_graph_terminates_on_no_tool_call() -> None:
     fake = _make_fake([AIMessage(content="here is your plan", tool_calls=[])])
     graph = build_agent_graph(fake, max_steps=4)
-    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="hi")]))
     assert out["done"] is True
     assert out["final_reply"] == "here is your plan"
 
 
-def test_graph_executes_tool_and_continues(monkeypatch) -> None:
+async def test_graph_executes_tool_and_continues(monkeypatch) -> None:
     monkeypatch.setattr(
         "app.agent.tools._semantic_search",
         lambda **kw: [
@@ -88,14 +88,14 @@ def test_graph_executes_tool_and_continues(monkeypatch) -> None:
         ]
     )
     graph = build_agent_graph(fake, max_steps=4)
-    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="italian please")]))
+    out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="italian please")]))
     assert out["step_count"] == 1
     assert "semantic_search" in out["scratch"]
     assert out["scratch"]["semantic_search"][0]["args"] == {"query": "italian", "k": 3}
     assert out["done"] is True
 
 
-def test_graph_respects_max_steps(monkeypatch) -> None:
+async def test_graph_respects_max_steps(monkeypatch) -> None:
     looping = [
         AIMessage(
             content="",
@@ -113,13 +113,13 @@ def test_graph_respects_max_steps(monkeypatch) -> None:
     graph = build_agent_graph(fake, max_steps=3)
     monkeypatch.setattr("app.agent.tools._semantic_search", lambda **_kw: [])
 
-    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="x")]))
+    out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="x")]))
     assert out["step_count"] == 3
     assert out["done"] is True
     assert out["final_reply"]
 
 
-def test_graph_handles_unknown_tool_name(monkeypatch) -> None:
+async def test_graph_handles_unknown_tool_name(monkeypatch) -> None:
     fake = _make_fake(
         [
             AIMessage(
@@ -136,12 +136,12 @@ def test_graph_handles_unknown_tool_name(monkeypatch) -> None:
         ]
     )
     graph = build_agent_graph(fake, max_steps=4)
-    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="hi")]))
     assert out["done"] is True
     assert out["final_reply"] == "recovered"
 
 
-def test_graph_records_tool_exception_in_scratch(monkeypatch) -> None:
+async def test_graph_records_tool_exception_in_scratch(monkeypatch) -> None:
     def _boom(**kw):
         raise RuntimeError("db down")
 
@@ -163,7 +163,7 @@ def test_graph_records_tool_exception_in_scratch(monkeypatch) -> None:
         ]
     )
     graph = build_agent_graph(fake, max_steps=4)
-    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="hi")]))
     scratch = out["scratch"]["semantic_search"][0]
     assert "error" in scratch["result"]
     assert "db down" in scratch["result"]["error"]
@@ -178,14 +178,14 @@ def test_graph_records_tool_exception_in_scratch(monkeypatch) -> None:
     assert "db down" in tool_messages[-1].content
 
 
-def test_plan_does_not_double_insert_system_prompt(monkeypatch) -> None:
+async def test_plan_does_not_double_insert_system_prompt(monkeypatch) -> None:
     """If the caller already supplied a SystemMessage, plan() must not stack a
     second one on top of it."""
     from langchain_core.messages import SystemMessage
 
     fake = _make_fake([AIMessage(content="hi", tool_calls=[])])
     graph = build_agent_graph(fake, max_steps=4)
-    out = graph.invoke(
+    out = await graph.ainvoke(
         ItineraryState(
             messages=[
                 SystemMessage(content="custom system prompt"),
@@ -198,7 +198,7 @@ def test_plan_does_not_double_insert_system_prompt(monkeypatch) -> None:
     assert system_messages[0].content == "custom system prompt"
 
 
-def test_act_handles_parallel_tool_calls(monkeypatch) -> None:
+async def test_act_handles_parallel_tool_calls(monkeypatch) -> None:
     """Modern OpenAI/Gemini fan out multiple tool calls in one AIMessage. Both
     must run, both ToolMessages append, and step_count increments by 1."""
     monkeypatch.setattr("app.agent.tools._semantic_search", lambda **_kw: [])
@@ -217,7 +217,7 @@ def test_act_handles_parallel_tool_calls(monkeypatch) -> None:
         ]
     )
     graph = build_agent_graph(fake, max_steps=4)
-    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="hi")]))
 
     from langchain_core.messages import ToolMessage as _ToolMessage
 
@@ -226,3 +226,48 @@ def test_act_handles_parallel_tool_calls(monkeypatch) -> None:
     assert out["step_count"] == 1
     assert "semantic_search" in out["scratch"]
     assert "nearby" in out["scratch"]
+
+
+def test_prune_for_llm_keeps_short_history_intact() -> None:
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="hi"),
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "semantic_search", "id": "1", "args": {"query": "x"}}],
+        ),
+        ToolMessage(content="[]", tool_call_id="1"),
+        AIMessage(content="done", tool_calls=[]),
+    ]
+    assert _prune_for_llm(msgs) == msgs
+
+
+def test_prune_for_llm_drops_oldest_tool_exchanges() -> None:
+    """With more than 2 tool-issuing AIMessages, the older ones lose their
+    tool_calls and their ToolMessages are dropped — but the rest survives."""
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="hi"),
+        AIMessage(
+            content="searching",
+            tool_calls=[{"name": "semantic_search", "id": "a", "args": {"q": "1"}}],
+        ),
+        ToolMessage(content="r1", tool_call_id="a"),
+        AIMessage(
+            content="searching again",
+            tool_calls=[{"name": "semantic_search", "id": "b", "args": {"q": "2"}}],
+        ),
+        ToolMessage(content="r2", tool_call_id="b"),
+        AIMessage(
+            content="searching once more",
+            tool_calls=[{"name": "semantic_search", "id": "c", "args": {"q": "3"}}],
+        ),
+        ToolMessage(content="r3", tool_call_id="c"),
+        AIMessage(content="done", tool_calls=[]),
+    ]
+    pruned = _prune_for_llm(msgs)
+    tool_messages = [m for m in pruned if isinstance(m, ToolMessage)]
+    # The oldest ToolMessage ("r1") is dropped.
+    assert {tm.content for tm in tool_messages} == {"r2", "r3"}
+    # The oldest AIMessage that issued tool_calls keeps its content but loses
+    # the tool_calls so the LLM doesn't see an unanswered call.
+    ai_with_tools = [m for m in pruned if isinstance(m, AIMessage) and m.tool_calls]
+    assert len(ai_with_tools) == 2  # the two most recent

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -95,7 +95,7 @@ def test_graph_executes_tool_and_continues(monkeypatch) -> None:
     assert out["done"] is True
 
 
-def test_graph_respects_max_steps() -> None:
+def test_graph_respects_max_steps(monkeypatch) -> None:
     looping = [
         AIMessage(
             content="",
@@ -111,10 +111,7 @@ def test_graph_respects_max_steps() -> None:
     ]
     fake = _make_fake(looping)
     graph = build_agent_graph(fake, max_steps=3)
-    # Patch the underlying retrieval so the tool calls don't hit the DB.
-    import app.agent.tools as tools_mod
-
-    tools_mod._semantic_search = lambda **kw: []  # type: ignore[assignment]
+    monkeypatch.setattr("app.agent.tools._semantic_search", lambda **_kw: [])
 
     out = graph.invoke(ItineraryState(messages=[HumanMessage(content="x")]))
     assert out["step_count"] == 3
@@ -171,3 +168,61 @@ def test_graph_records_tool_exception_in_scratch(monkeypatch) -> None:
     assert "error" in scratch["result"]
     assert "db down" in scratch["result"]["error"]
     assert out["done"] is True
+
+    # The exception must also surface to the LLM via the ToolMessage content,
+    # not just to scratch — otherwise the model has no way to react.
+    from langchain_core.messages import ToolMessage as _ToolMessage
+
+    tool_messages = [m for m in out["messages"] if isinstance(m, _ToolMessage)]
+    assert tool_messages, "act() must append a ToolMessage even on tool failure"
+    assert "db down" in tool_messages[-1].content
+
+
+def test_plan_does_not_double_insert_system_prompt(monkeypatch) -> None:
+    """If the caller already supplied a SystemMessage, plan() must not stack a
+    second one on top of it."""
+    from langchain_core.messages import SystemMessage
+
+    fake = _make_fake([AIMessage(content="hi", tool_calls=[])])
+    graph = build_agent_graph(fake, max_steps=4)
+    out = graph.invoke(
+        ItineraryState(
+            messages=[
+                SystemMessage(content="custom system prompt"),
+                HumanMessage(content="hello"),
+            ]
+        )
+    )
+    system_messages = [m for m in out["messages"] if isinstance(m, SystemMessage)]
+    assert len(system_messages) == 1
+    assert system_messages[0].content == "custom system prompt"
+
+
+def test_act_handles_parallel_tool_calls(monkeypatch) -> None:
+    """Modern OpenAI/Gemini fan out multiple tool calls in one AIMessage. Both
+    must run, both ToolMessages append, and step_count increments by 1."""
+    monkeypatch.setattr("app.agent.tools._semantic_search", lambda **_kw: [])
+    monkeypatch.setattr("app.agent.tools._nearby", lambda **_kw: [])
+
+    fake = _make_fake(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "semantic_search", "id": "a", "args": {"query": "x"}},
+                    {"name": "nearby", "id": "b", "args": {"place_id": "p1"}},
+                ],
+            ),
+            AIMessage(content="done", tool_calls=[]),
+        ]
+    )
+    graph = build_agent_graph(fake, max_steps=4)
+    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+
+    from langchain_core.messages import ToolMessage as _ToolMessage
+
+    tool_messages = [m for m in out["messages"] if isinstance(m, _ToolMessage)]
+    assert {tm.tool_call_id for tm in tool_messages} == {"a", "b"}
+    assert out["step_count"] == 1
+    assert "semantic_search" in out["scratch"]
+    assert "nearby" in out["scratch"]

--- a/tests/unit/test_agent_planning.py
+++ b/tests/unit/test_agent_planning.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.agent.planning import (
+    haversine_m,
+    next_arrival_time,
+    parse_stops_count,
+    remaining_walking_budget_m,
+    suggested_radius_m,
+    walking_time_min,
+)
+from app.agent.state import ItineraryState, Stop, UserConstraints
+
+
+def test_haversine_zero_distance() -> None:
+    assert haversine_m((37.7, -122.4), (37.7, -122.4)) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_haversine_small_distance_within_sf() -> None:
+    # Two known SF coordinates ~1 km apart (Mission Dolores to 16th St BART)
+    d = haversine_m((37.7596, -122.4269), (37.7651, -122.4194))
+    assert 700 < d < 1300
+
+
+def test_walking_time_min_matches_speed_constant() -> None:
+    # 800m at 80 m/min = 10 min.
+    minutes = walking_time_min(37.7596, -122.4269, 37.7651, -122.4194)
+    assert 7 < minutes < 16
+
+
+def test_next_arrival_time_chains_correctly() -> None:
+    prev = Stop(
+        place_id="p1",
+        name="X",
+        rationale="r",
+        source="google_places",
+        latitude=37.7596,
+        longitude=-122.4269,
+        planned_duration_min=90,
+        arrival_time=datetime(2026, 5, 6, 19, 0, tzinfo=timezone.utc),
+    )
+    arrival = next_arrival_time(prev, 37.7651, -122.4194)
+    delta_min = (arrival - prev.arrival_time).total_seconds() / 60.0
+    # 90 minutes of dinner + ~10 min of walking
+    assert 95 < delta_min < 110
+
+
+def test_next_arrival_time_requires_arrival_time() -> None:
+    prev = Stop(
+        place_id="p1",
+        name="X",
+        rationale="r",
+        source="google_places",
+        latitude=37.7,
+        longitude=-122.4,
+    )
+    with pytest.raises(ValueError, match="arrival_time"):
+        next_arrival_time(prev, 37.71, -122.41)
+
+
+def test_next_arrival_time_requires_coordinates() -> None:
+    prev = Stop(
+        place_id="p1",
+        name="X",
+        rationale="r",
+        source="google_places",
+        arrival_time=datetime(2026, 5, 6, 19, 0, tzinfo=timezone.utc),
+    )
+    with pytest.raises(ValueError, match="coordinates"):
+        next_arrival_time(prev, 37.71, -122.41)
+
+
+def test_remaining_walking_budget_clamps_at_zero() -> None:
+    state = ItineraryState(
+        constraints=UserConstraints(walking_budget_m=1000), walked_meters_so_far=1500
+    )
+    assert remaining_walking_budget_m(state) == 0.0
+
+
+def test_remaining_walking_budget_normal() -> None:
+    state = ItineraryState(
+        constraints=UserConstraints(walking_budget_m=2400), walked_meters_so_far=400
+    )
+    assert remaining_walking_budget_m(state) == 2000.0
+
+
+def test_suggested_radius_zero_remaining_stops() -> None:
+    state = ItineraryState()
+    assert suggested_radius_m(state, remaining_stops=0) == 0
+
+
+def test_suggested_radius_clamps_minimum() -> None:
+    state = ItineraryState(walked_meters_so_far=2400)
+    # Budget exhausted -> still returns at least the floor (300m).
+    assert suggested_radius_m(state, remaining_stops=2) == 300
+
+
+def test_suggested_radius_clamps_maximum() -> None:
+    state = ItineraryState(constraints=UserConstraints(walking_budget_m=10_000))
+    assert suggested_radius_m(state, remaining_stops=1) == 1500
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("just dinner", 1),
+        ("only dinner please", 1),
+        ("dinner and drinks", 2),
+        ("dinner + drinks", 2),
+        ("dinner then drinks", 2),
+        ("3 spots", 3),
+        ("plan 4 places", 4),
+        ("you decide", 3),  # default
+        ("a wonderful evening", 3),  # default
+        ("47 stops", 3),  # bogus -> default
+    ],
+)
+def test_parse_stops_count(text: str, expected: int) -> None:
+    assert parse_stops_count(text) == expected
+
+
+def test_parse_stops_count_custom_default() -> None:
+    assert parse_stops_count("you decide", default=5) == 5

--- a/tests/unit/test_agent_planning.py
+++ b/tests/unit/test_agent_planning.py
@@ -7,7 +7,6 @@ import pytest
 from app.agent.planning import (
     haversine_m,
     next_arrival_time,
-    parse_stops_count,
     remaining_walking_budget_m,
     suggested_radius_m,
     walking_time_min,
@@ -101,26 +100,3 @@ def test_suggested_radius_clamps_minimum() -> None:
 def test_suggested_radius_clamps_maximum() -> None:
     state = ItineraryState(constraints=UserConstraints(walking_budget_m=10_000))
     assert suggested_radius_m(state, remaining_stops=1) == 1500
-
-
-@pytest.mark.parametrize(
-    ("text", "expected"),
-    [
-        ("just dinner", 1),
-        ("only dinner please", 1),
-        ("dinner and drinks", 2),
-        ("dinner + drinks", 2),
-        ("dinner then drinks", 2),
-        ("3 spots", 3),
-        ("plan 4 places", 4),
-        ("you decide", 3),  # default
-        ("a wonderful evening", 3),  # default
-        ("47 stops", 3),  # bogus -> default
-    ],
-)
-def test_parse_stops_count(text: str, expected: int) -> None:
-    assert parse_stops_count(text) == expected
-
-
-def test_parse_stops_count_custom_default() -> None:
-    assert parse_stops_count("you decide", default=5) == 5

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from app.agent.prompts import CLARIFYING_STOPS_COUNT_TEMPLATE, SYSTEM_PROMPT
+
+
+def test_system_prompt_renders_with_max_steps() -> None:
+    rendered = SYSTEM_PROMPT.format(max_steps=8)
+    assert "8" in rendered
+    assert "{max_steps}" not in rendered
+
+
+def test_system_prompt_format_round_trips() -> None:
+    """str.format() must succeed without KeyError. The prompt deliberately
+    contains JSON-shaped examples wrapped in `{{ }}` that render as `{ }`
+    in the output — that is intended, but a single unescaped brace in the
+    raw template would raise here.
+    """
+    SYSTEM_PROMPT.format(max_steps=8)
+
+
+def test_system_prompt_only_substitutes_max_steps() -> None:
+    """If anyone adds a new `{foo}` placeholder without updating the .format()
+    call site, this test fails fast. We do this by formatting with max_steps
+    only and asserting no other unfilled `{name}` patterns remain.
+    """
+    import re
+
+    rendered = SYSTEM_PROMPT.format(max_steps=8)
+    # A bare `{word}` after rendering would be an un-substituted placeholder
+    # (legit JSON braces are doubled and render as `{` and `}` separately).
+    leftover = re.findall(r"\{[a-zA-Z_]\w*\}", rendered)
+    assert leftover == [], f"unfilled placeholders in prompt: {leftover}"
+
+
+def test_system_prompt_missing_max_steps_raises() -> None:
+    """Defensive: removing the {max_steps} substitution must not silently
+    drop the loop bound — `.format()` would raise KeyError, which the test
+    locks in."""
+    with pytest.raises(KeyError):
+        SYSTEM_PROMPT.format()
+
+
+def test_clarifying_stops_template_is_a_static_string() -> None:
+    assert isinstance(CLARIFYING_STOPS_COUNT_TEMPLATE, str)
+    assert "stops" in CLARIFYING_STOPS_COUNT_TEMPLATE

--- a/tests/unit/test_agent_smoke.py
+++ b/tests/unit/test_agent_smoke.py
@@ -66,10 +66,10 @@ def test_build_agent_graph_compiles_and_runs_happy_path() -> None:
     assert out["final_reply"] == "ok"
 
 
-def test_state_to_response_contract() -> None:
-    """Smoke: the response shape is exactly what frontend/src/api/chat.js consumes."""
-    from app.agent.graph import state_to_response
+def test_state_to_cards_smoke() -> None:
+    """Smoke: state_to_cards always returns a list of PlaceCard-shaped dicts."""
+    from app.agent.io import state_to_cards
     from app.agent.state import ItineraryState
 
-    payload = state_to_response(ItineraryState(final_reply="hi"), rag_label="x:y")
-    assert set(payload.keys()) == {"reply", "places", "ragLabel"}
+    cards = state_to_cards(ItineraryState(final_reply="hi"))
+    assert cards == []

--- a/tests/unit/test_agent_smoke.py
+++ b/tests/unit/test_agent_smoke.py
@@ -53,7 +53,7 @@ def test_all_tools_instantiates() -> None:
     from app.agent.tools import all_tools
 
     tools = all_tools()
-    assert len(tools) == 4
+    assert len(tools) == 5
 
 
 def test_build_agent_graph_compiles_and_runs_happy_path() -> None:

--- a/tests/unit/test_agent_smoke.py
+++ b/tests/unit/test_agent_smoke.py
@@ -1,0 +1,75 @@
+"""Smoke tests for the agent package — modules import cleanly, public objects
+instantiate, and the graph compiles end-to-end."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+
+class _NoopLLM(BaseChatModel):
+    """Minimal LLM stand-in: returns a single empty AIMessage with no tool calls."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "noop"
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs,
+    ) -> ChatResult:
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="ok", tool_calls=[]))]
+        )
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "app.agent",
+        "app.agent.state",
+        "app.agent.prompts",
+        "app.agent.tools",
+        "app.agent.graph",
+        "app.agent.planning",
+    ],
+)
+def test_module_imports(module: str) -> None:
+    importlib.import_module(module)
+
+
+def test_all_tools_instantiates() -> None:
+    from app.agent.tools import all_tools
+
+    tools = all_tools()
+    assert len(tools) == 4
+
+
+def test_build_agent_graph_compiles_and_runs_happy_path() -> None:
+    from app.agent.graph import build_agent_graph
+    from app.agent.state import ItineraryState
+
+    graph = build_agent_graph(_NoopLLM(), max_steps=2)
+    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    assert out["done"] is True
+    assert out["final_reply"] == "ok"
+
+
+def test_state_to_response_contract() -> None:
+    """Smoke: the response shape is exactly what frontend/src/api/chat.js consumes."""
+    from app.agent.graph import state_to_response
+    from app.agent.state import ItineraryState
+
+    payload = state_to_response(ItineraryState(final_reply="hi"), rag_label="x:y")
+    assert set(payload.keys()) == {"reply", "places", "ragLabel"}

--- a/tests/unit/test_agent_smoke.py
+++ b/tests/unit/test_agent_smoke.py
@@ -56,12 +56,12 @@ def test_all_tools_instantiates() -> None:
     assert len(tools) == 5
 
 
-def test_build_agent_graph_compiles_and_runs_happy_path() -> None:
+async def test_build_agent_graph_compiles_and_runs_happy_path() -> None:
     from app.agent.graph import build_agent_graph
     from app.agent.state import ItineraryState
 
     graph = build_agent_graph(_NoopLLM(), max_steps=2)
-    out = graph.invoke(ItineraryState(messages=[HumanMessage(content="hi")]))
+    out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="hi")]))
     assert out["done"] is True
     assert out["final_reply"] == "ok"
 

--- a/tests/unit/test_agent_state.py
+++ b/tests/unit/test_agent_state.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.agent.graph import state_to_response
+from app.agent.state import (
+    DEFAULT_STOP_DURATION_MIN,
+    DEFAULT_STOP_DURATION_MIN_FALLBACK,
+    ItineraryState,
+    PlaceCard,
+    Stop,
+    UserConstraints,
+    default_duration_for,
+)
+
+
+def test_itinerary_state_defaults() -> None:
+    state = ItineraryState()
+    assert state.stops == []
+    assert state.messages == []
+    assert state.scratch == {}
+    assert state.step_count == 0
+    assert state.done is False
+    assert state.final_reply is None
+    assert state.awaiting_stops_count is False
+    assert state.walked_meters_so_far == 0.0
+    assert isinstance(state.constraints, UserConstraints)
+    assert state.constraints.min_user_rating_count == 50
+    assert state.constraints.walking_budget_m == 2400
+
+
+def test_stop_round_trips_via_model_dump() -> None:
+    stop = Stop(
+        place_id="p1",
+        name="Trick Dog",
+        rationale="iconic SF cocktail bar",
+        source="google_places",
+        primary_type="cocktail_bar",
+        latitude=37.7,
+        longitude=-122.4,
+        planned_duration_min=60,
+        arrival_time=datetime(2026, 5, 6, 19, 0, tzinfo=timezone.utc),
+    )
+    payload = stop.model_dump(mode="json")
+    rebuilt = Stop(**payload)
+    assert rebuilt.place_id == stop.place_id
+    assert rebuilt.arrival_time is not None
+
+
+def test_default_duration_for_known_and_unknown_types() -> None:
+    assert default_duration_for("restaurant") == DEFAULT_STOP_DURATION_MIN["restaurant"]
+    assert default_duration_for("RESTAURANT") == DEFAULT_STOP_DURATION_MIN["restaurant"]
+    assert default_duration_for("unknown_type") == DEFAULT_STOP_DURATION_MIN_FALLBACK
+    assert default_duration_for(None) == DEFAULT_STOP_DURATION_MIN_FALLBACK
+    assert default_duration_for("") == DEFAULT_STOP_DURATION_MIN_FALLBACK
+
+
+def test_state_to_response_empty_stops() -> None:
+    state = ItineraryState(final_reply="No matches found.")
+    payload = state_to_response(state, rag_label="openai:gpt-4o-mini")
+    assert payload == {
+        "reply": "No matches found.",
+        "places": [],
+        "ragLabel": "openai:gpt-4o-mini",
+    }
+
+
+def test_state_to_response_with_stops() -> None:
+    state = ItineraryState(
+        stops=[
+            Stop(
+                place_id="p1",
+                name="X",
+                rationale="r",
+                source="google_places",
+                primary_type="restaurant",
+            )
+        ],
+        final_reply="Try X.",
+    )
+    payload = state_to_response(state, rag_label="gemini:gemini-2.5-flash")
+    assert payload["reply"] == "Try X."
+    assert payload["ragLabel"] == "gemini:gemini-2.5-flash"
+    assert len(payload["places"]) == 1
+    card = payload["places"][0]
+    assert card["place_id"] == "p1"
+    assert card["name"] == "X"
+    assert card["rationale"] == "r"
+    assert card["primary_type"] == "restaurant"
+    # PlaceCard fields not derived from Stop should be None / default.
+    assert card["address"] is None
+
+
+def test_place_card_serialization_keys() -> None:
+    card = PlaceCard(place_id="p1", name="X", rationale="r")
+    payload = card.model_dump(mode="json")
+    expected_keys = {
+        "place_id",
+        "name",
+        "address",
+        "rating",
+        "price_level",
+        "primary_type",
+        "arrival_time",
+        "rationale",
+        "booking_url",
+    }
+    assert set(payload.keys()) == expected_keys

--- a/tests/unit/test_agent_state.py
+++ b/tests/unit/test_agent_state.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from app.agent.graph import state_to_response
+from app.agent.io import state_to_cards
 from app.agent.state import (
     DEFAULT_STOP_DURATION_MIN,
     DEFAULT_STOP_DURATION_MIN_FALLBACK,
@@ -55,17 +55,12 @@ def test_default_duration_for_known_and_unknown_types() -> None:
     assert default_duration_for("") == DEFAULT_STOP_DURATION_MIN_FALLBACK
 
 
-def test_state_to_response_empty_stops() -> None:
+def test_state_to_cards_empty_stops() -> None:
     state = ItineraryState(final_reply="No matches found.")
-    payload = state_to_response(state, rag_label="openai:gpt-4o-mini")
-    assert payload == {
-        "reply": "No matches found.",
-        "places": [],
-        "ragLabel": "openai:gpt-4o-mini",
-    }
+    assert state_to_cards(state) == []
 
 
-def test_state_to_response_with_stops() -> None:
+def test_state_to_cards_with_stops() -> None:
     state = ItineraryState(
         stops=[
             Stop(
@@ -78,11 +73,9 @@ def test_state_to_response_with_stops() -> None:
         ],
         final_reply="Try X.",
     )
-    payload = state_to_response(state, rag_label="gemini:gemini-2.5-flash")
-    assert payload["reply"] == "Try X."
-    assert payload["ragLabel"] == "gemini:gemini-2.5-flash"
-    assert len(payload["places"]) == 1
-    card = payload["places"][0]
+    cards = state_to_cards(state)
+    assert len(cards) == 1
+    card = cards[0]
     assert card["place_id"] == "p1"
     assert card["name"] == "X"
     assert card["rationale"] == "r"

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool
+
+from app.agent.tools import (
+    _args_schema_for,
+    all_tools,
+    get_details,
+    kg_traverse,
+    nearby,
+    semantic_search,
+)
+
+
+def test_all_tools_returns_expected_names() -> None:
+    tools = all_tools()
+    assert {t.name for t in tools} == {
+        "semantic_search",
+        "nearby",
+        "get_details",
+        "kg_traverse",
+    }
+    for tool in tools:
+        assert isinstance(tool, BaseTool)
+        assert tool.description  # tool docstrings flow through to LLM
+
+
+def test_semantic_search_tool_invokes_underlying(monkeypatch) -> None:
+    captured: dict = {}
+
+    def _fake(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("app.agent.tools._semantic_search", _fake)
+    tools = {t.name: t for t in all_tools()}
+    tools["semantic_search"].invoke({"query": "italian", "k": 3})
+    assert captured == {"query": "italian", "filters": None, "k": 3}
+
+
+def test_nearby_tool_invokes_underlying(monkeypatch) -> None:
+    captured: dict = {}
+
+    def _fake(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("app.agent.tools._nearby", _fake)
+    tools = {t.name: t for t in all_tools()}
+    tools["nearby"].invoke({"place_id": "p1", "radius_m": 500, "k": 4})
+    assert captured == {"place_id": "p1", "radius_m": 500, "filters": None, "k": 4}
+
+
+def test_get_details_tool_invokes_underlying(monkeypatch) -> None:
+    captured: dict = {}
+
+    def _fake(**kwargs):
+        captured.update(kwargs)
+        return None
+
+    monkeypatch.setattr("app.agent.tools._get_details", _fake)
+    tools = {t.name: t for t in all_tools()}
+    tools["get_details"].invoke({"place_id": "p1"})
+    assert captured == {"place_id": "p1"}
+
+
+def test_kg_traverse_tool_returns_unavailable_stub() -> None:
+    tools = {t.name: t for t in all_tools()}
+    result = tools["kg_traverse"].invoke({"place_id": "p1"})
+    assert result == {
+        "available": False,
+        "reason": "knowledge graph not yet built; use semantic_search instead",
+    }
+
+
+def test_args_schema_skips_ctx() -> None:
+    schema = _args_schema_for(semantic_search)
+    fields = schema.model_fields
+    assert "ctx" not in fields
+    assert "query" in fields
+    assert "filters" in fields
+    assert "k" in fields
+
+
+def test_pydantic_ai_function_signatures_have_ctx() -> None:
+    """The Pydantic AI tool functions must accept a ctx parameter so that the
+    Pydantic AI side can pass in RunContext when used directly."""
+    import inspect
+
+    for fn in (semantic_search, nearby, get_details, kg_traverse):
+        sig = inspect.signature(fn)
+        assert "ctx" in sig.parameters
+        first = next(iter(sig.parameters))
+        assert first == "ctx"

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -17,6 +17,7 @@ def test_all_tools_returns_expected_names() -> None:
         "nearby",
         "get_details",
         "kg_traverse",
+        "commit_itinerary",
     }
     for tool in tools:
         assert isinstance(tool, BaseTool)

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
+import pytest
 from langchain_core.tools import BaseTool
 
 from app.agent.tools import (
     _args_schema_for,
     all_tools,
-    get_details,
-    kg_traverse,
-    nearby,
     semantic_search,
 )
 
@@ -23,6 +21,16 @@ def test_all_tools_returns_expected_names() -> None:
     for tool in tools:
         assert isinstance(tool, BaseTool)
         assert tool.description  # tool docstrings flow through to LLM
+
+
+def test_all_tools_returns_cached_instances() -> None:
+    """all_tools() returns a fresh list view but the StructuredTool instances
+    are cached at module import (Issue #16A)."""
+    a = all_tools()
+    b = all_tools()
+    assert a is not b
+    for ta, tb in zip(a, b, strict=True):
+        assert ta is tb
 
 
 def test_semantic_search_tool_invokes_underlying(monkeypatch) -> None:
@@ -73,22 +81,15 @@ def test_kg_traverse_tool_returns_unavailable_stub() -> None:
     }
 
 
-def test_args_schema_skips_ctx() -> None:
+def test_args_schema_includes_all_params() -> None:
     schema = _args_schema_for(semantic_search)
     fields = schema.model_fields
-    assert "ctx" not in fields
-    assert "query" in fields
-    assert "filters" in fields
-    assert "k" in fields
+    assert set(fields.keys()) == {"query", "filters", "k"}
 
 
-def test_pydantic_ai_function_signatures_have_ctx() -> None:
-    """The Pydantic AI tool functions must accept a ctx parameter so that the
-    Pydantic AI side can pass in RunContext when used directly."""
-    import inspect
+def test_args_schema_raises_on_missing_annotation() -> None:
+    def _bad(query, k: int = 5):  # `query` has no annotation
+        return []
 
-    for fn in (semantic_search, nearby, get_details, kg_traverse):
-        sig = inspect.signature(fn)
-        assert "ctx" in sig.parameters
-        first = next(iter(sig.parameters))
-        assert first == "ctx"
+    with pytest.raises(TypeError, match="missing a type annotation"):
+        _args_schema_for(_bad)

--- a/tests/unit/test_chain.py
+++ b/tests/unit/test_chain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import SecretStr
 
-from app.chain import build_rag_chain
+from app.chain import BuiltChain, build_rag_chain
 
 
 def test_build_rag_chain_supports_openai(mocker) -> None:
@@ -16,7 +16,7 @@ def test_build_rag_chain_supports_openai(mocker) -> None:
     mocker.patch("app.chain.ChatGoogleGenerativeAI")
     from_chain = mocker.patch("app.chain.RetrievalQA.from_chain_type", return_value=chain)
 
-    result_chain = build_rag_chain(
+    built = build_rag_chain(
         connection_string="postgresql://example",
         api_key="openai-key",
         llm_provider="openai",
@@ -25,6 +25,8 @@ def test_build_rag_chain_supports_openai(mocker) -> None:
         temperature=0.2,
     )
 
+    assert isinstance(built, BuiltChain)
+    assert built.llm == "openai-llm"
     retriever_cls.assert_called_once()
     openai_cls.assert_called_once_with(
         model="gpt-4o-mini",
@@ -37,7 +39,7 @@ def test_build_rag_chain_supports_openai(mocker) -> None:
         retriever=retriever,
         return_source_documents=True,
     )
-    assert result_chain.invoke({"query": "Best tacos"}) == {
+    assert built.chain.invoke({"query": "Best tacos"}) == {
         "result": "Try Taqueria Example.",
         "source_documents": [],
     }
@@ -56,7 +58,7 @@ def test_build_rag_chain_supports_gemini(mocker) -> None:
     )
     mocker.patch("app.chain.RetrievalQA.from_chain_type", return_value=chain)
 
-    result_chain = build_rag_chain(
+    built = build_rag_chain(
         connection_string="postgresql://example",
         api_key="gemini-key",
         llm_provider="gemini",
@@ -65,12 +67,13 @@ def test_build_rag_chain_supports_gemini(mocker) -> None:
         temperature=0.1,
     )
 
+    assert built.llm == "gemini-llm"
     gemini_cls.assert_called_once_with(
         model="gemini-2.5-flash",
         google_api_key=SecretStr("gemini-key"),
         temperature=0.1,
     )
-    assert result_chain.invoke({"query": "Pizza"}) == {
+    assert built.chain.invoke({"query": "Pizza"}) == {
         "result": "Try Del Popolo.",
         "source_documents": [],
     }

--- a/tests/unit/test_chat_endpoint.py
+++ b/tests/unit/test_chat_endpoint.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app.main import ActiveModelConfig, LoadedConfig, app
+
+
+def _stub_loaded_config(fake_chain) -> LoadedConfig:
+    return LoadedConfig(
+        chain=fake_chain,
+        llm=object(),
+        params=ActiveModelConfig(
+            llm_provider="openai",
+            chat_model="gpt-4o-mini",
+            k=5,
+            temperature=0.0,
+            run_id="run-123",
+            model_version="7",
+        ),
+    )
+
+
+def _final_state_dict(stops: list[dict[str, Any]] | None = None, reply: str = "Try it.") -> dict:
+    return {
+        "messages": [],
+        "constraints": {},
+        "stops": stops or [],
+        "scratch": {},
+        "step_count": 1,
+        "done": True,
+        "final_reply": reply,
+        "awaiting_stops_count": False,
+        "walked_meters_so_far": 0.0,
+    }
+
+
+def test_chat_endpoint_returns_reply_places_raglabel(mocker) -> None:
+    fake_graph = mocker.Mock()
+
+    async def _ainvoke(state, config=None):
+        return _final_state_dict(
+            stops=[
+                {
+                    "place_id": "p1",
+                    "name": "Trick Dog",
+                    "rationale": "iconic SF cocktail bar",
+                    "source": "google_places",
+                    "primary_type": "cocktail_bar",
+                    "planned_duration_min": 60,
+                    "arrival_time": None,
+                }
+            ],
+            reply="Trick Dog at 7pm, ~60 min.",
+        )
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={"message": "plan me a cocktail night", "history": []},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body.keys()) == {"reply", "places", "ragLabel"}
+    assert body["reply"] == "Trick Dog at 7pm, ~60 min."
+    assert body["ragLabel"] == "openai:gpt-4o-mini"
+    assert len(body["places"]) == 1
+    expected_place_keys = {
+        "place_id",
+        "name",
+        "address",
+        "rating",
+        "price_level",
+        "primary_type",
+        "arrival_time",
+        "rationale",
+        "booking_url",
+    }
+    assert set(body["places"][0].keys()) == expected_place_keys
+    assert body["places"][0]["place_id"] == "p1"
+
+
+def test_chat_endpoint_returns_503_when_agent_unavailable(mocker) -> None:
+    mocker.patch(
+        "app.main.load_registered_rag_chain",
+        side_effect=RuntimeError("mlflow unavailable"),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={"message": "anything", "history": []},
+        )
+
+    assert response.status_code == 503
+    assert "Agent graph unavailable" in response.json()["detail"]
+
+
+def test_chat_endpoint_passes_history_to_graph(mocker) -> None:
+    fake_graph = mocker.Mock()
+    captured: dict[str, Any] = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "actually make it 4 stops",
+                "history": [
+                    {"role": "user", "content": "plan a date"},
+                    {"role": "assistant", "content": "how many stops?"},
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    state = captured["state"]
+    assert len(state.messages) == 3
+    # roles in order: user, assistant, user
+    assert state.messages[0].type == "human"
+    assert state.messages[1].type == "ai"
+    assert state.messages[2].type == "human"
+    assert state.messages[2].content == "actually make it 4 stops"
+
+
+def test_chat_endpoint_accepts_empty_history(mocker) -> None:
+    fake_graph = mocker.Mock()
+
+    async def _ainvoke(state, config=None):
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post("/chat", json={"message": "hi"})
+
+    assert response.status_code == 200

--- a/tests/unit/test_chat_functional.py
+++ b/tests/unit/test_chat_functional.py
@@ -107,20 +107,3 @@ def test_chat_runs_real_graph_with_tool_call(monkeypatch, mocker) -> None:
     # this PR — the agent has to commit them. So `places` may be empty here,
     # but the contract keys must be present and correctly typed.
     assert isinstance(body["places"], list)
-
-
-def test_predict_proxies_through_real_graph(monkeypatch, mocker) -> None:
-    monkeypatch.setattr("app.agent.tools._semantic_search", lambda **_kw: [])
-    scripted = [AIMessage(content="No matches.", tool_calls=[])]
-    real_graph = build_agent_graph(_ScriptedLLM(scripted=scripted), max_steps=2)
-
-    mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config())
-    mocker.patch("app.main.build_agent_graph", return_value=real_graph)
-
-    with TestClient(app) as client:
-        response = client.post("/predict", json={"query": "anything", "limit": 5})
-
-    assert response.status_code == 200
-    body = response.json()
-    assert body["response"] == "No matches."
-    assert body["sources"] == []

--- a/tests/unit/test_chat_functional.py
+++ b/tests/unit/test_chat_functional.py
@@ -88,6 +88,26 @@ def test_chat_runs_real_graph_with_tool_call(monkeypatch, mocker) -> None:
                 }
             ],
         ),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "commit_itinerary",
+                    "id": "call-2",
+                    "args": {
+                        "stops": [
+                            {
+                                "place_id": "p1",
+                                "name": "Trick Dog",
+                                "rationale": "iconic SF cocktail bar",
+                                "source": "google_places",
+                                "primary_type": "cocktail_bar",
+                            }
+                        ]
+                    },
+                }
+            ],
+        ),
         AIMessage(content="Try Trick Dog.", tool_calls=[]),
     ]
     fake_llm = _ScriptedLLM(scripted=list(scripted))
@@ -103,7 +123,57 @@ def test_chat_runs_real_graph_with_tool_call(monkeypatch, mocker) -> None:
     body = response.json()
     assert body["reply"] == "Try Trick Dog."
     assert body["ragLabel"] == "openai:gpt-4o-mini"
-    # Stops are populated from state.stops, not directly from tool results in
-    # this PR — the agent has to commit them. So `places` may be empty here,
-    # but the contract keys must be present and correctly typed.
-    assert isinstance(body["places"], list)
+    assert len(body["places"]) == 1
+    assert body["places"][0]["place_id"] == "p1"
+    assert body["places"][0]["name"] == "Trick Dog"
+    assert body["places"][0]["primary_type"] == "cocktail_bar"
+
+
+def test_commit_itinerary_rejects_ungrounded_place_ids(monkeypatch, mocker) -> None:
+    """A place_id not seen via prior tool results must be dropped, not
+    silently accepted — that's the anti-hallucination guarantee."""
+    monkeypatch.setattr("app.agent.tools._semantic_search", lambda **_kw: [])
+
+    scripted = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "semantic_search",
+                    "id": "s1",
+                    "args": {"query": "cocktail bar"},
+                }
+            ],
+        ),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "commit_itinerary",
+                    "id": "c1",
+                    "args": {
+                        "stops": [
+                            {
+                                "place_id": "hallucinated",
+                                "name": "Made Up Bar",
+                                "rationale": "the LLM imagined this",
+                                "source": "google_places",
+                            }
+                        ]
+                    },
+                }
+            ],
+        ),
+        AIMessage(content="No grounded options.", tool_calls=[]),
+    ]
+    real_graph = build_agent_graph(_ScriptedLLM(scripted=list(scripted)), max_steps=4)
+
+    mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config())
+    mocker.patch("app.main.build_agent_graph", return_value=real_graph)
+
+    with TestClient(app) as client:
+        response = client.post("/chat", json={"message": "anything"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["places"] == []

--- a/tests/unit/test_chat_functional.py
+++ b/tests/unit/test_chat_functional.py
@@ -1,0 +1,126 @@
+"""Functional tests that exercise the /chat endpoint with a *real* agent graph.
+
+Only the LLM and the Postgres-backed retrieval functions are stubbed. The
+graph, tool wrapping, message handling, and FastAPI plumbing all run for real
+so we catch shape mismatches that pure unit tests miss.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from app.agent.graph import build_agent_graph
+from app.main import ActiveModelConfig, LoadedConfig, app
+from app.tools.retrieval import PlaceHit
+
+
+class _ScriptedLLM(BaseChatModel):
+    scripted: list[AIMessage]
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted"
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        msg = self.scripted.pop(0)
+        return ChatResult(generations=[ChatGeneration(message=msg)])
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> _ScriptedLLM:
+        return self
+
+
+def _stub_loaded_config() -> LoadedConfig:
+    return LoadedConfig(
+        chain=object(),
+        llm=object(),
+        params=ActiveModelConfig(
+            llm_provider="openai",
+            chat_model="gpt-4o-mini",
+            k=5,
+            temperature=0.0,
+            run_id="run-fn",
+            model_version="1",
+        ),
+    )
+
+
+def test_chat_runs_real_graph_with_tool_call(monkeypatch, mocker) -> None:
+    monkeypatch.setattr(
+        "app.agent.tools._semantic_search",
+        lambda **_kw: [
+            PlaceHit(
+                place_id="p1",
+                name="Trick Dog",
+                source="google_places",
+                similarity=0.9,
+                latitude=37.77,
+                longitude=-122.41,
+                rating=4.6,
+                price_level="PRICE_LEVEL_MODERATE",
+                business_status="OPERATIONAL",
+                primary_type="cocktail_bar",
+                formatted_address="3010 20th St, San Francisco",
+                snippet=None,
+            )
+        ],
+    )
+
+    scripted = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "semantic_search",
+                    "id": "call-1",
+                    "args": {"query": "cocktail bar"},
+                }
+            ],
+        ),
+        AIMessage(content="Try Trick Dog.", tool_calls=[]),
+    ]
+    fake_llm = _ScriptedLLM(scripted=list(scripted))
+    real_graph = build_agent_graph(fake_llm, max_steps=4)
+
+    mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config())
+    mocker.patch("app.main.build_agent_graph", return_value=real_graph)
+
+    with TestClient(app) as client:
+        response = client.post("/chat", json={"message": "cocktail bar in SF"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["reply"] == "Try Trick Dog."
+    assert body["ragLabel"] == "openai:gpt-4o-mini"
+    # Stops are populated from state.stops, not directly from tool results in
+    # this PR — the agent has to commit them. So `places` may be empty here,
+    # but the contract keys must be present and correctly typed.
+    assert isinstance(body["places"], list)
+
+
+def test_predict_proxies_through_real_graph(monkeypatch, mocker) -> None:
+    monkeypatch.setattr("app.agent.tools._semantic_search", lambda **_kw: [])
+    scripted = [AIMessage(content="No matches.", tool_calls=[])]
+    real_graph = build_agent_graph(_ScriptedLLM(scripted=scripted), max_steps=2)
+
+    mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config())
+    mocker.patch("app.main.build_agent_graph", return_value=real_graph)
+
+    with TestClient(app) as client:
+        response = client.post("/predict", json={"query": "anything", "limit": 5})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["response"] == "No matches."
+    assert body["sources"] == []

--- a/tests/unit/test_lifespan.py
+++ b/tests/unit/test_lifespan.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.config import get_settings
-from app.main import ActiveModelConfig, lifespan
+from app.main import ActiveModelConfig, LoadedConfig, lifespan
 
 TEST_DATABASE_URL = "postgresql://postgres:test@localhost:5432/city_concierge_test"
 
@@ -22,6 +22,8 @@ def _force_test_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_lifespan_initializes_and_closes_db_pool(mocker) -> None:
     fake_app = SimpleNamespace(state=SimpleNamespace())
     fake_chain = object()
+    fake_llm = object()
+    fake_graph = object()
     model_config = ActiveModelConfig(
         llm_provider="openai",
         chat_model="gpt-4o-mini",
@@ -34,12 +36,15 @@ async def test_lifespan_initializes_and_closes_db_pool(mocker) -> None:
     close_db_pool = mocker.patch("app.main.close_db_pool")
     load_registered_rag_chain = mocker.patch(
         "app.main.load_registered_rag_chain",
-        return_value=(fake_chain, model_config),
+        return_value=LoadedConfig(chain=fake_chain, llm=fake_llm, params=model_config),
     )
+    build_agent_graph = mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
 
     async with lifespan(fake_app):
         assert fake_app.state.rag_chain is fake_chain
         assert fake_app.state.active_model_config is model_config
+        assert fake_app.state.agent_graph is fake_graph
+        assert fake_app.state.rag_label == "openai:gpt-4o-mini"
 
     init_db_pool.assert_called_once_with(
         TEST_DATABASE_URL,
@@ -47,6 +52,7 @@ async def test_lifespan_initializes_and_closes_db_pool(mocker) -> None:
         10,
     )
     load_registered_rag_chain.assert_called_once_with()
+    build_agent_graph.assert_called_once_with(fake_llm)
     close_db_pool.assert_called_once_with()
 
 
@@ -64,6 +70,7 @@ async def test_lifespan_preserves_degraded_mode_when_rag_load_fails(mocker) -> N
     async with lifespan(fake_app):
         assert fake_app.state.rag_chain is None
         assert fake_app.state.active_model_config is None
+        assert fake_app.state.agent_graph is None
 
     init_db_pool.assert_called_once_with(
         TEST_DATABASE_URL,

--- a/tests/unit/test_predict_endpoint.py
+++ b/tests/unit/test_predict_endpoint.py
@@ -22,37 +22,26 @@ def _stub_loaded_config(fake_chain) -> LoadedConfig:
     )
 
 
-def test_predict_endpoint_proxies_through_agent(mocker) -> None:
-    fake_graph = mocker.Mock()
-
-    async def _ainvoke(state, config=None):
-        return {
-            "messages": [],
-            "constraints": {},
-            "stops": [
-                {
-                    "place_id": "p1",
-                    "name": "Taqueria Example",
-                    "rationale": "Top tacos in the Mission",
-                    "source": "google_places",
-                    "primary_type": "restaurant",
-                    "planned_duration_min": 90,
-                    "arrival_time": None,
-                }
-            ],
-            "scratch": {},
-            "step_count": 1,
-            "done": True,
-            "final_reply": "You should try Taqueria Example.",
-            "awaiting_stops_count": False,
-            "walked_meters_so_far": 0.0,
-        }
-
-    fake_graph.ainvoke = _ainvoke
-
+def test_predict_returns_chain_result_and_sources(mocker) -> None:
     fake_chain = mocker.Mock()
+    fake_chain.invoke.return_value = {
+        "result": "You should try Taqueria Example.",
+        "source_documents": [
+            SimpleNamespace(
+                metadata={
+                    "name": "Taqueria Example",
+                    "rating": 4.7,
+                    "address": "123 Mission St, San Francisco, CA",
+                    "similarity": 0.981,
+                    "place_id": "p1",
+                    "primary_type": "restaurant",
+                }
+            )
+        ],
+    }
+
     mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config(fake_chain))
-    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+    mocker.patch("app.main.build_agent_graph", return_value=object())
 
     with TestClient(app) as client:
         response = client.post(
@@ -66,40 +55,32 @@ def test_predict_endpoint_proxies_through_agent(mocker) -> None:
     assert len(body["sources"]) == 1
     assert body["sources"][0]["name"] == "Taqueria Example"
     assert body["sources"][0]["place_id"] == "p1"
+    assert body["sources"][0]["similarity"] == 0.981
+    fake_chain.invoke.assert_called_once_with({"query": "Best tacos in the Mission"})
 
 
-def test_predict_falls_back_to_chain_when_agent_unavailable(mocker) -> None:
+def test_predict_uses_chain_even_when_agent_graph_is_built(mocker) -> None:
+    """The agent never sits on the /predict path; /predict is the legacy contract."""
     fake_chain = mocker.Mock()
-    fake_chain.invoke.return_value = {
-        "result": "You should try Taqueria Example.",
-        "source_documents": [
-            SimpleNamespace(
-                metadata={
-                    "name": "Taqueria Example",
-                    "rating": 4.7,
-                    "address": "123 Mission St, San Francisco, CA",
-                    "similarity": 0.981,
-                }
-            )
-        ],
-    }
+    fake_chain.invoke.return_value = {"result": "ok", "source_documents": []}
+    fake_graph = mocker.Mock()
+    fake_graph.ainvoke = mocker.AsyncMock()
 
     mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config(fake_chain))
-    mocker.patch("app.main.build_agent_graph", side_effect=RuntimeError("graph build failed"))
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
 
     with TestClient(app) as client:
         response = client.post(
             "/predict",
-            json={"query": "Best tacos in the Mission", "limit": 5},
+            json={"query": "anything", "limit": 5},
         )
 
     assert response.status_code == 200
-    body = response.json()
-    assert body["response"] == "You should try Taqueria Example."
-    assert body["sources"][0]["name"] == "Taqueria Example"
+    fake_chain.invoke.assert_called_once()
+    fake_graph.ainvoke.assert_not_called()
 
 
-def test_predict_returns_503_when_everything_unavailable(mocker) -> None:
+def test_predict_returns_503_when_chain_unavailable(mocker) -> None:
     mocker.patch(
         "app.main.load_registered_rag_chain",
         side_effect=RuntimeError("mlflow unavailable"),

--- a/tests/unit/test_predict_endpoint.py
+++ b/tests/unit/test_predict_endpoint.py
@@ -4,10 +4,71 @@ from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
-from app.main import ActiveModelConfig, app
+from app.main import ActiveModelConfig, LoadedConfig, app
 
 
-def test_predict_endpoint_returns_response_and_sources(mocker) -> None:
+def _stub_loaded_config(fake_chain) -> LoadedConfig:
+    return LoadedConfig(
+        chain=fake_chain,
+        llm=object(),
+        params=ActiveModelConfig(
+            llm_provider="openai",
+            chat_model="gpt-4o-mini",
+            k=5,
+            temperature=0.0,
+            run_id="run-123",
+            model_version="7",
+        ),
+    )
+
+
+def test_predict_endpoint_proxies_through_agent(mocker) -> None:
+    fake_graph = mocker.Mock()
+
+    async def _ainvoke(state, config=None):
+        return {
+            "messages": [],
+            "constraints": {},
+            "stops": [
+                {
+                    "place_id": "p1",
+                    "name": "Taqueria Example",
+                    "rationale": "Top tacos in the Mission",
+                    "source": "google_places",
+                    "primary_type": "restaurant",
+                    "planned_duration_min": 90,
+                    "arrival_time": None,
+                }
+            ],
+            "scratch": {},
+            "step_count": 1,
+            "done": True,
+            "final_reply": "You should try Taqueria Example.",
+            "awaiting_stops_count": False,
+            "walked_meters_so_far": 0.0,
+        }
+
+    fake_graph.ainvoke = _ainvoke
+
+    fake_chain = mocker.Mock()
+    mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config(fake_chain))
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/predict",
+            json={"query": "Best tacos in the Mission", "limit": 5},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["response"] == "You should try Taqueria Example."
+    assert len(body["sources"]) == 1
+    assert body["sources"][0]["name"] == "Taqueria Example"
+    assert body["sources"][0]["place_id"] == "p1"
+
+
+def test_predict_falls_back_to_chain_when_agent_unavailable(mocker) -> None:
     fake_chain = mocker.Mock()
     fake_chain.invoke.return_value = {
         "result": "You should try Taqueria Example.",
@@ -23,20 +84,8 @@ def test_predict_endpoint_returns_response_and_sources(mocker) -> None:
         ],
     }
 
-    mocker.patch(
-        "app.main.load_registered_rag_chain",
-        return_value=(
-            fake_chain,
-            ActiveModelConfig(
-                llm_provider="openai",
-                chat_model="gpt-4o-mini",
-                k=5,
-                temperature=0.0,
-                run_id="run-123",
-                model_version="7",
-            ),
-        ),
-    )
+    mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config(fake_chain))
+    mocker.patch("app.main.build_agent_graph", side_effect=RuntimeError("graph build failed"))
 
     with TestClient(app) as client:
         response = client.post(
@@ -45,15 +94,21 @@ def test_predict_endpoint_returns_response_and_sources(mocker) -> None:
         )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "response": "You should try Taqueria Example.",
-        "sources": [
-            {
-                "name": "Taqueria Example",
-                "rating": 4.7,
-                "address": "123 Mission St, San Francisco, CA",
-                "similarity": 0.981,
-            }
-        ],
-    }
-    fake_chain.invoke.assert_called_once_with({"query": "Best tacos in the Mission"})
+    body = response.json()
+    assert body["response"] == "You should try Taqueria Example."
+    assert body["sources"][0]["name"] == "Taqueria Example"
+
+
+def test_predict_returns_503_when_everything_unavailable(mocker) -> None:
+    mocker.patch(
+        "app.main.load_registered_rag_chain",
+        side_effect=RuntimeError("mlflow unavailable"),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/predict",
+            json={"query": "Best tacos in the Mission", "limit": 5},
+        )
+
+    assert response.status_code == 503

--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -95,3 +95,38 @@ def test_get_relevant_documents_formats_vector_and_maps_metadata(mocker) -> None
         "primary_type": "mexican_restaurant",
         "similarity": 0.982,
     }
+
+
+def test_build_embedding_caches_identical_queries(mocker) -> None:
+    """Identical (query, model) pairs should hit the LRU cache and avoid a
+    second OpenAI round-trip."""
+    from app.retriever import _embed_cached, build_embedding
+
+    _embed_cached.cache_clear()
+
+    fake_client = MagicMock()
+    fake_client.embed_query.return_value = [0.1, 0.2, 0.3]
+    embeddings_cls = mocker.patch("app.retriever.OpenAIEmbeddings", return_value=fake_client)
+
+    v1 = build_embedding("italian", "text-embedding-3-small", openai_api_key="k")
+    v2 = build_embedding("italian", "text-embedding-3-small", openai_api_key="k")
+
+    assert v1 == v2 == [0.1, 0.2, 0.3]
+    # OpenAIEmbeddings constructor + embed_query each called only once.
+    assert embeddings_cls.call_count == 1
+    assert fake_client.embed_query.call_count == 1
+
+
+def test_build_embedding_different_queries_miss_cache(mocker) -> None:
+    from app.retriever import _embed_cached, build_embedding
+
+    _embed_cached.cache_clear()
+
+    fake_client = MagicMock()
+    fake_client.embed_query.side_effect = [[0.1], [0.2]]
+    mocker.patch("app.retriever.OpenAIEmbeddings", return_value=fake_client)
+
+    a = build_embedding("italian", "text-embedding-3-small", openai_api_key="k")
+    b = build_embedding("japanese", "text-embedding-3-small", openai_api_key="k")
+    assert a != b
+    assert fake_client.embed_query.call_count == 2


### PR DESCRIPTION
## Summary

W2 lands the plan/act/critique LangGraph agent behind `/chat`, plus a full code-review pass that addressed 16 issues across architecture, code quality, tests, and performance. Highlights:

- `/predict` stays on the legacy `RetrievalQA` chain (the agent path is `/chat` only).
- LangGraph nodes return partial state updates with an `add_messages` reducer instead of mutating in place — future-safe for checkpointers and parallel critique branches.
- New `commit_itinerary` tool with grounding validation: every committed `place_id` must come from a prior tool result, so hallucinated places are dropped at the graph level rather than relying on prompt suggestion.
- Async `plan`/`act` (LLM via `ainvoke`, sync tools via `asyncio.to_thread`) so a `max_steps=8` request no longer hogs a thread-pool worker for seconds at a time.
- Token-cost pruning: only the most recent two tool-call exchanges go to the LLM, while `state.messages` keeps the full history for tracing.
- LRU-cached embeddings, JSON-encoded tool results, schema generation that fails loudly on missing annotations, dropped `pydantic-ai` dep that had no runtime consumer.

## Issues addressed (1A–16A, all Option A from review)

| Tier | Issues | Commit |
|---|---|---|
| Decouple legacy contract | #1A | `a5b2070` |
| Tool layer cleanup | #2A #6A #16A | `4c7efa7` |
| Graph correctness | #4A #7A #11A #10A | `b2c5456` |
| commit_itinerary + grounding | #3A #9A | `36f6af4` |
| IO boundary + prompt test | #5A #8A #12A | `81641b2` |
| Performance | #13A #14A #15A | `86df438` |

## Test plan

- [x] `make test-unit` — 178 passing
- [x] `make lint` — clean
- [x] `make test-integration` (requires running Postgres + `APP_ENV=integration`)
- [x] Manual: `make dev`, hit `/chat` with a real OpenAI key, confirm `places[]` populates after the agent calls `commit_itinerary`
- [x] Manual: hit `/predict` and confirm it returns sources from the legacy chain (no agent fanout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)