### PR TITLE
docs(w2): correct footer — neighborhood is live on cloud sql

### DIFF
--- a/implementation_plan/james/w2_agent_graph.md
+++ b/implementation_plan/james/w2_agent_graph.md
@@ -802,4 +802,5 @@ Deferred to W3+:
 
 - `critique` node only does loop-bound + final-message detection — full self-correction logic lands in W3.
 - `propose_booking` tool (W4); `kg_traverse` is a stub.
-- W1 `neighborhood` column not yet on Cloud SQL — agent works without it; filter is a no-op until that migration deploys.
+- W1 migration verified deployed on Cloud SQL (alembic head `c428add573d7`, `neighborhood_of()` returns values for all 5,855 rows in the `place_documents` view). The `neighborhood` filter is live; no action needed.
+- `place_embeddings_v2` population on Cloud SQL is independent of W2 — flip `EMBEDDING_TABLE=place_embeddings_v2` once `make embed-v2` runs against the prod DB and W6 evals approve the v1→v2 swap.


### PR DESCRIPTION
## Summary
- The W2 status footer claimed `neighborhood` wasn't deployed yet. Verified Cloud SQL is at alembic head `c428add573d7`, `neighborhood_of()` and `place_documents` exist, and the column resolves for all 5,855 rows.
- Replaces the misleading bullet with the verified fact + clarifies that the only remaining task is independent of W2: populating `place_embeddings_v2` and flipping `EMBEDDING_TABLE` once W6 approves.

## Test plan
- [ ] Footer no longer implies a pending action

🤖 Generated with [Claude Code](https://claude.com/claude-code)