### PR TITLE
feat(w4): booking handoff stub with deterministic enrichment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,11 @@ jobs:
       - name: Run integration tests
         env:
           APP_ENV: integration
+          # The booking integration test exercises the real semantic_search
+          # path, which calls OpenAI for embeddings. Without a real key the
+          # conftest setdefault stub leaks through and the test 401s. Other
+          # integration tests don't touch OpenAI; this is just for booking.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         # The CI service account is provisioned as a CLOUD_IAM_SERVICE_ACCOUNT
         # DB user named with the .gserviceaccount.com suffix dropped. We
         # URL-encode the @ in the user, and the IAM token is the password.

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
+from datetime import datetime
 from typing import Any, Literal
 
 from langchain_core.language_models import BaseChatModel
@@ -31,6 +33,9 @@ from app.agent.critique.checks import itinerary_violations
 from app.agent.prompts import SYSTEM_PROMPT
 from app.agent.state import ItineraryState, RevisionHint, Stop
 from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
+from app.tools.booking import propose_booking
+
+logger = logging.getLogger(__name__)
 
 LOW_SIMILARITY_THRESHOLD = 0.55
 MAX_REVISIONS_PER_REASON = 2
@@ -82,10 +87,36 @@ def _commit_stops(state: ItineraryState, raw_stops: Any) -> tuple[list[Stop], di
             committed.append(Stop(**raw))
         except Exception as e:  # noqa: BLE001
             rejected.append({"place_id": pid, "reason": f"invalid stop: {e}"})
+    _enrich_with_booking(committed, state)
     return committed, {
         "committed": [s.place_id for s in committed],
         "rejected": rejected,
     }
+
+
+def _enrich_with_booking(stops: list[Stop], state: ItineraryState) -> None:
+    """Stamp booking_url + booking_provider on each committed stop in-place.
+
+    Deterministic — runs without involving the LLM, since URL construction is
+    a pure transform of (place_id, when, party_size). If propose_booking
+    raises (DB miss, etc.) we log and skip that stop; a missing booking link
+    is a degraded-but-shippable state, not a hard failure.
+    """
+    party_size = state.constraints.party_size or 2
+    fallback_when = state.constraints.when or datetime.now()
+    for stop in stops:
+        when = stop.arrival_time or fallback_when
+        try:
+            proposal = propose_booking(stop.place_id, when, party_size)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "booking enrichment failed for place_id=%s",
+                stop.place_id,
+                exc_info=True,
+            )
+            continue
+        stop.booking_url = proposal.booking_url
+        stop.booking_provider = proposal.provider
 
 
 _RECENT_TOOL_EXCHANGES_KEPT = 2

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -18,6 +18,7 @@ import logging
 from datetime import datetime
 from typing import Any, Literal
 
+import psycopg2
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, StateGraph
@@ -113,7 +114,12 @@ def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
         when = stop.arrival_time or fallback_when
         try:
             proposal = propose_booking(stop.place_id, when, party_size)
-        except Exception:  # noqa: BLE001
+        except (ValueError, psycopg2.Error):
+            # Recoverable: missing place_id (ValueError from propose_booking)
+            # or transient DB blip (psycopg2.Error). Skip enrichment for this
+            # stop; the rest of the commit still ships. Programmer errors
+            # (TypeError, AttributeError, etc.) propagate so we hear about
+            # the bug instead of silently shipping cards with no booking link.
             logger.warning(
                 "booking enrichment failed for place_id=%s",
                 stop.place_id,

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from datetime import datetime
 from typing import Any, Literal
 
 import psycopg2
@@ -109,9 +108,15 @@ def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
     through the LLM and re-committing the same place_ids.
     """
     party_size = state.constraints.party_size or 2
-    fallback_when = state.constraints.when or datetime.now()
     for stop in stops:
-        when = stop.arrival_time or fallback_when
+        when = stop.arrival_time or state.constraints.when
+        if when is None:
+            # No time → no booking link. Falling back to datetime.now() would
+            # embed wall-clock time in the URL, breaking re-commit idempotency
+            # (same inputs, different URL each call) and meaning nothing to
+            # the user. The card ships without a booking link; downstream can
+            # re-enrich once the user supplies a time.
+            continue
         try:
             proposal = propose_booking(stop.place_id, when, party_size)
         except (ValueError, psycopg2.Error):

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -33,7 +33,8 @@ from app.agent.critique.checks import itinerary_violations
 from app.agent.prompts import SYSTEM_PROMPT
 from app.agent.state import ItineraryState, RevisionHint, Stop
 from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
-from app.tools.booking import propose_booking
+from app.tools.booking import propose_booking_from_details
+from app.tools.retrieval import get_details_many
 
 logger = logging.getLogger(__name__)
 
@@ -97,10 +98,14 @@ def _commit_stops(state: ItineraryState, raw_stops: Any) -> tuple[list[Stop], di
 def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
     """Stamp booking_url + booking_provider on each committed stop in-place.
 
-    Deterministic — runs without involving the LLM, since URL construction is
-    a pure transform of (place_id, when, party_size). If propose_booking
-    raises (DB miss, etc.) we log and skip that stop; a missing booking link
-    is a degraded-but-shippable state, not a hard failure.
+    Deterministic — URL construction is a pure transform of (PlaceDetails,
+    when, party_size), so the LLM is not involved.
+
+    One batched DB read (get_details_many) covers all stops; previously this
+    was an N+1 over commit_itinerary. Per-stop URL building is pure and
+    cannot raise ValueError/psycopg2.Error, so the error-handling moved to
+    the single batched read: a DB blip skips enrichment for this commit
+    (cards ship without booking links), bugs propagate.
 
     Called by _commit_stops on initial commit. Public (no leading underscore)
     so a future constraint-edit path — "make it 4 people instead of 2" or
@@ -108,6 +113,19 @@ def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
     through the LLM and re-committing the same place_ids.
     """
     party_size = state.constraints.party_size or 2
+    place_ids = [stop.place_id for stop in stops]
+    try:
+        details_by_id = get_details_many(place_ids)
+    except psycopg2.Error:
+        # Single point of DB failure for the whole enrichment. Skip enrichment
+        # for the entire commit; cards still ship without booking links.
+        logger.warning(
+            "booking enrichment DB read failed for %d stops",
+            len(place_ids),
+            exc_info=True,
+        )
+        return
+
     for stop in stops:
         when = stop.arrival_time or state.constraints.when
         if when is None:
@@ -117,20 +135,14 @@ def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
             # the user. The card ships without a booking link; downstream can
             # re-enrich once the user supplies a time.
             continue
-        try:
-            proposal = propose_booking(stop.place_id, when, party_size)
-        except (ValueError, psycopg2.Error):
-            # Recoverable: missing place_id (ValueError from propose_booking)
-            # or transient DB blip (psycopg2.Error). Skip enrichment for this
-            # stop; the rest of the commit still ships. Programmer errors
-            # (TypeError, AttributeError, etc.) propagate so we hear about
-            # the bug instead of silently shipping cards with no booking link.
-            logger.warning(
-                "booking enrichment failed for place_id=%s",
-                stop.place_id,
-                exc_info=True,
-            )
+        details = details_by_id.get(stop.place_id)
+        if details is None:
+            # place_id grounded in scratch but missing from DB at enrichment
+            # time — race condition on the deletion side, or a stale id. Same
+            # recoverable case as the old ValueError("unknown place_id"): skip.
+            logger.warning("booking enrichment skipped: place_id=%s not in DB", stop.place_id)
             continue
+        proposal = propose_booking_from_details(details, when, party_size)
         stop.booking_url = proposal.booking_url
         stop.booking_provider = proposal.provider
 

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -87,20 +87,25 @@ def _commit_stops(state: ItineraryState, raw_stops: Any) -> tuple[list[Stop], di
             committed.append(Stop(**raw))
         except Exception as e:  # noqa: BLE001
             rejected.append({"place_id": pid, "reason": f"invalid stop: {e}"})
-    _enrich_with_booking(committed, state)
+    enrich_stops_with_booking(committed, state)
     return committed, {
         "committed": [s.place_id for s in committed],
         "rejected": rejected,
     }
 
 
-def _enrich_with_booking(stops: list[Stop], state: ItineraryState) -> None:
+def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
     """Stamp booking_url + booking_provider on each committed stop in-place.
 
     Deterministic — runs without involving the LLM, since URL construction is
     a pure transform of (place_id, when, party_size). If propose_booking
     raises (DB miss, etc.) we log and skip that stop; a missing booking link
     is a degraded-but-shippable state, not a hard failure.
+
+    Called by _commit_stops on initial commit. Public (no leading underscore)
+    so a future constraint-edit path — "make it 4 people instead of 2" or
+    "shift dinner to 8pm" — can refresh URLs in place without round-tripping
+    through the LLM and re-committing the same place_ids.
     """
     party_size = state.constraints.party_size or 2
     fallback_when = state.constraints.when or datetime.now()

--- a/app/agent/io.py
+++ b/app/agent/io.py
@@ -44,6 +44,8 @@ def state_to_cards(state: ItineraryState) -> list[dict[str, Any]]:
             primary_type=s.primary_type,
             arrival_time=s.arrival_time,
             rationale=s.rationale,
+            booking_url=s.booking_url,
+            booking_provider=s.booking_provider,
         ).model_dump(mode="json")
         for s in state.stops
     ]

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -14,6 +14,8 @@ from langchain_core.messages import BaseMessage
 from langgraph.graph.message import add_messages
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.tools.booking_types import Provider as BookingProvider
+
 RevisionReason = Literal[
     "empty_results",
     "all_closed",
@@ -119,7 +121,7 @@ class Stop(BaseModel):
     longitude: float | None = None
     primary_type: str | None = None
     booking_url: str | None = None
-    booking_provider: str | None = None
+    booking_provider: BookingProvider | None = None
 
 
 class ItineraryState(BaseModel):
@@ -160,4 +162,4 @@ class PlaceCard(BaseModel):
     arrival_time: datetime | None = None
     rationale: str
     booking_url: str | None = None
-    booking_provider: str | None = None
+    booking_provider: BookingProvider | None = None

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -118,6 +118,8 @@ class Stop(BaseModel):
     latitude: float | None = None
     longitude: float | None = None
     primary_type: str | None = None
+    booking_url: str | None = None
+    booking_provider: str | None = None
 
 
 class ItineraryState(BaseModel):
@@ -157,4 +159,5 @@ class PlaceCard(BaseModel):
     primary_type: str | None = None
     arrival_time: datetime | None = None
     rationale: str
-    booking_url: str | None = None  # populated by W4
+    booking_url: str | None = None
+    booking_provider: str | None = None

--- a/app/tools/booking.py
+++ b/app/tools/booking.py
@@ -14,6 +14,8 @@ propose_booking from app/agent/graph.py without involving the LLM.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from urllib.parse import urlencode, urlparse
 
@@ -31,16 +33,54 @@ class BookingProposal(BaseModel):
     notes: str | None = None
 
 
+@dataclass(frozen=True)
+class _ProviderSpec:
+    """How a single deep-linkable provider is recognized and parameterized.
+
+    `host_match` substrings are checked against the URL hostname (lowercased)
+    in `detect_provider`. `params` builds the query dict the venue's booking
+    page expects; signature is (iso_date, iso_time, party_size) -> dict.
+    """
+
+    host_match: tuple[str, ...]
+    params: Callable[[str, str, int], dict[str, object]]
+    notes: str
+
+
+_PROVIDER_SPECS: dict[Provider, _ProviderSpec] = {
+    "resy": _ProviderSpec(
+        host_match=("resy.com",),
+        params=lambda d, _t, n: {"date": d, "seats": n},
+        notes="Tap to open Resy with your date and party size pre-filled.",
+    ),
+    "tock": _ProviderSpec(
+        host_match=("exploretock.com", "tock.com"),
+        params=lambda d, t, n: {"date": d, "size": n, "time": t},
+        notes="Tap to open Tock with your reservation pre-filled.",
+    ),
+    "opentable": _ProviderSpec(
+        host_match=("opentable.com",),
+        params=lambda d, t, n: {"covers": n, "dateTime": f"{d}T{t}"},
+        notes="Tap to open OpenTable with your reservation pre-filled.",
+    ),
+}
+
+_FALLBACK_NOTES: dict[Provider, str] = {
+    "unknown": (
+        "Online booking not detected; opens the venue's website. "
+        "You may need to find their reservations page."
+    ),
+    "google_maps": "No website on file; opens Google Maps.",
+}
+
+
 def detect_provider(website_uri: str | None) -> Provider:
     if not website_uri:
         return "unknown"
     host = (urlparse(website_uri).hostname or "").lower()
-    if "resy.com" in host:
-        return "resy"
-    if "exploretock.com" in host or "tock.com" in host:
-        return "tock"
-    if "opentable.com" in host:
-        return "opentable"
+    for name, spec in _PROVIDER_SPECS.items():
+        if any(needle in host for needle in spec.host_match):
+            return name
     return "unknown"
 
 
@@ -81,38 +121,15 @@ def _build_booking_url(
     the row's maps_uri, then google_maps via a name search. The frontend keys
     its label off the effective provider so the user sees "Open venue website"
     or "Open in Google Maps" rather than "Open in Unknown".
+
+    We DON'T use maps_uri when a website exists: a map pin strips the
+    reservations page the user actually wants.
     """
-    iso_date = when.strftime("%Y-%m-%d")
-    iso_time = when.strftime("%H:%M")
     website = details.website_uri
-
-    if detected == "resy" and website:
-        return _append_query(website, {"date": iso_date, "seats": party_size}), "resy"
-
-    if detected == "tock" and website:
-        return (
-            _append_query(
-                website,
-                {"date": iso_date, "size": party_size, "time": iso_time},
-            ),
-            "tock",
-        )
-
-    if detected == "opentable" and website:
-        return (
-            _append_query(
-                website,
-                {"covers": party_size, "dateTime": f"{iso_date}T{iso_time}"},
-            ),
-            "opentable",
-        )
-
-    # Three-tier fallback when no provider deep-link is available:
-    #   1. The venue's own website (most likely to host a reservations page).
-    #   2. Google Maps via the row's maps_uri (deep-link to the pin).
-    #   3. Google Maps via a name search (last resort — no website, no pin).
-    # We DON'T use maps_uri when a website exists: a map pin strips the
-    # reservations page the user actually wants.
+    spec = _PROVIDER_SPECS.get(detected)
+    if spec and website:
+        params = spec.params(when.strftime("%Y-%m-%d"), when.strftime("%H:%M"), party_size)
+        return _append_query(website, params), detected
     if website:
         return website, "unknown"
     if details.maps_uri:
@@ -128,17 +145,6 @@ def _append_query(url: str, params: dict) -> str:
     return f"{url}{sep}{urlencode(params)}"
 
 
-_NOTES: dict[Provider, str] = {
-    "resy": "Tap to open Resy with your date and party size pre-filled.",
-    "tock": "Tap to open Tock with your reservation pre-filled.",
-    "opentable": "Tap to open OpenTable with your reservation pre-filled.",
-    "unknown": (
-        "Online booking not detected; opens the venue's website. "
-        "You may need to find their reservations page."
-    ),
-    "google_maps": "No website on file; opens Google Maps.",
-}
-
-
 def _notes_for(provider: Provider) -> str:
-    return _NOTES[provider]
+    spec = _PROVIDER_SPECS.get(provider)
+    return spec.notes if spec is not None else _FALLBACK_NOTES[provider]

--- a/app/tools/booking.py
+++ b/app/tools/booking.py
@@ -15,14 +15,12 @@ propose_booking from app/agent/graph.py without involving the LLM.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
 from urllib.parse import urlencode, urlparse
 
 from pydantic import BaseModel
 
+from app.tools.booking_types import Provider
 from app.tools.retrieval import PlaceDetails, get_details
-
-Provider = Literal["resy", "tock", "opentable", "google_maps", "unknown"]
 
 
 class BookingProposal(BaseModel):

--- a/app/tools/booking.py
+++ b/app/tools/booking.py
@@ -1,0 +1,133 @@
+"""Booking handoff. Detect the reservation provider for a place and build a
+deep-link with date / party size / time pre-filled where the provider's URL
+scheme supports it. Falls back to Google Maps when no provider is detected.
+
+Not automation: the user still confirms the reservation on the provider's
+site. See implementation_plan/james/w4_booking_stub.md for the design and the
+docs/api/chat_contract.md "Booking" section for the frontend contract.
+
+This module is deliberately a plain library — it is NOT registered as an LLM
+tool. URL construction is a deterministic transform of (place_id, when,
+party_size); the agent graph auto-enriches committed stops by calling
+propose_booking from app/agent/graph.py without involving the LLM.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from urllib.parse import urlencode, urlparse
+
+from pydantic import BaseModel
+
+from app.tools.retrieval import PlaceDetails, get_details
+
+Provider = Literal["resy", "tock", "opentable", "google_maps", "unknown"]
+
+
+class BookingProposal(BaseModel):
+    place_id: str
+    provider: Provider
+    booking_url: str
+    automation_available: bool = False
+    notes: str | None = None
+
+
+def detect_provider(website_uri: str | None) -> Provider:
+    if not website_uri:
+        return "unknown"
+    host = (urlparse(website_uri).hostname or "").lower()
+    if "resy.com" in host:
+        return "resy"
+    if "exploretock.com" in host or "tock.com" in host:
+        return "tock"
+    if "opentable.com" in host:
+        return "opentable"
+    return "unknown"
+
+
+def propose_booking(
+    place_id: str,
+    when: datetime,
+    party_size: int = 2,
+) -> BookingProposal:
+    """Build a deep-link to the venue's booking flow.
+
+    Raises ValueError if `place_id` is not in the DB. The caller (graph
+    auto-enrichment) should swallow this and skip enrichment for that stop —
+    a missing booking URL is recoverable; a 500 from a leaf utility is not.
+    """
+    details = get_details(place_id=place_id)
+    if details is None:
+        raise ValueError(f"unknown place_id {place_id}")
+
+    detected = detect_provider(details.website_uri)
+    url, effective = _build_booking_url(detected, details, when, party_size)
+    return BookingProposal(
+        place_id=place_id,
+        provider=effective,
+        booking_url=url,
+        notes=_notes_for(effective),
+    )
+
+
+def _build_booking_url(
+    detected: Provider,
+    details: PlaceDetails,
+    when: datetime,
+    party_size: int,
+) -> tuple[str, Provider]:
+    """Return (url, effective_provider). The effective provider may differ from
+    the detected one when we have to fall back — e.g. detected=unknown with no
+    website becomes google_maps. The frontend keys its label off the effective
+    provider so users see "Open in Google Maps" rather than "Open in Unknown".
+    """
+    iso_date = when.strftime("%Y-%m-%d")
+    iso_time = when.strftime("%H:%M")
+    website = details.website_uri
+
+    if detected == "resy" and website:
+        return _append_query(website, {"date": iso_date, "seats": party_size}), "resy"
+
+    if detected == "tock" and website:
+        return (
+            _append_query(
+                website,
+                {"date": iso_date, "size": party_size, "time": iso_time},
+            ),
+            "tock",
+        )
+
+    if detected == "opentable" and website:
+        return (
+            _append_query(
+                website,
+                {"covers": party_size, "dateTime": f"{iso_date}T{iso_time}"},
+            ),
+            "opentable",
+        )
+
+    if details.maps_uri:
+        return details.maps_uri, "google_maps"
+    return (
+        f"https://www.google.com/maps/search/?api=1&query={details.name}",
+        "google_maps",
+    )
+
+
+def _append_query(url: str, params: dict) -> str:
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}{urlencode(params)}"
+
+
+_NOTES: dict[Provider, str] = {
+    "resy": "Tap to open Resy with your date and party size pre-filled.",
+    "tock": "Tap to open Tock with your reservation pre-filled.",
+    "opentable": "Tap to open OpenTable with your reservation pre-filled.",
+    "google_maps": "No online booking detected; opens Google Maps.",
+    "unknown": "Online booking not detected.",
+}
+
+
+def _notes_for(provider: Provider) -> str:
+    return _NOTES[provider]

--- a/app/tools/booking.py
+++ b/app/tools/booking.py
@@ -76,9 +76,11 @@ def _build_booking_url(
     party_size: int,
 ) -> tuple[str, Provider]:
     """Return (url, effective_provider). The effective provider may differ from
-    the detected one when we have to fall back — e.g. detected=unknown with no
-    website becomes google_maps. The frontend keys its label off the effective
-    provider so users see "Open in Google Maps" rather than "Open in Unknown".
+    the detected one when we fall back. Three-tier fallback when no provider
+    deep-link is available: venue website ("unknown"), then google_maps via
+    the row's maps_uri, then google_maps via a name search. The frontend keys
+    its label off the effective provider so the user sees "Open venue website"
+    or "Open in Google Maps" rather than "Open in Unknown".
     """
     iso_date = when.strftime("%Y-%m-%d")
     iso_time = when.strftime("%H:%M")
@@ -105,6 +107,14 @@ def _build_booking_url(
             "opentable",
         )
 
+    # Three-tier fallback when no provider deep-link is available:
+    #   1. The venue's own website (most likely to host a reservations page).
+    #   2. Google Maps via the row's maps_uri (deep-link to the pin).
+    #   3. Google Maps via a name search (last resort — no website, no pin).
+    # We DON'T use maps_uri when a website exists: a map pin strips the
+    # reservations page the user actually wants.
+    if website:
+        return website, "unknown"
     if details.maps_uri:
         return details.maps_uri, "google_maps"
     return (
@@ -122,8 +132,11 @@ _NOTES: dict[Provider, str] = {
     "resy": "Tap to open Resy with your date and party size pre-filled.",
     "tock": "Tap to open Tock with your reservation pre-filled.",
     "opentable": "Tap to open OpenTable with your reservation pre-filled.",
-    "google_maps": "No online booking detected; opens Google Maps.",
-    "unknown": "Online booking not detected.",
+    "unknown": (
+        "Online booking not detected; opens the venue's website. "
+        "You may need to find their reservations page."
+    ),
+    "google_maps": "No website on file; opens Google Maps.",
 }
 
 

--- a/app/tools/booking.py
+++ b/app/tools/booking.py
@@ -98,11 +98,22 @@ def propose_booking(
     details = get_details(place_id=place_id)
     if details is None:
         raise ValueError(f"unknown place_id {place_id}")
+    return propose_booking_from_details(details, when, party_size)
 
+
+def propose_booking_from_details(
+    details: PlaceDetails,
+    when: datetime,
+    party_size: int = 2,
+) -> BookingProposal:
+    """URL construction without the DB read. Used by graph enrichment after
+    a single batched get_details_many call replaces what would otherwise be
+    N round-trips for an N-stop itinerary. propose_booking() above remains
+    the convenient single-place entry point for direct callers + tests."""
     detected = detect_provider(details.website_uri)
     url, effective = _build_booking_url(detected, details, when, party_size)
     return BookingProposal(
-        place_id=place_id,
+        place_id=details.place_id,
         provider=effective,
         booking_url=url,
         notes=_notes_for(effective),

--- a/app/tools/booking.py
+++ b/app/tools/booking.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from urllib.parse import urlencode, urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
 from pydantic import BaseModel
 
@@ -141,8 +141,18 @@ def _build_booking_url(
 
 
 def _append_query(url: str, params: dict) -> str:
-    sep = "&" if "?" in url else "?"
-    return f"{url}{sep}{urlencode(params)}"
+    """Merge `params` into the URL's query string, replacing existing keys.
+
+    Uses urlsplit/urlunsplit so fragments are preserved, pre-encoded params
+    are decoded then re-encoded canonically, and our params overwrite any
+    pre-existing same-key params (so e.g. our `date=2026-04-26` wins over a
+    `?date=lunch` in the input). Hand-rolled string concat got this wrong on
+    fragments (`#section?...` is server-invisible) and same-key collisions.
+    """
+    parts = urlsplit(url)
+    merged = dict(parse_qsl(parts.query, keep_blank_values=True))
+    merged.update({k: str(v) for k, v in params.items()})
+    return urlunsplit(parts._replace(query=urlencode(merged)))
 
 
 def _notes_for(provider: Provider) -> str:

--- a/app/tools/booking.py
+++ b/app/tools/booking.py
@@ -134,10 +134,11 @@ def _build_booking_url(
         return website, "unknown"
     if details.maps_uri:
         return details.maps_uri, "google_maps"
-    return (
-        f"https://www.google.com/maps/search/?api=1&query={details.name}",
-        "google_maps",
-    )
+    # Last-resort name search. Encode the name properly — venue names contain
+    # `&`, unicode, apostrophes, etc., and raw f-string interpolation breaks
+    # for any of those.
+    query = urlencode({"api": "1", "query": details.name})
+    return f"https://www.google.com/maps/search/?{query}", "google_maps"
 
 
 def _append_query(url: str, params: dict) -> str:

--- a/app/tools/booking_types.py
+++ b/app/tools/booking_types.py
@@ -1,0 +1,12 @@
+"""Closed set of booking providers, factored out so both app.tools.booking
+(producer) and app.agent.state (consumer, via Stop / PlaceCard) can share one
+definition without a circular import.
+
+Adding a new provider is a single-source-of-truth change here; both the URL
+builder and the persisted Stop will pick it up."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+Provider = Literal["resy", "tock", "opentable", "google_maps", "unknown"]

--- a/app/tools/retrieval.py
+++ b/app/tools/retrieval.py
@@ -179,6 +179,29 @@ def get_details(place_id: str) -> PlaceDetails | None:
     return PlaceDetails(**rows[0])
 
 
+def get_details_many(place_ids: list[str]) -> dict[str, PlaceDetails]:
+    """Batched get_details. One SQL round-trip for the whole list, returning
+    a {place_id: PlaceDetails} dict. Missing place_ids are absent from the
+    result (callers filter / handle accordingly). Used by booking enrichment
+    on commit_itinerary to avoid an N+1 over the committed stops."""
+    if not place_ids:
+        return {}
+    view = _view_name()  # validated allowlist member — safe to f-string
+    sql = f"""
+        SELECT
+            place_id, name, primary_type, types, formatted_address,
+            latitude, longitude, rating, user_rating_count, price_level,
+            business_status, website_uri, maps_uri, editorial_summary,
+            regular_opening_hours, source,
+            LEFT(embedding_text, 800) AS snippet,
+            0.0 AS similarity
+        FROM {view}
+        WHERE place_id = ANY(%s)
+    """  # noqa: S608
+    rows = _execute(sql, [place_ids])
+    return {row["place_id"]: PlaceDetails(**row) for row in rows}
+
+
 # Re-export for the test that asserts the mapping covers the allowlist.
 __all__ = [
     "PlaceHit",
@@ -186,6 +209,7 @@ __all__ = [
     "semantic_search",
     "nearby",
     "get_details",
+    "get_details_many",
     "_VIEW_FOR_TABLE",
     "ALLOWED_EMBEDDING_TABLES",
 ]

--- a/docs/api/chat_contract.md
+++ b/docs/api/chat_contract.md
@@ -126,8 +126,9 @@ reservation on the provider's site. We cannot guarantee table availability —
 | `"resy"` | "Open in Resy" | Opens Resy with date + party size pre-filled. |
 | `"tock"` | "Open in Tock" | Opens Tock with date + size + time pre-filled. |
 | `"opentable"` | "Open in OpenTable" | Opens OpenTable with covers + dateTime pre-filled. |
-| `"google_maps"` | "View on Google Maps" | No online booking detected. |
-| `null` | (no button) | Enrichment failed or the place has no website + no maps URL. Extremely rare. |
+| `"unknown"` | "Visit website" | Provider not detected; opens the venue's website. The user finds the reservations page themselves. |
+| `"google_maps"` | "View on Google Maps" | No website on file; opens Google Maps. |
+| `null` | (no button) | Enrichment failed. Extremely rare. |
 
 ### Frontend usage
 
@@ -146,6 +147,7 @@ const LABELS = {
   resy:        'Open in Resy',
   tock:        'Open in Tock',
   opentable:   'Open in OpenTable',
+  unknown:     'Visit website',
   google_maps: 'View on Google Maps',
 };
 const labelFor = (p) => LABELS[p] ?? 'Visit website';

--- a/docs/api/chat_contract.md
+++ b/docs/api/chat_contract.md
@@ -1,0 +1,276 @@
+# Chat API Contract (frontend ↔ backend)
+
+This is the source of truth for the HTTP contract the City Concierge frontend
+calls. Backend code: `app/main.py`, `app/agent/state.py`, `app/agent/io.py`.
+
+If you find this doc disagreeing with the code, the code wins — but please
+open an issue or fix the doc in the same PR.
+
+Last updated for: W4 (booking handoff). Reflects everything merged W0 → W4.
+
+---
+
+## Endpoint inventory
+
+| Method + path | Purpose | Status |
+|---|---|---|
+| `POST /chat` | Agent-driven itinerary (W2/W3) | ✅ Active — primary endpoint |
+| `POST /predict` | Legacy single-pass RAG (pre-W2) | ⚠️ Compatibility shim — currently used by frontend; migrate to `/chat` |
+| `GET /health` | App + LLM config status | ✅ Active |
+| `GET /health/db` | DB connectivity check | ✅ Active |
+| `GET /root` | Hello-world | ✅ Active |
+
+Base URL is configured via `VITE_API_URL` (see `frontend/src/api/chat.js`).
+Local dev default: `http://localhost:8000`. Production: Cloud Run service URL.
+
+---
+
+## `POST /chat` — primary endpoint
+
+The agent plans a multi-stop itinerary, grounded in the structured DB.
+Conversation history is stateless on the backend — the frontend sends the full
+history each turn.
+
+### Request
+
+```json
+{
+  "message": "plan a date night in north beach: dinner around 7, drinks then dessert, all under $$$",
+  "history": [
+    { "role": "user", "content": "earlier user message" },
+    { "role": "assistant", "content": "earlier assistant reply" }
+  ]
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `message` | string | Current user turn. |
+| `history` | array | Prior turns. Empty on the first turn. Each item has `role: "user" \| "assistant"` and `content: string`. |
+
+### Response
+
+```json
+{
+  "reply": "I've put together a North Beach date night...",
+  "places": [PlaceCard, ...],
+  "ragLabel": "openai:gpt-4o"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `reply` | string | The agent's final natural-language reply. May be a clarifying question instead of an itinerary — see "Multi-turn flows" below. |
+| `places` | array of PlaceCard | Committed stops, in itinerary order. Empty array when the reply is a clarifying question or an error apology. |
+| `ragLabel` | string | Model identifier (`provider:model`) for UI badge. Falls back to `"unknown"` if the active model config can't be read. |
+
+### `PlaceCard` shape
+
+```ts
+{
+  place_id:         string,         // Google Places ID; stable across calls
+  name:             string,
+  address:          string | null,
+  rating:           number | null,  // 0-5
+  price_level:      number | null,  // 0-4 (Google scale)
+  primary_type:     string | null,  // e.g. "restaurant", "cocktail_bar"
+  arrival_time:     string | null,  // ISO 8601 datetime, agent-planned
+  rationale:        string,         // 1-2 sentence justification
+  booking_url:      string | null,  // see Booking section below (W4)
+  booking_provider: string | null   // see Booking section below (W4)
+}
+```
+
+`place_id` is the join key for everything: maps, future detail pages, the
+booking link. Always include it in any UI keys / cache lookups.
+
+### Multi-turn flows
+
+The agent sometimes returns a clarifying question instead of an itinerary
+(e.g. "How many stops would you like?"). In that case:
+
+- `places` is `[]`
+- `reply` contains the question
+- The frontend appends both the user's message and the assistant's reply to
+  `history` and waits for the next user turn
+
+There is no special status code or flag — the empty `places` array is the
+signal. Keep the chat UI layout flexible enough to render an
+itinerary-less assistant turn.
+
+### Errors
+
+| Status | Body shape | When |
+|---|---|---|
+| 503 | `{"detail": "Agent graph unavailable: ..."}` | MLflow registry was unreachable when the app booted. The agent isn't loaded. |
+| 422 | `{"detail": [...FastAPI validation errors...]}` | Request body doesn't match `ChatRequest`. |
+| 500 | `{"detail": "..."}` | Unhandled exception in the graph. Should be rare; surface as a generic "something went wrong" toast. |
+
+The frontend should treat 503 as a long-lived "AI offline" state — it persists
+until the backend restarts. Polling `/health` is the cheap way to check.
+
+---
+
+## Booking integration (W4)
+
+When the agent commits an itinerary, every stop is auto-enriched with a
+`booking_url` + `booking_provider`. The frontend renders these as a
+link/button per card.
+
+This is a **handoff**, not a confirmed booking. The user still completes the
+reservation on the provider's site. We cannot guarantee table availability —
+**the button MUST NOT say "Book now" or "Reserve."** Suggested labels:
+
+| `booking_provider` | Label | Notes |
+|---|---|---|
+| `"resy"` | "Open in Resy" | Opens Resy with date + party size pre-filled. |
+| `"tock"` | "Open in Tock" | Opens Tock with date + size + time pre-filled. |
+| `"opentable"` | "Open in OpenTable" | Opens OpenTable with covers + dateTime pre-filled. |
+| `"google_maps"` | "View on Google Maps" | No online booking detected. |
+| `null` | (no button) | Enrichment failed or the place has no website + no maps URL. Extremely rare. |
+
+### Frontend usage
+
+```jsx
+{place.booking_url && (
+  <a
+    href={place.booking_url}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    {labelFor(place.booking_provider)}
+  </a>
+)}
+
+const LABELS = {
+  resy:        'Open in Resy',
+  tock:        'Open in Tock',
+  opentable:   'Open in OpenTable',
+  google_maps: 'View on Google Maps',
+};
+const labelFor = (p) => LABELS[p] ?? 'Visit website';
+```
+
+Always open in a new tab (`target="_blank" rel="noopener noreferrer"`) —
+booking flows are multi-step and the user shouldn't lose the chat.
+
+---
+
+## `POST /predict` — legacy contract
+
+The frontend currently calls `/predict` (`frontend/src/api/chat.js`). It's a
+single-pass RAG endpoint that predates the agent. New work should target
+`/chat`; `/predict` stays as a compatibility shim until the frontend migrates.
+
+### Request
+
+```json
+{ "query": "Best tacos in the Mission", "limit": 5 }
+```
+
+### Response
+
+```json
+{
+  "response": "Here are some recommendations...",
+  "sources": [
+    {
+      "name":         "...",
+      "rating":       4.5,
+      "address":      "...",
+      "similarity":   0.83,
+      "place_id":     "...",
+      "primary_type": "restaurant"
+    }
+  ]
+}
+```
+
+### Errors
+
+| Status | When |
+|---|---|
+| 503 | RAG chain wasn't loaded at boot (MLflow unreachable). |
+| 422 | Body doesn't match `RecommendationRequest`. |
+
+---
+
+## `/chat` migration guide (for the frontend dev doing the swap)
+
+| Old (`/predict`) | New (`/chat`) | Notes |
+|---|---|---|
+| `query` | `message` | |
+| `limit` | _(removed)_ | Agent decides stop count. Pass-through to nothing. |
+| _(none)_ | `history` | Send the full prior conversation each turn. |
+| `response` (string) | `reply` (string) | Same idea. |
+| `sources[]` | `places[]` | Different shape — see `PlaceCard` above. |
+| `sources[].name` | `places[].name` | Same. |
+| `sources[].rating` | `places[].rating` | Same. |
+| `sources[].address` | `places[].address` | Same. |
+| `sources[].similarity` | _(not exposed)_ | Internal to retrieval. If you want a "match strength" badge, derive from agent rationale or skip. |
+| `sources[].place_id` | `places[].place_id` | Same. |
+| `sources[].primary_type` | `places[].primary_type` | Same. |
+| _(none)_ | `places[].arrival_time` | New: itinerary order + planned time. Render as "7:00 PM" near the place name. |
+| _(none)_ | `places[].rationale` | New: 1-2 sentence justification. Render below the name. |
+| _(none)_ | `places[].booking_url` + `booking_provider` | New (W4). See Booking section. |
+| _(none)_ | `ragLabel` | Already in `/predict` adapter as a derived field; now comes from the backend directly. |
+
+The mock-data path (`MOCK_PLACES` in `frontend/src/api/chat.js`) can stay —
+it predates both endpoints and is unrelated to backend wire format.
+
+---
+
+## `GET /health`
+
+```json
+// when ready
+{ "status": "ok", "llm_provider": "openai", "chat_model": "gpt-4o" }
+
+// when MLflow registry was unreachable at boot
+{ "status": "degraded", "rag_chain": "unavailable" }
+```
+
+Use this for an "AI offline" banner. Cheap and unauthenticated.
+
+## `GET /health/db`
+
+```json
+// 200
+{ "status": "ok" }
+
+// 500 if the DB pool is down
+```
+
+Mainly for ops / readiness probes. The frontend doesn't need to call this.
+
+---
+
+## CORS
+
+`app/main.py` configures CORS via the `cors_allow_origins` setting. Allowed
+methods: `GET`, `POST`, `OPTIONS`. Allowed headers: `*`.
+
+If you serve the frontend from a new origin (preview deploy, custom domain),
+update the backend allowlist before going live or browser requests will fail
+with a CORS error.
+
+---
+
+## What's NOT yet in the contract
+
+These are deliberately not exposed today. If the frontend starts depending on
+them, surface that need so we can plan it.
+
+- **Trace IDs** — Langfuse traces (W0) are emitted server-side but not
+  echoed back in response headers. If we ever want a "View trace" debug
+  link, we'd add `X-Trace-Id`.
+- **Knowledge-graph fields** — `kg_traverse` returns a "not yet available"
+  stub today; W7 will populate place relations. No frontend impact until then.
+- **Booking automation status** — `automation_available` exists on the
+  backend `BookingProposal` model but is always `false` today. Future
+  Playwright PR may flip it; the field isn't on `PlaceCard` yet.
+- **Per-stop walking distance** — the agent computes walking math internally
+  but doesn't surface "0.3 mi from previous stop" on the card. Add to
+  `PlaceCard` if/when designs need it.
+- **Streaming** — `/chat` is request/response. No SSE / chunked streaming.
+  Acceptable for short replies; revisit if median latency exceeds ~3s.

--- a/implementation_plan/james/FUTURE_WATCH.md
+++ b/implementation_plan/james/FUTURE_WATCH.md
@@ -43,6 +43,30 @@ reassess — but plain edge tables are likely still simpler at this scale.
 
 ## Watch as the codebase grows
 
+### `PlaceCard` is missing address / rating / price_level
+
+**What:** `state_to_cards` (`app/agent/io.py:38`) projects `Stop` → `PlaceCard`,
+but `Stop` never carried `address`, `rating`, or `price_level` (W2 didn't add
+them). Every card the frontend renders has `address: null, rating: null,
+price_level: null` even though `places_raw` has all three. `PlaceCard` declares
+the fields as optional, so the gap is silent.
+
+**Concern:** the frontend gets a degraded card — name + booking link but no
+location, no rating, no price tier. Most place-card UIs surface those.
+
+**Trigger:** before/with the next frontend pass that displays place cards
+prominently. Two viable fixes:
+
+1. Extend `Stop` with `address`/`rating`/`price_level` and populate them in
+   `_commit_stops` from the grounded `PlaceHit`/`PlaceDetails` already in
+   `state.scratch`. Preferred — no extra DB calls, data flows once.
+2. Re-fetch via `get_details(place_id)` inside `state_to_cards`. Costs N reads
+   per commit; only worth it if the scratch path doesn't carry the fields.
+
+Touches `app/agent/state.py` (`Stop`), `app/agent/graph.py` (`_commit_stops`),
+`app/agent/io.py` (`state_to_cards`). Not load-bearing for W4 (booking) — the
+gap predates W4 and was surfaced during W4 review.
+
 ### `app/agent/` directory size
 
 **What:** W2 + W3 + W4 + W7 all add files under `app/agent/`. After everything

--- a/implementation_plan/james/w4_booking_stub.md
+++ b/implementation_plan/james/w4_booking_stub.md
@@ -286,3 +286,19 @@ Manually verify URLs against 3 real SF places (one Resy, one Tock, one no-provid
 - **Provider detection by hostname is shallow.** Some venues link to a chain page (e.g. `https://www.example.com/reservations` that redirects to Resy). We won't detect those. Acceptable; users can still tap and book manually.
 - **Multi-stop bookings:** if the user wants both stops booked, the agent emits two `booking_url`s. Acceptable for the stub. Real automation (later) can chain them.
 - **Future automation gate:** when we add Playwright, gate it on `BOOKING_AUTOMATION_ENABLED=true` AND `BOOKING_USER_ID == settings.demo_user_id`. Never enabled for real users in this plan.
+
+## Status
+
+**Status:** 🚧 In review on `feature/agent-w4-booking-stub` (2026-05-07). Tool surface and frontend contract delivered; deviates from plan in one place (see below).
+
+Deviations from the original plan:
+
+- **`propose_booking` is NOT registered as an LLM tool.** The plan called for the agent to invoke `propose_booking` after committing stops, with prompt instructions and Pydantic AI validation at the tool boundary. Implementation instead auto-enriches every committed stop deterministically inside `_commit_stops` (`app/agent/graph.py:97`), without involving the LLM. URL construction is a pure transform of `(place_id, when, party_size)` — there is no judgment for the LLM to add — and `_commit_stops` has already validated grounding, so the LLM cannot hallucinate a `place_id` into a booking URL. Trade-off: the tool surface no longer "locks in" via prompt; the future Playwright PR will need to either re-introduce the tool or extend `_enrich_with_booking` directly. Net win on correctness (no missed enrichment, no malformed `party_size: "two"`) and token cost.
+- `app/tools/booking.py` is a plain library; `app/agent/tools.py` and `app/agent/prompts.py` are unchanged from W3.
+- `_build_booking_url` returns `(url, effective_provider)` so the frontend label keys off the post-fallback provider (e.g. `google_maps`, not `unknown`) — small departure from the plan's single-Provider return.
+- Frontend wire contract documented in `docs/api/chat_contract.md` (W0–W4).
+
+Deferred to a follow-up PR (not in this plan):
+
+- Real Playwright automation behind `BOOKING_AUTOMATION_ENABLED`.
+- Per-provider URL scheme drift monitoring.

--- a/tests/integration/test_booking.py
+++ b/tests/integration/test_booking.py
@@ -1,0 +1,56 @@
+"""Integration test for booking handoff against a real Postgres + pgvector.
+
+Exercises propose_booking end-to-end: real get_details query against the
+places_raw table, real provider detection from the row's website_uri, real
+URL construction. Skipped unless APP_ENV=integration is set.
+
+Run with:
+    make db-up
+    APP_ENV=integration poetry run pytest tests/integration/test_booking.py
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("APP_ENV", "test") != "integration",
+    reason="Set APP_ENV=integration and provide a real DATABASE_URL to run integration tests.",
+)
+
+from app.tools.booking import propose_booking  # noqa: E402
+from app.tools.retrieval import semantic_search  # noqa: E402
+
+
+def _any_real_place_id() -> str:
+    """Pick any place_id from the live DB so we don't hard-code a fixture
+    that drifts. semantic_search is the same path the agent uses."""
+    hits = semantic_search(query="restaurant", k=1)
+    if not hits:
+        pytest.skip("places_raw is empty; seed the DB before running integration tests.")
+    return hits[0].place_id
+
+
+def test_propose_booking_against_real_database() -> None:
+    """Real DB lookup + real URL construction. The exact provider depends on
+    what's seeded — we just assert the contract holds: a non-empty URL, a
+    valid Provider literal value, and notes populated for any branch."""
+    place_id = _any_real_place_id()
+    proposal = propose_booking(place_id, datetime(2026, 5, 7, 19, 30), party_size=2)
+
+    assert proposal.place_id == place_id
+    assert proposal.booking_url
+    assert proposal.booking_url.startswith("http")
+    assert proposal.provider in {"resy", "tock", "opentable", "google_maps", "unknown"}
+    assert proposal.notes is not None
+
+
+def test_propose_booking_unknown_place_id_raises_against_real_db() -> None:
+    """A place_id that isn't in the DB raises ValueError, not a silent None."""
+    with pytest.raises(ValueError, match="unknown place_id"):
+        propose_booking(
+            "definitely-not-a-real-place-id-zzz", datetime(2026, 5, 7, 19, 30), party_size=2
+        )

--- a/tests/integration/test_booking.py
+++ b/tests/integration/test_booking.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 from app.tools.booking import propose_booking  # noqa: E402
-from app.tools.retrieval import semantic_search  # noqa: E402
+from app.tools.retrieval import get_details, semantic_search  # noqa: E402
 
 
 def _any_real_place_id() -> str:
@@ -36,16 +36,44 @@ def _any_real_place_id() -> str:
 
 def test_propose_booking_against_real_database() -> None:
     """Real DB lookup + real URL construction. The exact provider depends on
-    what's seeded — we just assert the contract holds: a non-empty URL, a
-    valid Provider literal value, and notes populated for any branch."""
+    what's seeded; whichever tier we land on, the assertions for THAT tier's
+    contract must hold (params present, URL pointing at the right thing)."""
     place_id = _any_real_place_id()
-    proposal = propose_booking(place_id, datetime(2026, 5, 7, 19, 30), party_size=2)
+    when = datetime(2026, 5, 7, 19, 30)
+    proposal = propose_booking(place_id, when, party_size=2)
 
     assert proposal.place_id == place_id
     assert proposal.booking_url
     assert proposal.booking_url.startswith("http")
     assert proposal.provider in {"resy", "tock", "opentable", "google_maps", "unknown"}
     assert proposal.notes is not None
+
+    # Provider-tier-specific contract. Loose set-membership above passes for any
+    # URL; these per-tier checks would fail if the URL builder regressed (wrong
+    # row, missing params, fallback inverted).
+    iso_date = "2026-05-07"
+    iso_time = "19:30"
+    if proposal.provider == "resy":
+        assert f"date={iso_date}" in proposal.booking_url
+        assert "seats=2" in proposal.booking_url
+    elif proposal.provider == "tock":
+        assert f"date={iso_date}" in proposal.booking_url
+        assert "size=2" in proposal.booking_url
+        # urlencode percent-encodes the colon in HH:MM.
+        assert "time=19%3A30" in proposal.booking_url
+    elif proposal.provider == "opentable":
+        assert "covers=2" in proposal.booking_url
+        assert f"dateTime={iso_date}T{iso_time.replace(':', '%3A')}" in proposal.booking_url
+    elif proposal.provider == "unknown":
+        # Three-tier fallback: when no provider deep-link is detected but the
+        # row has a website, we return that website unchanged.
+        details = get_details(place_id=place_id)
+        assert details is not None
+        assert proposal.booking_url == details.website_uri
+    elif proposal.provider == "google_maps":
+        # Either the row's maps_uri or the name-search fallback. Both go to
+        # google.com/maps and carry no booking params (none exist for Maps).
+        assert "google.com/maps" in proposal.booking_url
 
 
 def test_propose_booking_unknown_place_id_raises_against_real_db() -> None:

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
@@ -363,8 +364,6 @@ def test_commit_stops_enrichment_propagates_programmer_errors() -> None:
     """Bugs in enrichment (TypeError, AttributeError, etc.) must NOT be
     silently swallowed — that's how regressions ship to prod undetected. Only
     the documented recoverable cases (missing place_id, DB blip) are caught."""
-    import pytest
-
     state = _state_with_grounded(["p1"])
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
@@ -466,6 +465,91 @@ def test_enrich_stops_with_booking_mutates_in_place() -> None:
     # Both got party_size=4 from constraints (no per-stop arrival_time).
     assert all(s.booking_provider == "tock" for s in stops)
     assert all("size=4" in (s.booking_url or "") for s in stops)
+
+
+def test_enrich_skipped_when_no_time_anywhere() -> None:
+    """Neither stop.arrival_time nor constraints.when is set → enrichment must
+    skip the stop, NOT inject datetime.now(). The wall-clock fallback would
+    embed a timestamp in the URL that's meaningless to the user and breaks
+    re-commit idempotency (same inputs, different URL each call)."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(constraints=UserConstraints(party_size=2))  # when=None
+
+    propose = patch("app.agent.graph.propose_booking")
+    with propose as mock_propose:
+        enrich_stops_with_booking(stops, state)
+
+    # Crucially, propose_booking was NOT called — the no-time path skips entirely.
+    mock_propose.assert_not_called()
+    assert stops[0].booking_url is None
+    assert stops[0].booking_provider is None
+
+
+def test_enrich_idempotent_when_no_time_set() -> None:
+    """The no-time skip preserves re-commit idempotency: same inputs in,
+    same (absent) booking link out, both calls."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(constraints=UserConstraints(party_size=2))
+
+    with patch("app.agent.graph.propose_booking") as mock_propose:
+        enrich_stops_with_booking(stops, state)
+        first_url = stops[0].booking_url
+        enrich_stops_with_booking(stops, state)
+        second_url = stops[0].booking_url
+
+    assert first_url is None
+    assert second_url is None
+    assert mock_propose.call_count == 0
+
+
+def test_enrich_uses_constraints_when_when_arrival_time_missing() -> None:
+    """If a stop has no arrival_time but constraints.when IS set, the constraint
+    fills in. (Counterpoint to the skip test above — make sure we don't skip
+    too aggressively.)"""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    captured: list[datetime] = []
+
+    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+        captured.append(when)
+        return BookingProposal(place_id=place_id, provider="resy", booking_url="https://x")
+
+    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+        enrich_stops_with_booking(stops, state)
+
+    assert captured == [datetime(2026, 5, 7, 19, 0)]
+
+
+@pytest.mark.parametrize("party_size_in,expected_in_call", [(None, 2), (0, 2), (4, 4), (1, 1)])
+def test_enrich_party_size_defaulting(party_size_in: int | None, expected_in_call: int) -> None:
+    """party_size None or 0 → defaults to 2 (you can't book a table for 0).
+    Other positive values pass through unchanged. Locks the `or 2` semantics
+    so a future refactor doesn't accidentally allow 0-party bookings or change
+    the default."""
+    stops = [
+        Stop(
+            place_id="p1",
+            name="A",
+            rationale="r",
+            source="google_places",
+            arrival_time=datetime(2026, 5, 7, 19, 0),
+        )
+    ]
+    state = ItineraryState(constraints=UserConstraints(party_size=party_size_in))
+
+    captured: list[int] = []
+
+    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+        captured.append(party_size)
+        return BookingProposal(place_id=place_id, provider="resy", booking_url="https://x")
+
+    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+        enrich_stops_with_booking(stops, state)
+
+    assert captured == [expected_in_call]
 
 
 def test_enrich_stops_with_booking_uses_arrival_time_per_stop() -> None:

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -3,15 +3,18 @@ of tool calls. Verifies plan->act->critique loops correctly and terminates."""
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
+from unittest.mock import patch
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 
-from app.agent.graph import _prune_for_llm, build_agent_graph
-from app.agent.state import ItineraryState
+from app.agent.graph import _commit_stops, _prune_for_llm, build_agent_graph
+from app.agent.state import ItineraryState, UserConstraints
+from app.tools.booking import BookingProposal
 from app.tools.retrieval import PlaceHit
 
 
@@ -271,3 +274,57 @@ def test_prune_for_llm_drops_oldest_tool_exchanges() -> None:
     # the tool_calls so the LLM doesn't see an unanswered call.
     ai_with_tools = [m for m in pruned if isinstance(m, AIMessage) and m.tool_calls]
     assert len(ai_with_tools) == 2  # the two most recent
+
+
+def _state_with_grounded(place_ids: list[str], party_size: int = 2) -> ItineraryState:
+    """Build a state where the given place_ids appear in scratch, so
+    _commit_stops considers them grounded."""
+    hits = [
+        PlaceHit(place_id=pid, name=f"Place {pid}", source="google_places", similarity=0.9)
+        for pid in place_ids
+    ]
+    return ItineraryState(
+        scratch={"semantic_search": [{"args": {}, "result": hits, "step": 0, "id": "s1"}]},
+        constraints=UserConstraints(party_size=party_size, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+
+def test_commit_stops_enriches_with_booking() -> None:
+    """Auto-enrichment must stamp booking_url + booking_provider on every
+    committed stop, without the LLM needing to call propose_booking."""
+    state = _state_with_grounded(["p1", "p2"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "first", "source": "google_places"},
+        {"place_id": "p2", "name": "Place p2", "rationale": "second", "source": "google_places"},
+    ]
+
+    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+        return BookingProposal(
+            place_id=place_id,
+            provider="resy",
+            booking_url=f"https://resy.com/{place_id}?seats={party_size}",
+        )
+
+    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+        committed, payload = _commit_stops(state, raw_stops)
+
+    assert payload["committed"] == ["p1", "p2"]
+    assert all(s.booking_url is not None for s in committed)
+    assert all(s.booking_provider == "resy" for s in committed)
+    assert "p1" in committed[0].booking_url
+    assert "seats=2" in committed[0].booking_url
+
+
+def test_commit_stops_enrichment_swallows_propose_booking_errors() -> None:
+    """A failure inside propose_booking (e.g. transient DB miss) must not
+    break commit; the stop is committed without a booking link instead."""
+    state = _state_with_grounded(["p1"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
+    ]
+    with patch("app.agent.graph.propose_booking", side_effect=RuntimeError("db down")):
+        committed, payload = _commit_stops(state, raw_stops)
+
+    assert payload["committed"] == ["p1"]
+    assert committed[0].booking_url is None
+    assert committed[0].booking_provider is None

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -315,16 +315,60 @@ def test_commit_stops_enriches_with_booking() -> None:
     assert "seats=2" in committed[0].booking_url
 
 
-def test_commit_stops_enrichment_swallows_propose_booking_errors() -> None:
-    """A failure inside propose_booking (e.g. transient DB miss) must not
-    break commit; the stop is committed without a booking link instead."""
+def test_commit_stops_enrichment_swallows_value_error_for_unknown_place_id() -> None:
+    """A ValueError from propose_booking (the documented recoverable case —
+    place_id not in DB) must not break commit; the stop is committed without a
+    booking link instead."""
     state = _state_with_grounded(["p1"])
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with patch("app.agent.graph.propose_booking", side_effect=RuntimeError("db down")):
+    with patch(
+        "app.agent.graph.propose_booking",
+        side_effect=ValueError("unknown place_id p1"),
+    ):
         committed, payload = _commit_stops(state, raw_stops)
 
     assert payload["committed"] == ["p1"]
     assert committed[0].booking_url is None
     assert committed[0].booking_provider is None
+
+
+def test_commit_stops_enrichment_swallows_psycopg_db_blip() -> None:
+    """A transient DB error during enrichment shouldn't kill the whole commit
+    — the user still gets the planned stops, just without booking links."""
+    import psycopg2
+
+    state = _state_with_grounded(["p1"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
+    ]
+    with patch(
+        "app.agent.graph.propose_booking",
+        side_effect=psycopg2.OperationalError("connection blip"),
+    ):
+        committed, payload = _commit_stops(state, raw_stops)
+
+    assert payload["committed"] == ["p1"]
+    assert committed[0].booking_url is None
+    assert committed[0].booking_provider is None
+
+
+def test_commit_stops_enrichment_propagates_programmer_errors() -> None:
+    """Bugs in enrichment (TypeError, AttributeError, etc.) must NOT be
+    silently swallowed — that's how regressions ship to prod undetected. Only
+    the documented recoverable cases (missing place_id, DB blip) are caught."""
+    import pytest
+
+    state = _state_with_grounded(["p1"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
+    ]
+    with (
+        patch(
+            "app.agent.graph.propose_booking",
+            side_effect=TypeError("propose_booking() got an unexpected kwarg"),
+        ),
+        pytest.raises(TypeError),
+    ):
+        _commit_stops(state, raw_stops)

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any
 from unittest.mock import patch
 
+import psycopg2
 import pytest
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -21,7 +22,28 @@ from app.agent.graph import (
 )
 from app.agent.state import ItineraryState, Stop, UserConstraints
 from app.tools.booking import BookingProposal
-from app.tools.retrieval import PlaceHit
+from app.tools.retrieval import PlaceDetails, PlaceHit
+
+
+def _details_for(place_id: str, name: str | None = None) -> PlaceDetails:
+    """Minimal PlaceDetails fixture for booking-enrichment tests. Booking
+    construction itself is mocked via propose_booking_from_details; only the
+    place_id needs to be load-bearing here."""
+    return PlaceDetails(
+        place_id=place_id,
+        name=name or f"Place {place_id}",
+        source="google_places",
+        similarity=0.0,
+    )
+
+
+def _patch_details_many_for(place_ids: list[str]):
+    """Patch get_details_many to return a minimal PlaceDetails for each id.
+    Returns the patcher so tests can also assert call_count if they care."""
+    return patch(
+        "app.agent.graph.get_details_many",
+        return_value={pid: _details_for(pid) for pid in place_ids},
+    )
 
 
 class _ScriptedLLM(BaseChatModel):
@@ -297,21 +319,26 @@ def _state_with_grounded(place_ids: list[str], party_size: int = 2) -> Itinerary
 
 def test_commit_stops_enriches_with_booking() -> None:
     """Auto-enrichment must stamp booking_url + booking_provider on every
-    committed stop, without the LLM needing to call propose_booking."""
+    committed stop, without the LLM calling a tool. Now batched: one
+    get_details_many fetches details for all stops in a single round-trip,
+    then per-stop URL construction is pure."""
     state = _state_with_grounded(["p1", "p2"])
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "first", "source": "google_places"},
         {"place_id": "p2", "name": "Place p2", "rationale": "second", "source": "google_places"},
     ]
 
-    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
         return BookingProposal(
-            place_id=place_id,
+            place_id=details.place_id,
             provider="resy",
-            booking_url=f"https://resy.com/{place_id}?seats={party_size}",
+            booking_url=f"https://resy.com/{details.place_id}?seats={party_size}",
         )
 
-    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+    with (
+        _patch_details_many_for(["p1", "p2"]) as mock_get,
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
         committed, payload = _commit_stops(state, raw_stops)
 
     assert payload["committed"] == ["p1", "p2"]
@@ -319,20 +346,20 @@ def test_commit_stops_enriches_with_booking() -> None:
     assert all(s.booking_provider == "resy" for s in committed)
     assert "p1" in committed[0].booking_url
     assert "seats=2" in committed[0].booking_url
+    # The whole point of this refactor: ONE DB call for the whole commit, not N.
+    assert mock_get.call_count == 1
 
 
-def test_commit_stops_enrichment_swallows_value_error_for_unknown_place_id() -> None:
-    """A ValueError from propose_booking (the documented recoverable case —
-    place_id not in DB) must not break commit; the stop is committed without a
-    booking link instead."""
+def test_commit_stops_skips_enrichment_for_place_id_missing_from_db() -> None:
+    """If get_details_many returns no row for a committed place_id (race
+    condition: deletion between scratch grounding and enrichment, or a stale
+    id), the stop is committed without a booking link instead of crashing.
+    Same recoverable semantic the old ValueError("unknown place_id") had."""
     state = _state_with_grounded(["p1"])
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with patch(
-        "app.agent.graph.propose_booking",
-        side_effect=ValueError("unknown place_id p1"),
-    ):
+    with patch("app.agent.graph.get_details_many", return_value={}):
         committed, payload = _commit_stops(state, raw_stops)
 
     assert payload["committed"] == ["p1"]
@@ -341,16 +368,15 @@ def test_commit_stops_enrichment_swallows_value_error_for_unknown_place_id() -> 
 
 
 def test_commit_stops_enrichment_swallows_psycopg_db_blip() -> None:
-    """A transient DB error during enrichment shouldn't kill the whole commit
-    — the user still gets the planned stops, just without booking links."""
-    import psycopg2
-
+    """A transient DB error during the batched read shouldn't kill the whole
+    commit — the user still gets the planned stops, just without booking
+    links. The error is caught at the single point of DB contact."""
     state = _state_with_grounded(["p1"])
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
     with patch(
-        "app.agent.graph.propose_booking",
+        "app.agent.graph.get_details_many",
         side_effect=psycopg2.OperationalError("connection blip"),
     ):
         committed, payload = _commit_stops(state, raw_stops)
@@ -361,17 +387,18 @@ def test_commit_stops_enrichment_swallows_psycopg_db_blip() -> None:
 
 
 def test_commit_stops_enrichment_propagates_programmer_errors() -> None:
-    """Bugs in enrichment (TypeError, AttributeError, etc.) must NOT be
-    silently swallowed — that's how regressions ship to prod undetected. Only
-    the documented recoverable cases (missing place_id, DB blip) are caught."""
+    """Bugs in URL construction (TypeError, AttributeError, etc.) must NOT
+    be silently swallowed — that's how regressions ship to prod undetected.
+    Only the documented recoverable cases (missing-from-DB, DB blip) are caught."""
     state = _state_with_grounded(["p1"])
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
     with (
+        _patch_details_many_for(["p1"]),
         patch(
-            "app.agent.graph.propose_booking",
-            side_effect=TypeError("propose_booking() got an unexpected kwarg"),
+            "app.agent.graph.propose_booking_from_details",
+            side_effect=TypeError("propose_booking_from_details() got an unexpected kwarg"),
         ),
         pytest.raises(TypeError),
     ):
@@ -388,14 +415,17 @@ def test_commit_stops_re_commit_is_idempotent() -> None:
         {"place_id": "p1", "name": "Place p1", "rationale": "first", "source": "google_places"},
     ]
 
-    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
         return BookingProposal(
-            place_id=place_id,
+            place_id=details.place_id,
             provider="resy",
-            booking_url=f"https://resy.com/{place_id}?seats={party_size}",
+            booking_url=f"https://resy.com/{details.place_id}?seats={party_size}",
         )
 
-    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+    with (
+        _patch_details_many_for(["p1"]),
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
         first_committed, _ = _commit_stops(state, raw_stops)
         second_committed, _ = _commit_stops(state, raw_stops)
 
@@ -403,34 +433,40 @@ def test_commit_stops_re_commit_is_idempotent() -> None:
     assert first_committed[0].booking_provider == second_committed[0].booking_provider
 
 
-def test_commit_stops_per_stop_enrichment_failure_does_not_taint_siblings() -> None:
-    """A 2-stop commit where one place_id raises ValueError mid-enrichment
-    must still ship the other stop's booking link. The for-loop in
-    enrich_stops_with_booking is supposed to skip on per-stop failure, not
-    bail on the whole commit."""
+def test_commit_stops_per_stop_independence_when_one_id_missing() -> None:
+    """A 2-stop commit where one place_id is missing from the DB result must
+    still ship the other stop's booking link. The for-loop in
+    enrich_stops_with_booking skips per-stop on missing details rather than
+    bailing on the whole commit."""
     state = _state_with_grounded(["p1", "p2"])
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "first", "source": "google_places"},
         {"place_id": "p2", "name": "Place p2", "rationale": "second", "source": "google_places"},
     ]
 
-    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
-        if place_id == "p1":
-            raise ValueError("unknown place_id p1")
+    # get_details_many returns details for p2 but NOT p1 — same shape as the
+    # DB filtering p1 out (e.g. the row was deleted mid-commit).
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
         return BookingProposal(
-            place_id=place_id,
+            place_id=details.place_id,
             provider="opentable",
-            booking_url=f"https://opentable.com/{place_id}",
+            booking_url=f"https://opentable.com/{details.place_id}",
         )
 
-    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+    with (
+        patch(
+            "app.agent.graph.get_details_many",
+            return_value={"p2": _details_for("p2")},
+        ),
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
         committed, _ = _commit_stops(state, raw_stops)
 
-    # p1 enrichment failed and was skipped — no booking fields populated.
+    # p1 missing from DB → skipped, no booking fields populated.
     assert committed[0].place_id == "p1"
     assert committed[0].booking_url is None
     assert committed[0].booking_provider is None
-    # p2 enrichment was independent of p1 and succeeded.
+    # p2 was independent of p1 and succeeded.
     assert committed[1].place_id == "p2"
     assert committed[1].booking_url == "https://opentable.com/p2"
     assert committed[1].booking_provider == "opentable"
@@ -449,15 +485,18 @@ def test_enrich_stops_with_booking_mutates_in_place() -> None:
         constraints=UserConstraints(party_size=4, when=datetime(2026, 5, 7, 19, 0)),
     )
 
-    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
         return BookingProposal(
-            place_id=place_id,
+            place_id=details.place_id,
             provider="tock",
-            booking_url=f"https://exploretock.com/{place_id}?size={party_size}",
+            booking_url=f"https://exploretock.com/{details.place_id}?size={party_size}",
         )
 
     original_ids = [id(s) for s in stops]
-    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+    with (
+        _patch_details_many_for(["p1", "p2"]),
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
         enrich_stops_with_booking(stops, state)
 
     # Same Stop objects (mutated, not replaced).
@@ -475,12 +514,14 @@ def test_enrich_skipped_when_no_time_anywhere() -> None:
     stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
     state = ItineraryState(constraints=UserConstraints(party_size=2))  # when=None
 
-    propose = patch("app.agent.graph.propose_booking")
-    with propose as mock_propose:
+    with (
+        _patch_details_many_for(["p1"]),
+        patch("app.agent.graph.propose_booking_from_details") as mock_build,
+    ):
         enrich_stops_with_booking(stops, state)
 
-    # Crucially, propose_booking was NOT called — the no-time path skips entirely.
-    mock_propose.assert_not_called()
+    # Crucially, the URL builder was NOT called — the no-time path skips entirely.
+    mock_build.assert_not_called()
     assert stops[0].booking_url is None
     assert stops[0].booking_provider is None
 
@@ -491,7 +532,10 @@ def test_enrich_idempotent_when_no_time_set() -> None:
     stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
     state = ItineraryState(constraints=UserConstraints(party_size=2))
 
-    with patch("app.agent.graph.propose_booking") as mock_propose:
+    with (
+        _patch_details_many_for(["p1"]),
+        patch("app.agent.graph.propose_booking_from_details") as mock_build,
+    ):
         enrich_stops_with_booking(stops, state)
         first_url = stops[0].booking_url
         enrich_stops_with_booking(stops, state)
@@ -499,7 +543,7 @@ def test_enrich_idempotent_when_no_time_set() -> None:
 
     assert first_url is None
     assert second_url is None
-    assert mock_propose.call_count == 0
+    assert mock_build.call_count == 0
 
 
 def test_enrich_uses_constraints_when_when_arrival_time_missing() -> None:
@@ -513,11 +557,14 @@ def test_enrich_uses_constraints_when_when_arrival_time_missing() -> None:
 
     captured: list[datetime] = []
 
-    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
         captured.append(when)
-        return BookingProposal(place_id=place_id, provider="resy", booking_url="https://x")
+        return BookingProposal(place_id=details.place_id, provider="resy", booking_url="https://x")
 
-    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+    with (
+        _patch_details_many_for(["p1"]),
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
         enrich_stops_with_booking(stops, state)
 
     assert captured == [datetime(2026, 5, 7, 19, 0)]
@@ -542,11 +589,14 @@ def test_enrich_party_size_defaulting(party_size_in: int | None, expected_in_cal
 
     captured: list[int] = []
 
-    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
         captured.append(party_size)
-        return BookingProposal(place_id=place_id, provider="resy", booking_url="https://x")
+        return BookingProposal(place_id=details.place_id, provider="resy", booking_url="https://x")
 
-    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+    with (
+        _patch_details_many_for(["p1"]),
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
         enrich_stops_with_booking(stops, state)
 
     assert captured == [expected_in_call]
@@ -578,11 +628,16 @@ def test_enrich_stops_with_booking_uses_arrival_time_per_stop() -> None:
 
     captured: list[tuple[str, datetime]] = []
 
-    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
-        captured.append((place_id, when))
-        return BookingProposal(place_id=place_id, provider="resy", booking_url="https://resy.com/x")
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
+        captured.append((details.place_id, when))
+        return BookingProposal(
+            place_id=details.place_id, provider="resy", booking_url="https://resy.com/x"
+        )
 
-    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+    with (
+        _patch_details_many_for(["p1", "p2"]),
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
         enrich_stops_with_booking(stops, state)
 
     assert captured == [

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -12,8 +12,13 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 
-from app.agent.graph import _commit_stops, _prune_for_llm, build_agent_graph
-from app.agent.state import ItineraryState, UserConstraints
+from app.agent.graph import (
+    _commit_stops,
+    _prune_for_llm,
+    build_agent_graph,
+    enrich_stops_with_booking,
+)
+from app.agent.state import ItineraryState, Stop, UserConstraints
 from app.tools.booking import BookingProposal
 from app.tools.retrieval import PlaceHit
 
@@ -372,3 +377,131 @@ def test_commit_stops_enrichment_propagates_programmer_errors() -> None:
         pytest.raises(TypeError),
     ):
         _commit_stops(state, raw_stops)
+
+
+def test_commit_stops_re_commit_is_idempotent() -> None:
+    """The W3 critique loop drives a second commit_itinerary call when the
+    first plan fails a check. Re-committing the same place_id must produce the
+    same booking link — same inputs, same output. Locks the contract so a
+    future 'skip if already enriched' optimization can't silently break it."""
+    state = _state_with_grounded(["p1"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "first", "source": "google_places"},
+    ]
+
+    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+        return BookingProposal(
+            place_id=place_id,
+            provider="resy",
+            booking_url=f"https://resy.com/{place_id}?seats={party_size}",
+        )
+
+    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+        first_committed, _ = _commit_stops(state, raw_stops)
+        second_committed, _ = _commit_stops(state, raw_stops)
+
+    assert first_committed[0].booking_url == second_committed[0].booking_url
+    assert first_committed[0].booking_provider == second_committed[0].booking_provider
+
+
+def test_commit_stops_per_stop_enrichment_failure_does_not_taint_siblings() -> None:
+    """A 2-stop commit where one place_id raises ValueError mid-enrichment
+    must still ship the other stop's booking link. The for-loop in
+    enrich_stops_with_booking is supposed to skip on per-stop failure, not
+    bail on the whole commit."""
+    state = _state_with_grounded(["p1", "p2"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "first", "source": "google_places"},
+        {"place_id": "p2", "name": "Place p2", "rationale": "second", "source": "google_places"},
+    ]
+
+    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+        if place_id == "p1":
+            raise ValueError("unknown place_id p1")
+        return BookingProposal(
+            place_id=place_id,
+            provider="opentable",
+            booking_url=f"https://opentable.com/{place_id}",
+        )
+
+    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+        committed, _ = _commit_stops(state, raw_stops)
+
+    # p1 enrichment failed and was skipped — no booking fields populated.
+    assert committed[0].place_id == "p1"
+    assert committed[0].booking_url is None
+    assert committed[0].booking_provider is None
+    # p2 enrichment was independent of p1 and succeeded.
+    assert committed[1].place_id == "p2"
+    assert committed[1].booking_url == "https://opentable.com/p2"
+    assert committed[1].booking_provider == "opentable"
+
+
+def test_enrich_stops_with_booking_mutates_in_place() -> None:
+    """Direct coverage of the public helper. Future constraint-edit flows
+    will call enrich_stops_with_booking on already-built Stop objects without
+    going through _commit_stops; the in-place-mutation contract is what makes
+    that re-enrichment cheap."""
+    stops = [
+        Stop(place_id="p1", name="A", rationale="r", source="google_places"),
+        Stop(place_id="p2", name="B", rationale="r", source="google_places"),
+    ]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=4, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+        return BookingProposal(
+            place_id=place_id,
+            provider="tock",
+            booking_url=f"https://exploretock.com/{place_id}?size={party_size}",
+        )
+
+    original_ids = [id(s) for s in stops]
+    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+        enrich_stops_with_booking(stops, state)
+
+    # Same Stop objects (mutated, not replaced).
+    assert [id(s) for s in stops] == original_ids
+    # Both got party_size=4 from constraints (no per-stop arrival_time).
+    assert all(s.booking_provider == "tock" for s in stops)
+    assert all("size=4" in (s.booking_url or "") for s in stops)
+
+
+def test_enrich_stops_with_booking_uses_arrival_time_per_stop() -> None:
+    """When stops have different arrival_times, each stop's URL must reflect
+    its OWN time, not constraints.when. Otherwise a 3-stop itinerary's late
+    stops get a 'date' for the first stop's time slot."""
+    stops = [
+        Stop(
+            place_id="p1",
+            name="dinner",
+            rationale="r",
+            source="google_places",
+            arrival_time=datetime(2026, 5, 7, 19, 0),
+        ),
+        Stop(
+            place_id="p2",
+            name="drinks",
+            rationale="r",
+            source="google_places",
+            arrival_time=datetime(2026, 5, 7, 21, 30),
+        ),
+    ]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    captured: list[tuple[str, datetime]] = []
+
+    def fake_propose(place_id: str, when: datetime, party_size: int) -> BookingProposal:
+        captured.append((place_id, when))
+        return BookingProposal(place_id=place_id, provider="resy", booking_url="https://resy.com/x")
+
+    with patch("app.agent.graph.propose_booking", side_effect=fake_propose):
+        enrich_stops_with_booking(stops, state)
+
+    assert captured == [
+        ("p1", datetime(2026, 5, 7, 19, 0)),
+        ("p2", datetime(2026, 5, 7, 21, 30)),
+    ]

--- a/tests/unit/test_agent_state.py
+++ b/tests/unit/test_agent_state.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from app.agent.io import state_to_cards
 from app.agent.state import (
     DEFAULT_STOP_DURATION_MIN,
@@ -82,6 +84,45 @@ def test_state_to_cards_with_stops() -> None:
     assert card["primary_type"] == "restaurant"
     # PlaceCard fields not derived from Stop should be None / default.
     assert card["address"] is None
+
+
+@pytest.mark.parametrize("provider", ["resy", "tock", "opentable", "google_maps", "unknown", None])
+def test_stop_accepts_every_valid_booking_provider(provider: str | None) -> None:
+    """The closed BookingProvider literal must accept exactly the five providers
+    used by app.tools.booking, plus None."""
+    stop = Stop(
+        place_id="p1",
+        name="X",
+        rationale="r",
+        source="google_places",
+        booking_provider=provider,
+    )
+    assert stop.booking_provider == provider
+
+
+def test_stop_rejects_unknown_booking_provider() -> None:
+    """End-to-end typing contract: a typo on Stop fails the same way it would
+    fail on BookingProposal — Stop and BookingProposal share the literal."""
+    with pytest.raises(ValueError):
+        Stop(
+            place_id="p1",
+            name="X",
+            rationale="r",
+            source="google_places",
+            booking_provider="resyy",  # type: ignore[arg-type]
+        )
+
+
+def test_place_card_rejects_unknown_booking_provider() -> None:
+    """The frontend label table is keyed off booking_provider; a mistyped
+    value would silently render as 'no label'. Lock the contract here."""
+    with pytest.raises(ValueError):
+        PlaceCard(
+            place_id="p1",
+            name="X",
+            rationale="r",
+            booking_provider="yelp",  # type: ignore[arg-type]
+        )
 
 
 def test_place_card_serialization_keys() -> None:

--- a/tests/unit/test_agent_state.py
+++ b/tests/unit/test_agent_state.py
@@ -97,5 +97,6 @@ def test_place_card_serialization_keys() -> None:
         "arrival_time",
         "rationale",
         "booking_url",
+        "booking_provider",
     }
     assert set(payload.keys()) == expected_keys

--- a/tests/unit/test_booking.py
+++ b/tests/unit/test_booking.py
@@ -112,6 +112,49 @@ def test_appends_with_ampersand_when_url_already_has_query() -> None:
     assert b.booking_url.count("?") == 1
 
 
+def test_preserves_fragment_when_appending_query() -> None:
+    """A URL fragment (#section) must come AFTER the query string, not before
+    it — otherwise the params end up after the fragment and the server never
+    sees them. Hand-rolled `?` concatenation got this wrong."""
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://resy.com/cities/sf/foo#book"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.booking_url.endswith("#book")
+    assert "date=2026-04-26" in b.booking_url
+    assert "seats=2" in b.booking_url
+    # The ? must come BEFORE the # in a valid URL.
+    assert b.booking_url.index("?") < b.booking_url.index("#")
+
+
+def test_overwrites_existing_param_with_same_key() -> None:
+    """If the venue's website already has `?date=lunch`, our `date=2026-...`
+    must replace it — most providers honor the FIRST value of a duplicate key
+    and would silently ignore our deep-link params otherwise."""
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://resy.com/cities/sf/foo?date=lunch"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert "date=2026-04-26" in b.booking_url
+    assert "date=lunch" not in b.booking_url
+    # Single `date=` token, not two.
+    assert b.booking_url.count("date=") == 1
+
+
+def test_handles_trailing_question_mark_cleanly() -> None:
+    """`https://x?` with no params should produce `https://x?date=...&seats=...`,
+    not `https://x?&date=...` (leading `&` after `?` is malformed)."""
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://resy.com/cities/sf/foo?"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert "?&" not in b.booking_url
+    assert "date=2026-04-26" in b.booking_url
+
+
 def test_unknown_provider_with_website_returns_website_unchanged() -> None:
     """A venue whose website isn't Resy/Tock/OpenTable still has a website that
     is much more useful than a map pin — it likely hosts a reservations page.

--- a/tests/unit/test_booking.py
+++ b/tests/unit/test_booking.py
@@ -196,7 +196,56 @@ def test_no_website_no_maps_uri_falls_back_to_maps_search() -> None:
         b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
     assert b.provider == "google_maps"
     assert "google.com/maps/search" in b.booking_url
-    assert "Tony's" in b.booking_url
+    # urlencode escapes the apostrophe to %27.
+    assert "Tony%27s" in b.booking_url
+
+
+def test_maps_search_encodes_ampersand_in_venue_name() -> None:
+    """Raw f-string interpolation of `&` would terminate the query string and
+    break the URL. urlencode must escape it to %26."""
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(
+            website_uri=None, maps_uri=None, name="Tartine Manufactory & Bakery"
+        ),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.provider == "google_maps"
+    # The literal `&` must NOT appear inside the query token; only `&` joining
+    # api=1 and query=... is allowed.
+    assert "Bakery" in b.booking_url
+    # Exactly one '&' as a separator between api=1 and query=... — none inside
+    # the encoded venue name.
+    assert b.booking_url.count("&") == 1
+    assert "%26" in b.booking_url
+
+
+def test_maps_search_encodes_unicode_in_venue_name() -> None:
+    """Non-ASCII characters must be percent-encoded; raw interpolation produces
+    URLs that some clients reject and others mojibake."""
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(website_uri=None, maps_uri=None, name="Café Joséphine"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.provider == "google_maps"
+    # Non-ASCII chars survive only as percent-encoded bytes.
+    assert "Caf" in b.booking_url
+    assert "Joséphine" not in b.booking_url
+    assert "%C3%A9" in b.booking_url  # 'é' encoded
+
+
+def test_maps_search_encodes_plus_in_venue_name() -> None:
+    """A literal '+' in a name (e.g. 'M.Y. China + Hakkasan') means space
+    after URL-decoding; encoding must escape it to %2B."""
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(website_uri=None, maps_uri=None, name="Mr.+Mrs Bun"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.provider == "google_maps"
+    # '+' inside the venue name escaped as %2B; raw '+' would be misread as space.
+    assert "%2B" in b.booking_url
 
 
 def test_empty_website_string_treated_as_no_website() -> None:

--- a/tests/unit/test_booking.py
+++ b/tests/unit/test_booking.py
@@ -281,14 +281,15 @@ def test_notes_match_provider() -> None:
     assert "Resy" in b.notes
 
 
-# ─── Functional: graph commit -> real propose_booking -> Stop fields ────────
+# ─── Functional: graph commit -> real URL construction -> Stop fields ──────
 #
-# These tests drive `_commit_stops` end-to-end with the *real* propose_booking
-# implementation. Only the SQL boundary (`get_details`) is mocked. This
-# verifies the composition: provider detection + URL building + graph
-# enrichment all work together. Compare to the unit tests above (mock
-# get_details, hit propose_booking directly) and the test in test_agent_graph
-# (mock propose_booking entirely) — this layer is the in-between.
+# These tests drive `_commit_stops` end-to-end with the *real*
+# propose_booking_from_details implementation. Only the SQL boundary
+# (`get_details_many`, called once per commit) is mocked. This verifies the
+# composition: provider detection + URL building + graph enrichment all work
+# together. Compare to the unit tests above (mock get_details, hit
+# propose_booking directly) and the test in test_agent_graph (mock the URL
+# builder entirely) — this layer is the in-between.
 
 
 def _grounded_state(place_ids: list[str], party_size: int = 2) -> ItineraryState:
@@ -299,6 +300,14 @@ def _grounded_state(place_ids: list[str], party_size: int = 2) -> ItineraryState
     return ItineraryState(
         scratch={"semantic_search": [{"args": {}, "result": hits, "step": 0, "id": "s1"}]},
         constraints=UserConstraints(party_size=party_size, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+
+def _patch_graph_details_many(place_id: str, details: PlaceDetails):
+    """Patch the graph's batched DB call to return one details row."""
+    return patch(
+        "app.agent.graph.get_details_many",
+        return_value={place_id: details},
     )
 
 
@@ -314,10 +323,7 @@ def test_functional_commit_attaches_resy_url_via_real_propose_booking() -> None:
             "arrival_time": datetime(2026, 5, 7, 19, 30).isoformat(),
         }
     ]
-    with patch(
-        "app.tools.booking.get_details",
-        return_value=_fake_details("https://resy.com/cities/sf/foo"),
-    ):
+    with _patch_graph_details_many("p1", _fake_details("https://resy.com/cities/sf/foo")):
         committed, _ = _commit_stops(state, raw_stops)
 
     assert len(committed) == 1
@@ -336,9 +342,9 @@ def test_functional_falls_back_to_venue_website_for_non_provider_site() -> None:
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with patch(
-        "app.tools.booking.get_details",
-        return_value=_fake_details(
+    with _patch_graph_details_many(
+        "p1",
+        _fake_details(
             website_uri="https://random-cafe.example",
             maps_uri="https://maps.google.com/?cid=999",
         ),
@@ -356,12 +362,9 @@ def test_functional_falls_back_to_maps_when_no_website() -> None:
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with patch(
-        "app.tools.booking.get_details",
-        return_value=_fake_details(
-            website_uri=None,
-            maps_uri="https://maps.google.com/?cid=999",
-        ),
+    with _patch_graph_details_many(
+        "p1",
+        _fake_details(website_uri=None, maps_uri="https://maps.google.com/?cid=999"),
     ):
         committed, _ = _commit_stops(state, raw_stops)
 
@@ -377,10 +380,7 @@ def test_functional_uses_constraints_when_arrival_time_missing() -> None:
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with patch(
-        "app.tools.booking.get_details",
-        return_value=_fake_details("https://www.opentable.com/baz"),
-    ):
+    with _patch_graph_details_many("p1", _fake_details("https://www.opentable.com/baz")):
         committed, _ = _commit_stops(state, raw_stops)
 
     stop = committed[0]

--- a/tests/unit/test_booking.py
+++ b/tests/unit/test_booking.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from app.agent.graph import _commit_stops
+from app.agent.state import ItineraryState, UserConstraints
+from app.tools.booking import BookingProposal, detect_provider, propose_booking
+from app.tools.retrieval import PlaceDetails, PlaceHit
+
+# ─── Smoke: models construct ────────────────────────────────────────────────
+
+
+def test_booking_proposal_constructs_with_required_fields_only() -> None:
+    """The proposal model accepts the minimum surface — provider, place_id,
+    booking_url. Optional fields default cleanly so callers never have to pass
+    `automation_available` or `notes` to build a valid object."""
+    p = BookingProposal(place_id="x", provider="resy", booking_url="https://resy.com/x")
+    assert p.automation_available is False
+    assert p.notes is None
+
+
+def test_booking_proposal_rejects_unknown_provider() -> None:
+    """The Provider literal is the contract with the frontend label table.
+    A typo here would surface as a 'no label rendered' bug in the UI."""
+    with pytest.raises(ValueError):
+        BookingProposal(place_id="x", provider="resyy", booking_url="https://x")  # type: ignore[arg-type]
+
+
+# ─── Unit / logic: pure functions with mocked DB boundary ──────────────────
+
+
+@pytest.mark.parametrize(
+    "uri,expected",
+    [
+        ("https://resy.com/cities/sf/foo", "resy"),
+        ("https://www.resy.com/cities/sf/foo", "resy"),
+        ("https://www.exploretock.com/bar", "tock"),
+        ("https://tock.com/bar", "tock"),
+        ("https://www.opentable.com/baz", "opentable"),
+        ("https://example.com", "unknown"),
+        (None, "unknown"),
+        ("", "unknown"),
+    ],
+)
+def test_detect_provider(uri: str | None, expected: str) -> None:
+    assert detect_provider(uri) == expected
+
+
+def _fake_details(
+    website_uri: str | None,
+    maps_uri: str | None = "https://maps.google.com/?cid=1",
+    name: str = "Foo",
+) -> PlaceDetails:
+    return PlaceDetails(
+        place_id="p1",
+        name=name,
+        source="google_places",
+        similarity=0.0,
+        website_uri=website_uri,
+        maps_uri=maps_uri,
+    )
+
+
+def test_resy_url_includes_date_and_seats() -> None:
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://resy.com/cities/sf/foo"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=4)
+    assert b.provider == "resy"
+    assert "date=2026-04-26" in b.booking_url
+    assert "seats=4" in b.booking_url
+    assert b.booking_url.startswith("https://resy.com/cities/sf/foo?")
+
+
+def test_tock_url_includes_date_size_time() -> None:
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://www.exploretock.com/bar"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.provider == "tock"
+    # urlencode percent-encodes the colon in 19:30
+    assert "time=19%3A30" in b.booking_url
+    assert "size=2" in b.booking_url
+    assert "date=2026-04-26" in b.booking_url
+
+
+def test_opentable_url_includes_covers_and_datetime() -> None:
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://www.opentable.com/baz"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=3)
+    assert b.provider == "opentable"
+    assert "covers=3" in b.booking_url
+    # Tee+colon both percent-encoded by urlencode
+    assert "dateTime=2026-04-26T19%3A30" in b.booking_url
+
+
+def test_appends_with_ampersand_when_url_already_has_query() -> None:
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://resy.com/cities/sf/foo?ref=share"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    # Existing ?ref=share preserved, our params appended with &
+    assert "?ref=share&" in b.booking_url
+    assert b.booking_url.count("?") == 1
+
+
+def test_unknown_provider_falls_back_to_maps_uri() -> None:
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(
+            website_uri="https://random.cafe",
+            maps_uri="https://maps.google.com/?cid=42",
+        ),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.provider == "google_maps"
+    assert b.booking_url == "https://maps.google.com/?cid=42"
+
+
+def test_no_website_no_maps_uri_falls_back_to_maps_search() -> None:
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(website_uri=None, maps_uri=None, name="Tony's"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.provider == "google_maps"
+    assert "google.com/maps/search" in b.booking_url
+    assert "Tony's" in b.booking_url
+
+
+def test_unknown_place_id_raises() -> None:
+    with (
+        patch("app.tools.booking.get_details", return_value=None),
+        pytest.raises(ValueError, match="unknown place_id"),
+    ):
+        propose_booking("nope", datetime(2026, 4, 26, 19, 30), party_size=2)
+
+
+def test_notes_match_provider() -> None:
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://resy.com/cities/sf/foo"),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.notes is not None
+    assert "Resy" in b.notes
+
+
+# ─── Functional: graph commit -> real propose_booking -> Stop fields ────────
+#
+# These tests drive `_commit_stops` end-to-end with the *real* propose_booking
+# implementation. Only the SQL boundary (`get_details`) is mocked. This
+# verifies the composition: provider detection + URL building + graph
+# enrichment all work together. Compare to the unit tests above (mock
+# get_details, hit propose_booking directly) and the test in test_agent_graph
+# (mock propose_booking entirely) — this layer is the in-between.
+
+
+def _grounded_state(place_ids: list[str], party_size: int = 2) -> ItineraryState:
+    hits = [
+        PlaceHit(place_id=pid, name=f"Place {pid}", source="google_places", similarity=0.9)
+        for pid in place_ids
+    ]
+    return ItineraryState(
+        scratch={"semantic_search": [{"args": {}, "result": hits, "step": 0, "id": "s1"}]},
+        constraints=UserConstraints(party_size=party_size, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+
+def test_functional_commit_attaches_resy_url_via_real_propose_booking() -> None:
+    """Resy detection + URL params + Stop enrichment all wired together."""
+    state = _grounded_state(["p1"], party_size=4)
+    raw_stops = [
+        {
+            "place_id": "p1",
+            "name": "Place p1",
+            "rationale": "dinner",
+            "source": "google_places",
+            "arrival_time": datetime(2026, 5, 7, 19, 30).isoformat(),
+        }
+    ]
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://resy.com/cities/sf/foo"),
+    ):
+        committed, _ = _commit_stops(state, raw_stops)
+
+    assert len(committed) == 1
+    stop = committed[0]
+    assert stop.booking_provider == "resy"
+    assert stop.booking_url is not None
+    assert "date=2026-05-07" in stop.booking_url
+    assert "seats=4" in stop.booking_url
+
+
+def test_functional_falls_back_to_google_maps_for_non_provider_site() -> None:
+    """A venue whose website isn't Resy/Tock/OpenTable still gets a usable
+    booking_url — the Google Maps deep-link from places_raw.maps_uri."""
+    state = _grounded_state(["p1"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
+    ]
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(
+            website_uri="https://random-cafe.example",
+            maps_uri="https://maps.google.com/?cid=999",
+        ),
+    ):
+        committed, _ = _commit_stops(state, raw_stops)
+
+    stop = committed[0]
+    assert stop.booking_provider == "google_maps"
+    assert stop.booking_url == "https://maps.google.com/?cid=999"
+
+
+def test_functional_uses_constraints_when_arrival_time_missing() -> None:
+    """When the LLM commits a stop without arrival_time, enrichment should
+    fall back to constraints.when so the URL still has a date param."""
+    state = _grounded_state(["p1"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
+    ]
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details("https://www.opentable.com/baz"),
+    ):
+        committed, _ = _commit_stops(state, raw_stops)
+
+    stop = committed[0]
+    # constraints.when = 2026-05-07 19:00
+    assert "dateTime=2026-05-07T19%3A00" in (stop.booking_url or "")

--- a/tests/unit/test_booking.py
+++ b/tests/unit/test_booking.py
@@ -112,11 +112,31 @@ def test_appends_with_ampersand_when_url_already_has_query() -> None:
     assert b.booking_url.count("?") == 1
 
 
-def test_unknown_provider_falls_back_to_maps_uri() -> None:
+def test_unknown_provider_with_website_returns_website_unchanged() -> None:
+    """A venue whose website isn't Resy/Tock/OpenTable still has a website that
+    is much more useful than a map pin — it likely hosts a reservations page.
+    The website URL is returned as-is (no booking params to inject) under the
+    'unknown' provider label."""
     with patch(
         "app.tools.booking.get_details",
         return_value=_fake_details(
             website_uri="https://random.cafe",
+            maps_uri="https://maps.google.com/?cid=42",
+        ),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.provider == "unknown"
+    assert b.booking_url == "https://random.cafe"
+    # Notes must steer the user toward finding the reservations page.
+    assert b.notes is not None and "website" in b.notes.lower()
+
+
+def test_no_provider_no_website_falls_back_to_maps_uri() -> None:
+    """Without a website, the row's maps_uri is the next best deep-link."""
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(
+            website_uri=None,
             maps_uri="https://maps.google.com/?cid=42",
         ),
     ):
@@ -134,6 +154,21 @@ def test_no_website_no_maps_uri_falls_back_to_maps_search() -> None:
     assert b.provider == "google_maps"
     assert "google.com/maps/search" in b.booking_url
     assert "Tony's" in b.booking_url
+
+
+def test_empty_website_string_treated_as_no_website() -> None:
+    """An empty `website_uri` (PostgreSQL NOT NULL with default '') is just as
+    useless as None. Don't return an empty URL as a 'website' fallback."""
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(
+            website_uri="",
+            maps_uri="https://maps.google.com/?cid=99",
+        ),
+    ):
+        b = propose_booking("p1", datetime(2026, 4, 26, 19, 30), party_size=2)
+    assert b.provider == "google_maps"
+    assert b.booking_url == "https://maps.google.com/?cid=99"
 
 
 def test_unknown_place_id_raises() -> None:
@@ -201,9 +236,10 @@ def test_functional_commit_attaches_resy_url_via_real_propose_booking() -> None:
     assert "seats=4" in stop.booking_url
 
 
-def test_functional_falls_back_to_google_maps_for_non_provider_site() -> None:
+def test_functional_falls_back_to_venue_website_for_non_provider_site() -> None:
     """A venue whose website isn't Resy/Tock/OpenTable still gets a usable
-    booking_url — the Google Maps deep-link from places_raw.maps_uri."""
+    booking_url — the venue's own website (more useful than a map pin, since
+    it likely hosts a reservations page)."""
     state = _grounded_state(["p1"])
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
@@ -212,6 +248,26 @@ def test_functional_falls_back_to_google_maps_for_non_provider_site() -> None:
         "app.tools.booking.get_details",
         return_value=_fake_details(
             website_uri="https://random-cafe.example",
+            maps_uri="https://maps.google.com/?cid=999",
+        ),
+    ):
+        committed, _ = _commit_stops(state, raw_stops)
+
+    stop = committed[0]
+    assert stop.booking_provider == "unknown"
+    assert stop.booking_url == "https://random-cafe.example"
+
+
+def test_functional_falls_back_to_maps_when_no_website() -> None:
+    """No website at all → Google Maps deep-link from places_raw.maps_uri."""
+    state = _grounded_state(["p1"])
+    raw_stops = [
+        {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
+    ]
+    with patch(
+        "app.tools.booking.get_details",
+        return_value=_fake_details(
+            website_uri=None,
             maps_uri="https://maps.google.com/?cid=999",
         ),
     ):

--- a/tests/unit/test_chat_endpoint.py
+++ b/tests/unit/test_chat_endpoint.py
@@ -83,6 +83,7 @@ def test_chat_endpoint_returns_reply_places_raglabel(mocker) -> None:
         "arrival_time",
         "rationale",
         "booking_url",
+        "booking_provider",
     }
     assert set(body["places"][0].keys()) == expected_place_keys
     assert body["places"][0]["place_id"] == "p1"

--- a/tests/unit/test_tools_retrieval.py
+++ b/tests/unit/test_tools_retrieval.py
@@ -12,6 +12,7 @@ from app.tools.retrieval import (
     PlaceDetails,
     PlaceHit,
     get_details,
+    get_details_many,
     nearby,
     semantic_search,
 )
@@ -236,3 +237,63 @@ def test_get_details_returns_place_details_when_found(patch_get_conn) -> None:
     assert details is not None
     assert details.types == ["bakery", "cafe"]
     assert details.user_rating_count == 1234
+
+
+# --- get_details_many ------------------------------------------------------
+
+
+def _details_row(place_id: str) -> dict:
+    return {
+        "place_id": place_id,
+        "name": f"Place {place_id}",
+        "primary_type": "restaurant",
+        "types": ["restaurant"],
+        "formatted_address": "1 Main",
+        "latitude": 37.7,
+        "longitude": -122.4,
+        "rating": 4.5,
+        "user_rating_count": 100,
+        "price_level": "PRICE_LEVEL_MODERATE",
+        "business_status": "OPERATIONAL",
+        "website_uri": f"https://{place_id}.example",
+        "maps_uri": "https://maps.google.com/?cid=1",
+        "editorial_summary": None,
+        "regular_opening_hours": {},
+        "source": "google_places",
+        "snippet": "x",
+        "similarity": 0.0,
+    }
+
+
+def test_get_details_many_empty_input_skips_db_call() -> None:
+    """Empty list short-circuits — no SQL, no round-trip. Important when an
+    early-stage commit has zero stops; we don't want to query for ANY([])."""
+    # No patch fixture used: if it tried to hit the DB the test would fail
+    # because there's no connection mocked.
+    assert get_details_many([]) == {}
+
+
+def test_get_details_many_returns_keyed_dict(patch_get_conn) -> None:
+    """The contract: input list of N place_ids → output dict of up-to-N rows
+    keyed by place_id. Order doesn't matter; presence does."""
+    cursor = patch_get_conn([_details_row("p1"), _details_row("p2")])
+    out = get_details_many(["p1", "p2"])
+
+    assert set(out.keys()) == {"p1", "p2"}
+    assert out["p1"].place_id == "p1"
+    assert out["p2"].place_id == "p2"
+    assert out["p1"].website_uri == "https://p1.example"
+    # Single SQL execute — this is the whole point of batching vs N round-trips.
+    assert cursor.executed_sql.count("ANY") == 1
+    # Params: a single list of place_ids passed as the ANY operand.
+    assert cursor.executed_params == [["p1", "p2"]]
+
+
+def test_get_details_many_omits_missing_ids_silently(patch_get_conn) -> None:
+    """If a requested place_id isn't in the DB, it's simply absent from the
+    result dict — no error, no None placeholder. Callers (booking enrichment)
+    use `dict.get(...)` and skip on miss."""
+    patch_get_conn([_details_row("p1")])  # p2 not in DB
+    out = get_details_many(["p1", "p2"])
+    assert "p1" in out
+    assert "p2" not in out


### PR DESCRIPTION
## Summary

Implements W4 (booking handoff stub) per `implementation_plan/james/w4_booking_stub.md`, plus a focused review pass. Every committed stop in an itinerary is auto-enriched with a `booking_url` + `booking_provider`. Resy/Tock/OpenTable get true deep-links with date/party/time pre-filled; other venues fall back to the venue website, then Google Maps.

- **Deviates from plan in one place (documented):** `propose_booking` is NOT registered as an LLM tool. URL construction is a pure transform of `(place_id, when, party_size)`, so the agent graph auto-enriches on `commit_itinerary` deterministically. Net win on correctness (no missed enrichment, no malformed `party_size: "two"` from the LLM) and token cost. See the W4 plan footer for the full rationale.
- **Frontend contract documented in** `docs/api/chat_contract.md` (W0–W4 surface).

## Review pass

13 follow-up commits after the initial implementation, by section:

**Architecture** — share `BookingProvider` literal across `Stop`/`PlaceCard`/`BookingProposal` so the closed set is enforced end-to-end; three-tier fallback (provider → venue website → Google Maps) so non-Resy/Tock/OpenTable venues get a useful link instead of a map pin; make `enrich_stops_with_booking` public for future constraint-edit reuse.

**Code quality** — one `_PROVIDER_SPECS` registry replaces 3 near-identical branches; narrow exception catch (only `ValueError` + `psycopg2.Error`, bugs propagate); proper `urlsplit`/`urlunsplit` for query merge (fragments preserved, duplicate keys overwritten); `PlaceCard` address/rating/price_level gap logged in `FUTURE_WATCH`.

**Tests** — URL-encode venue name in maps-search fallback (handles `&`, unicode, `+`, apostrophes); re-commit idempotency, per-stop independence, public-helper coverage; tighten integration assertions to per-tier contracts; skip enrichment when no time set (removes `datetime.now()` non-determinism in URLs) + `party_size` defaulting tests.

**Performance** — batched `get_details_many` collapses what was an N+1 over commit_itinerary into one DB round-trip per commit, regardless of stop count.

## Test plan

- [x] All unit tests green (291 passed)
- [x] Pre-commit hooks pass (ruff lint + format)
- [x] Integration tests pass against Cloud SQL (`make test-integration-cloud` → 25 passed, 1 skipped — Langfuse trace test)
- [x] Manual smoke against real Cloud SQL data — Resy deep-link tier verified end-to-end:
  - `Mr. Pollo` (real Resy venue in seeded data) → `https://resy.com/cities/sf/mr-pollo?date=2026-05-08&seats=2`
  - URL adapts to party size + date (party of 4 on 5/9 → `?date=2026-05-09&seats=4`)
  - Provider correctly detected as `resy` from `website_uri`
- [x] Manual smoke confirms website-fallback tier opens the venue's site (not a map pin):
  - Souvla, North Beach Restaurant, Pacific Cocktail Haven, etc. → `provider="unknown"`, `booking_url` = venue's actual website unchanged
  - Bonus: maps fallback verified — Mission Bar, C C's Cocktail Lounge (no `website_uri` in DB) → `provider="google_maps"`, URL is `maps.google.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)