### PR TITLE
fix(agent): populate PlaceCard address/rating/price_level

### DIFF
--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -31,7 +31,7 @@ from app.agent.critique import (
 )
 from app.agent.critique.checks import itinerary_violations
 from app.agent.prompts import SYSTEM_PROMPT
-from app.agent.state import ItineraryState, RevisionHint, Stop
+from app.agent.state import ItineraryState, RevisionHint, Stop, price_level_to_rank
 from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
 from app.tools.booking import propose_booking_from_details
 from app.tools.retrieval import get_details_many
@@ -127,6 +127,21 @@ def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
         return
 
     for stop in stops:
+        details = details_by_id.get(stop.place_id)
+        if details is None:
+            # place_id grounded in scratch but missing from DB at enrichment
+            # time — race condition on the deletion side, or a stale id. Same
+            # recoverable case as the old ValueError("unknown place_id"): skip
+            # both card-field and booking enrichment for this stop.
+            logger.warning("enrichment skipped: place_id=%s not in DB", stop.place_id)
+            continue
+
+        # Card fields do NOT depend on a booking time — stamp them before the
+        # `when is None` skip so a timeless stop still renders a full card.
+        stop.address = details.formatted_address
+        stop.rating = details.rating
+        stop.price_level = price_level_to_rank(details.price_level)
+
         when = stop.arrival_time or state.constraints.when
         if when is None:
             # No time → no booking link. Falling back to datetime.now() would
@@ -134,13 +149,6 @@ def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
             # (same inputs, different URL each call) and meaning nothing to
             # the user. The card ships without a booking link; downstream can
             # re-enrich once the user supplies a time.
-            continue
-        details = details_by_id.get(stop.place_id)
-        if details is None:
-            # place_id grounded in scratch but missing from DB at enrichment
-            # time — race condition on the deletion side, or a stale id. Same
-            # recoverable case as the old ValueError("unknown place_id"): skip.
-            logger.warning("booking enrichment skipped: place_id=%s not in DB", stop.place_id)
             continue
         proposal = propose_booking_from_details(details, when, party_size)
         stop.booking_url = proposal.booking_url

--- a/app/agent/io.py
+++ b/app/agent/io.py
@@ -41,6 +41,9 @@ def state_to_cards(state: ItineraryState) -> list[dict[str, Any]]:
         PlaceCard(
             place_id=s.place_id,
             name=s.name,
+            address=s.address,
+            rating=s.rating,
+            price_level=s.price_level,
             primary_type=s.primary_type,
             arrival_time=s.arrival_time,
             rationale=s.rationale,

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -110,9 +110,33 @@ def default_duration_for(primary_type: str | None) -> int:
     return DEFAULT_STOP_DURATION_MIN.get(primary_type.lower(), DEFAULT_STOP_DURATION_MIN_FALLBACK)
 
 
+_PRICE_LEVEL_RANK: dict[str, int] = {
+    "PRICE_LEVEL_FREE": 0,
+    "PRICE_LEVEL_INEXPENSIVE": 1,
+    "PRICE_LEVEL_MODERATE": 2,
+    "PRICE_LEVEL_EXPENSIVE": 3,
+    "PRICE_LEVEL_VERY_EXPENSIVE": 4,
+}
+
+
+def price_level_to_rank(value: str | None) -> int | None:
+    """Map Google's price_level enum string to the 0..4 rank PlaceCard expects.
+
+    Mirrors the SQL `price_level_rank()` function (alembic c428add573d7) so the
+    card's integer tier matches the rank used in SearchFilters comparisons.
+    Unknown / unspecified / None all collapse to None.
+    """
+    if value is None:
+        return None
+    return _PRICE_LEVEL_RANK.get(value)
+
+
 class Stop(BaseModel):
     place_id: str
     name: str
+    address: str | None = None
+    rating: float | None = None
+    price_level: int | None = None  # 0..4, mapped via price_level_to_rank
     arrival_time: datetime | None = None
     planned_duration_min: int = DEFAULT_STOP_DURATION_MIN_FALLBACK
     rationale: str

--- a/docs/api/chat_contract.md
+++ b/docs/api/chat_contract.md
@@ -6,7 +6,7 @@ calls. Backend code: `app/main.py`, `app/agent/state.py`, `app/agent/io.py`.
 If you find this doc disagreeing with the code, the code wins — but please
 open an issue or fix the doc in the same PR.
 
-Last updated for: W5 (coverage-gap ingestion agent). Reflects everything merged W0 → W5. W5 doesn't touch the chat API — it's a data-pipeline workstream — so the contract is unchanged.
+Last updated for: W5 (coverage-gap ingestion agent). Reflects everything merged W0 → W5. Note (2026-05-16): the `PlaceCard` `address`/`rating`/`price_level` fields were always in the documented contract but the backend shipped them as `null` until the `fix/placecard-address-rating-price` fix — they are now actually populated. No shape change.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-16-placecard-address-rating-price.md
+++ b/docs/superpowers/plans/2026-05-16-placecard-address-rating-price.md
@@ -458,6 +458,40 @@ git commit -m "docs(future-watch): mark PlaceCard card-fields item resolved"
 
 ---
 
+### Task 6: Sync the frontend chat contract doc
+
+`docs/api/chat_contract.md` already documents `address`/`rating`/`price_level`
+in the `PlaceCard` shape (lines 69-82) with correct types — the contract was
+right; the backend just wasn't fulfilling it (shipped nulls). So this is NOT a
+shape change. Update only the doc's freshness metadata so the history stays
+honest about when these fields became really populated.
+
+**Files:**
+- Modify: `docs/api/chat_contract.md:9` ("Last updated for" line)
+
+- [ ] **Step 1: Update the freshness line**
+
+In `docs/api/chat_contract.md`, replace line 9:
+
+```markdown
+Last updated for: W5 (coverage-gap ingestion agent). Reflects everything merged W0 → W5. W5 doesn't touch the chat API — it's a data-pipeline workstream — so the contract is unchanged.
+```
+
+with:
+
+```markdown
+Last updated for: W5 (coverage-gap ingestion agent). Reflects everything merged W0 → W5. Note (2026-05-16): the `PlaceCard` `address`/`rating`/`price_level` fields were always in the documented contract but the backend shipped them as `null` until the `fix/placecard-address-rating-price` fix — they are now actually populated. No shape change.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/api/chat_contract.md
+git commit -m "docs(contract): note PlaceCard card fields now populated"
+```
+
+---
+
 ## Notes for the executor
 
 - Use `poetry run` for pytest/mypy/ruff (project is poetry editable-installed; never add `sys.path` hacks).

--- a/docs/superpowers/plans/2026-05-16-placecard-address-rating-price.md
+++ b/docs/superpowers/plans/2026-05-16-placecard-address-rating-price.md
@@ -1,0 +1,466 @@
+# PlaceCard address / rating / price_level Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry `address`, `rating`, and `price_level` from the already-fetched `PlaceDetails` onto `Stop` so `PlaceCard`s the frontend renders are no longer silently null.
+
+**Architecture:** Extend `Stop` with three optional fields plus a `price_level_to_rank` helper (string enum → int 0..4, mirroring SQL `price_level_rank()`). Populate the fields inside the existing batched `get_details_many` loop in `enrich_stops_with_booking` — zero new DB calls — and *before* the `when is None` early-continue so card data lands even without a booking time. `state_to_cards` passes the fields through.
+
+**Tech Stack:** Python 3.10, Pydantic v2, pytest (`asyncio_mode=auto`), `unittest.mock`.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-placecard-address-rating-price-design.md`
+
+---
+
+### Task 1: `price_level_to_rank` helper + `Stop` fields
+
+**Files:**
+- Modify: `app/agent/state.py` (add helper after `default_duration_for`, add 3 fields to `Stop` at lines 113-124)
+- Test: `tests/unit/test_state.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_state.py`:
+
+```python
+"""Unit tests for app.agent.state helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agent.state import Stop, price_level_to_rank
+
+
+@pytest.mark.parametrize(
+    ("enum", "expected"),
+    [
+        ("PRICE_LEVEL_FREE", 0),
+        ("PRICE_LEVEL_INEXPENSIVE", 1),
+        ("PRICE_LEVEL_MODERATE", 2),
+        ("PRICE_LEVEL_EXPENSIVE", 3),
+        ("PRICE_LEVEL_VERY_EXPENSIVE", 4),
+        ("PRICE_LEVEL_UNSPECIFIED", None),
+        ("garbage", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_price_level_to_rank(enum: str | None, expected: int | None) -> None:
+    assert price_level_to_rank(enum) == expected
+
+
+def test_stop_defaults_new_fields_to_none() -> None:
+    s = Stop(place_id="p1", name="A", rationale="r", source="google_places")
+    assert s.address is None
+    assert s.rating is None
+    assert s.price_level is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_state.py -v`
+Expected: FAIL — `ImportError: cannot import name 'price_level_to_rank'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/agent/state.py`, add this helper immediately after `default_duration_for` (currently ends line 110):
+
+```python
+_PRICE_LEVEL_RANK: dict[str, int] = {
+    "PRICE_LEVEL_FREE": 0,
+    "PRICE_LEVEL_INEXPENSIVE": 1,
+    "PRICE_LEVEL_MODERATE": 2,
+    "PRICE_LEVEL_EXPENSIVE": 3,
+    "PRICE_LEVEL_VERY_EXPENSIVE": 4,
+}
+
+
+def price_level_to_rank(value: str | None) -> int | None:
+    """Map Google's price_level enum string to the 0..4 rank PlaceCard expects.
+
+    Mirrors the SQL `price_level_rank()` function (alembic c428add573d7) so the
+    card's integer tier matches the rank used in SearchFilters comparisons.
+    Unknown / unspecified / None all collapse to None.
+    """
+    if value is None:
+        return None
+    return _PRICE_LEVEL_RANK.get(value)
+```
+
+Then extend the `Stop` model (currently lines 113-124) — add three fields after `name`:
+
+```python
+class Stop(BaseModel):
+    place_id: str
+    name: str
+    address: str | None = None
+    rating: float | None = None
+    price_level: int | None = None  # 0..4, mapped via price_level_to_rank
+    arrival_time: datetime | None = None
+    planned_duration_min: int = DEFAULT_STOP_DURATION_MIN_FALLBACK
+    rationale: str
+    source: str  # 'google_places' | 'editorial'
+    latitude: float | None = None
+    longitude: float | None = None
+    primary_type: str | None = None
+    booking_url: str | None = None
+    booking_provider: BookingProvider | None = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_state.py -v`
+Expected: PASS (11 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/agent/state.py tests/unit/test_state.py
+git commit -m "feat(agent): add address/rating/price_level to Stop + rank helper"
+```
+
+---
+
+### Task 2: Populate the fields in `enrich_stops_with_booking`
+
+**Files:**
+- Modify: `app/agent/graph.py` (the `for stop in stops:` loop in `enrich_stops_with_booking`, currently lines 129-147)
+- Test: `tests/unit/test_agent_graph.py` (add tests near the existing enrichment tests)
+
+The critical correctness point: today the loop does `when = ...; if when is None: continue` (line 130-137) *before* resolving `details`. The new fields must be stamped from `details` **before** that `continue`, so a stop with no booking time still gets address/rating/price. That means we resolve `details` and stamp the three fields at the top of the loop body, then keep the existing `when is None` / `details is None` / booking logic.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_agent_graph.py`. First, extend the `_details_for` helper usage — add a new fixture-style helper near `_details_for` (line 28):
+
+```python
+def _rich_details_for(place_id: str) -> PlaceDetails:
+    """PlaceDetails carrying address/rating/price for card-field tests."""
+    return PlaceDetails(
+        place_id=place_id,
+        name=f"Place {place_id}",
+        source="google_places",
+        similarity=0.0,
+        formatted_address=f"{place_id} Main St, San Francisco",
+        rating=4.4,
+        price_level="PRICE_LEVEL_MODERATE",
+    )
+```
+
+Then add these tests (place them after `test_enrich_stops_with_booking_mutates_in_place`, ~line 507):
+
+```python
+def test_enrich_populates_card_fields_from_details() -> None:
+    """address/rating/price_level flow from PlaceDetails onto Stop."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
+        return BookingProposal(
+            place_id=details.place_id, provider="tock", booking_url="https://x"
+        )
+
+    with (
+        patch(
+            "app.agent.graph.get_details_many",
+            return_value={"p1": _rich_details_for("p1")},
+        ),
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
+        enrich_stops_with_booking(stops, state)
+
+    assert stops[0].address == "p1 Main St, San Francisco"
+    assert stops[0].rating == 4.4
+    assert stops[0].price_level == 2
+
+
+def test_enrich_card_fields_set_even_when_no_booking_time() -> None:
+    """Regression guard: the no-time path skips booking but must NOT skip
+    address/rating/price. These do not depend on `when`."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(constraints=UserConstraints(party_size=2))  # when=None
+
+    with (
+        patch(
+            "app.agent.graph.get_details_many",
+            return_value={"p1": _rich_details_for("p1")},
+        ),
+        patch("app.agent.graph.propose_booking_from_details") as mock_build,
+    ):
+        enrich_stops_with_booking(stops, state)
+
+    mock_build.assert_not_called()  # no booking without a time
+    assert stops[0].booking_url is None
+    # ...but card fields still landed:
+    assert stops[0].address == "p1 Main St, San Francisco"
+    assert stops[0].rating == 4.4
+    assert stops[0].price_level == 2
+
+
+def test_enrich_card_fields_none_when_details_missing() -> None:
+    """place_id missing from DB at enrichment time → fields stay None
+    (same degradation as booking links)."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    with patch("app.agent.graph.get_details_many", return_value={}):
+        enrich_stops_with_booking(stops, state)
+
+    assert stops[0].address is None
+    assert stops[0].rating is None
+    assert stops[0].price_level is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run pytest tests/unit/test_agent_graph.py -k "card_fields" -v`
+Expected: FAIL — `assert None == 'p1 Main St, San Francisco'` (fields not yet populated)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/agent/graph.py`, replace the loop body in `enrich_stops_with_booking`. Current code (lines 129-147):
+
+```python
+    for stop in stops:
+        when = stop.arrival_time or state.constraints.when
+        if when is None:
+            # No time → no booking link. Falling back to datetime.now() would
+            # embed wall-clock time in the URL, breaking re-commit idempotency
+            # (same inputs, different URL each call) and meaning nothing to
+            # the user. The card ships without a booking link; downstream can
+            # re-enrich once the user supplies a time.
+            continue
+        details = details_by_id.get(stop.place_id)
+        if details is None:
+            # place_id grounded in scratch but missing from DB at enrichment
+            # time — race condition on the deletion side, or a stale id. Same
+            # recoverable case as the old ValueError("unknown place_id"): skip.
+            logger.warning("booking enrichment skipped: place_id=%s not in DB", stop.place_id)
+            continue
+        proposal = propose_booking_from_details(details, when, party_size)
+        stop.booking_url = proposal.booking_url
+        stop.booking_provider = proposal.provider
+```
+
+Replace with (resolve `details` first, stamp card fields before any `continue`):
+
+```python
+    for stop in stops:
+        details = details_by_id.get(stop.place_id)
+        if details is None:
+            # place_id grounded in scratch but missing from DB at enrichment
+            # time — race condition on the deletion side, or a stale id. Same
+            # recoverable case as the old ValueError("unknown place_id"): skip
+            # both card-field and booking enrichment for this stop.
+            logger.warning("enrichment skipped: place_id=%s not in DB", stop.place_id)
+            continue
+
+        # Card fields do NOT depend on a booking time — stamp them before the
+        # `when is None` skip so a timeless stop still renders a full card.
+        stop.address = details.formatted_address
+        stop.rating = details.rating
+        stop.price_level = price_level_to_rank(details.price_level)
+
+        when = stop.arrival_time or state.constraints.when
+        if when is None:
+            # No time → no booking link. Falling back to datetime.now() would
+            # embed wall-clock time in the URL, breaking re-commit idempotency
+            # (same inputs, different URL each call) and meaning nothing to
+            # the user. The card ships without a booking link; downstream can
+            # re-enrich once the user supplies a time.
+            continue
+        proposal = propose_booking_from_details(details, when, party_size)
+        stop.booking_url = proposal.booking_url
+        stop.booking_provider = proposal.provider
+```
+
+Add the import — find the existing import of state symbols in `app/agent/graph.py` and add `price_level_to_rank` to it. Verify with:
+
+```bash
+grep -n "from app.agent.state import" app/agent/graph.py
+```
+
+Add `price_level_to_rank` to that import list (alphabetically/where it fits the existing style).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run pytest tests/unit/test_agent_graph.py -v`
+Expected: PASS — all existing enrichment tests AND the 3 new `card_fields` tests pass. (The reworded log string `"enrichment skipped: place_id=%s not in DB"` — confirm no existing test asserts the old `"booking enrichment skipped"` text; if one does, update that assertion.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/agent/graph.py tests/unit/test_agent_graph.py
+git commit -m "feat(agent): populate Stop card fields in enrich_stops_with_booking"
+```
+
+---
+
+### Task 3: Pass fields through `state_to_cards`
+
+**Files:**
+- Modify: `app/agent/io.py:38-51` (`state_to_cards`)
+- Test: `tests/unit/test_io.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_io.py`:
+
+```python
+"""Unit tests for app.agent.io projection."""
+
+from __future__ import annotations
+
+from app.agent.io import state_to_cards
+from app.agent.state import ItineraryState, Stop
+
+
+def test_state_to_cards_carries_address_rating_price() -> None:
+    state = ItineraryState(
+        stops=[
+            Stop(
+                place_id="p1",
+                name="Tartine",
+                address="600 Guerrero St, San Francisco",
+                rating=4.5,
+                price_level=2,
+                rationale="great pastries",
+                source="google_places",
+            )
+        ]
+    )
+
+    cards = state_to_cards(state)
+
+    assert len(cards) == 1
+    assert cards[0]["address"] == "600 Guerrero St, San Francisco"
+    assert cards[0]["rating"] == 4.5
+    assert cards[0]["price_level"] == 2
+
+
+def test_state_to_cards_defaults_missing_fields_to_none() -> None:
+    state = ItineraryState(
+        stops=[Stop(place_id="p1", name="X", rationale="r", source="google_places")]
+    )
+
+    cards = state_to_cards(state)
+
+    assert cards[0]["address"] is None
+    assert cards[0]["rating"] is None
+    assert cards[0]["price_level"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_io.py -v`
+Expected: FAIL — `assert None == '600 Guerrero St, San Francisco'` (fields not passed through)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/agent/io.py`, update the `PlaceCard(...)` construction in `state_to_cards` (lines 41-49) to pass the three fields:
+
+```python
+def state_to_cards(state: ItineraryState) -> list[dict[str, Any]]:
+    """Project committed stops into the PlaceCard shape the frontend renders."""
+    return [
+        PlaceCard(
+            place_id=s.place_id,
+            name=s.name,
+            address=s.address,
+            rating=s.rating,
+            price_level=s.price_level,
+            primary_type=s.primary_type,
+            arrival_time=s.arrival_time,
+            rationale=s.rationale,
+            booking_url=s.booking_url,
+            booking_provider=s.booking_provider,
+        ).model_dump(mode="json")
+        for s in state.stops
+    ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_io.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/agent/io.py tests/unit/test_io.py
+git commit -m "feat(agent): pass address/rating/price_level through state_to_cards"
+```
+
+---
+
+### Task 4: Full-suite regression + typecheck
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `poetry run pytest tests/unit/ -q`
+Expected: PASS — no regressions. Pay attention to `test_agent_graph.py`, `test_booking.py` (they exercise `enrich_stops_with_booking`).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `poetry run mypy app/`
+Expected: no new errors. `price_level_to_rank` returns `int | None`; `PlaceCard.price_level` is `int | None` — types align.
+
+- [ ] **Step 3: Lint**
+
+Run: `poetry run ruff check app/ tests/unit/test_state.py tests/unit/test_io.py`
+Expected: clean. (Pre-commit also runs ruff on commit; this is a pre-flight.)
+
+- [ ] **Step 4: Commit (only if Step 1-3 surfaced fixable nits)**
+
+If nothing changed, skip. Otherwise:
+
+```bash
+git add -A
+git commit -m "chore: lint/type fixups for PlaceCard field passthrough"
+```
+
+---
+
+### Task 5: Update implementation-plan tracking + FUTURE_WATCH
+
+Per `CLAUDE.md`: this fix resolves a FUTURE_WATCH item (not a workstream merge, so README.md status table is untouched — there's no W-row for it). Mark the FUTURE_WATCH item resolved instead.
+
+**Files:**
+- Modify: `implementation_plan/james/FUTURE_WATCH.md` (the "`PlaceCard` is missing address / rating / price_level" section, lines 46-68)
+
+- [ ] **Step 1: Mark the item resolved**
+
+In `implementation_plan/james/FUTURE_WATCH.md`, replace the `**Trigger:**` paragraph of that section (lines 57-65) with a resolution note:
+
+```markdown
+**Resolved (2026-05-16):** Fixed via Approach 1 on branch
+`fix/placecard-address-rating-price`. `Stop` now carries
+`address`/`rating`/`price_level`; populated in `enrich_stops_with_booking`
+from the already-fetched `PlaceDetails` (zero extra DB calls). `price_level`
+is mapped enum→int 0..4 via `price_level_to_rank` (mirrors SQL
+`price_level_rank()`). Card fields are stamped before the `when is None`
+booking skip so timeless stops still render full cards.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add implementation_plan/james/FUTURE_WATCH.md
+git commit -m "docs(future-watch): mark PlaceCard card-fields item resolved"
+```
+
+---
+
+## Notes for the executor
+
+- Use `poetry run` for pytest/mypy/ruff (project is poetry editable-installed; never add `sys.path` hacks).
+- Do NOT run `ruff` manually before committing as a *gate* — the pre-commit hook owns that. The ruff step in Task 4 is a read-only pre-flight; if the hook reformats on commit, re-stage and amend.
+- The user merges PRs themselves — stop after CI is green; do not `gh pr merge`.
+- Commits are small and single-line per project convention.

--- a/docs/superpowers/specs/2026-05-16-placecard-address-rating-price-design.md
+++ b/docs/superpowers/specs/2026-05-16-placecard-address-rating-price-design.md
@@ -1,0 +1,97 @@
+# PlaceCard address / rating / price_level — design
+
+**Date:** 2026-05-16
+**Branch:** `fix/placecard-address-rating-price`
+**Source:** `implementation_plan/james/FUTURE_WATCH.md` → "`PlaceCard` is missing address / rating / price_level"
+
+## Problem
+
+`state_to_cards` (`app/agent/io.py:38`) projects `Stop` → `PlaceCard`, but `Stop`
+never carried `address`, `rating`, or `price_level`. Every card the frontend
+renders ships `address: null, rating: null, price_level: null` even though
+`places_raw` (and the already-fetched `PlaceDetails`) has all three. `PlaceCard`
+declares the fields optional, so the gap is silent. The frontend already reads
+`address` and `rating`; `price_level` is in the contract for future use.
+
+## Type mismatch (not flagged in FUTURE_WATCH)
+
+`PlaceDetails.price_level` is the Google v1 enum **string**
+(`'PRICE_LEVEL_MODERATE'`), but `PlaceCard.price_level` is typed `int | None`.
+The fix must convert string → int 0..4, mirroring the existing SQL function
+`price_level_rank()` (alembic `c428add573d7`):
+
+| enum | rank |
+|---|---|
+| `PRICE_LEVEL_FREE` | 0 |
+| `PRICE_LEVEL_INEXPENSIVE` | 1 |
+| `PRICE_LEVEL_MODERATE` | 2 |
+| `PRICE_LEVEL_EXPENSIVE` | 3 |
+| `PRICE_LEVEL_VERY_EXPENSIVE` | 4 |
+| anything else / null | None |
+
+## Approach (chosen: A)
+
+Extend `Stop` and populate the fields inside the **existing** batched read in
+`enrich_stops_with_booking` (`app/agent/graph.py:98`). That function already
+calls `get_details_many(place_ids)` once per commit and iterates each stop's
+`PlaceDetails` — the address/rating/price data is already in hand. **Zero new
+DB calls.**
+
+Rejected alternatives:
+- **B** — re-fetch via `get_details` in `state_to_cards`: N reads per render,
+  and `state_to_cards` is a pure projection today.
+- **C** — carry raw `PlaceDetails` on `Stop`: bloats state with unused fields.
+
+## Changes
+
+1. **`app/agent/state.py`**
+   - `Stop` gains: `address: str | None = None`, `rating: float | None = None`,
+     `price_level: int | None = None`.
+   - Add module-level helper `price_level_to_rank(value: str | None) -> int | None`
+     mirroring the `price_level_rank()` WHEN-table. Lives in `state.py` next to
+     `Stop` (the only consumer), keeping the projection in `io.py` pure.
+
+2. **`app/agent/graph.py`** — in `enrich_stops_with_booking`, inside the existing
+   `for stop in stops:` loop, after `details = details_by_id.get(stop.place_id)`
+   resolves non-None, stamp:
+   - `stop.address = details.formatted_address`
+   - `stop.rating = details.rating`
+   - `stop.price_level = price_level_to_rank(details.price_level)`
+
+   Important ordering nuance: today the loop `continue`s early when `when is
+   None` (no booking time) — but address/rating/price do **not** depend on
+   `when`. The enrichment of these three fields must happen **before** the
+   `when is None` continue, so a stop with no arrival time still gets its
+   card data (it just won't get a booking link). The `details is None` /
+   DB-failure skips still apply (same degradation as booking links today).
+
+3. **`app/agent/io.py`** — `state_to_cards` passes the three new fields through
+   to `PlaceCard`.
+
+## Error handling / degradation
+
+Unchanged failure model: if `get_details_many` raises `psycopg2.Error` or a
+`place_id` is missing from the DB at enrichment time, those stops keep
+`address/rating/price_level = None`. This is the exact same degradation that
+already applies to booking links and is acceptable per the existing design.
+
+## Testing
+
+Per project test-layering convention (unit/mock + smoke + functional):
+
+- **Unit** — new `tests/unit/test_io.py`: `state_to_cards` carries the three
+  fields end-to-end from `Stop`. Unit test for `price_level_to_rank` covering
+  every enum, unknown string, and `None`.
+- **Unit** — extend graph enrichment tests: a stop with `when=None` still gets
+  address/rating/price (regression guard for the ordering nuance); DB-failure
+  path leaves them `None`.
+- **Functional** — existing `test_chat_functional.py` style: a committed
+  itinerary's cards expose non-null address/rating where the fixture place has
+  them.
+
+## Out of scope
+
+- Frontend changes to display `price_level` (contract-only today).
+- Backfilling `Stop` fields on a constraint-edit re-enrich path (no such path
+  exists yet; `enrich_stops_with_booking` is already structured to support it
+  when it does).

--- a/implementation_plan/james/FUTURE_WATCH.md
+++ b/implementation_plan/james/FUTURE_WATCH.md
@@ -54,18 +54,17 @@ the fields as optional, so the gap is silent.
 **Concern:** the frontend gets a degraded card — name + booking link but no
 location, no rating, no price tier. Most place-card UIs surface those.
 
-**Trigger:** before/with the next frontend pass that displays place cards
-prominently. Two viable fixes:
-
-1. Extend `Stop` with `address`/`rating`/`price_level` and populate them in
-   `_commit_stops` from the grounded `PlaceHit`/`PlaceDetails` already in
-   `state.scratch`. Preferred — no extra DB calls, data flows once.
-2. Re-fetch via `get_details(place_id)` inside `state_to_cards`. Costs N reads
-   per commit; only worth it if the scratch path doesn't carry the fields.
-
-Touches `app/agent/state.py` (`Stop`), `app/agent/graph.py` (`_commit_stops`),
-`app/agent/io.py` (`state_to_cards`). Not load-bearing for W4 (booking) — the
-gap predates W4 and was surfaced during W4 review.
+**Resolved (2026-05-16):** Fixed via Approach 1 on branch
+`fix/placecard-address-rating-price`. `Stop` now carries
+`address`/`rating`/`price_level`; populated in `enrich_stops_with_booking`
+(`app/agent/graph.py`) from the already-fetched `PlaceDetails` — zero extra DB
+calls, reusing the existing batched `get_details_many` read. `price_level` is
+mapped enum→int 0..4 via `price_level_to_rank` (`app/agent/state.py`, mirrors
+SQL `price_level_rank()`). Card fields are stamped *before* the `when is None`
+booking skip so timeless stops still render full cards. `state_to_cards`
+(`app/agent/io.py`) passes the fields through. Frontend contract
+(`docs/api/chat_contract.md`) already declared these fields — no shape change,
+the backend just stopped shipping them as `null`.
 
 ### `app/agent/` directory size
 

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -37,6 +37,19 @@ def _details_for(place_id: str, name: str | None = None) -> PlaceDetails:
     )
 
 
+def _rich_details_for(place_id: str) -> PlaceDetails:
+    """PlaceDetails carrying address/rating/price for card-field tests."""
+    return PlaceDetails(
+        place_id=place_id,
+        name=f"Place {place_id}",
+        source="google_places",
+        similarity=0.0,
+        formatted_address=f"{place_id} Main St, San Francisco",
+        rating=4.4,
+        price_level="PRICE_LEVEL_MODERATE",
+    )
+
+
 def _patch_details_many_for(place_ids: list[str]):
     """Patch get_details_many to return a minimal PlaceDetails for each id.
     Returns the patcher so tests can also assert call_count if they care."""
@@ -504,6 +517,68 @@ def test_enrich_stops_with_booking_mutates_in_place() -> None:
     # Both got party_size=4 from constraints (no per-stop arrival_time).
     assert all(s.booking_provider == "tock" for s in stops)
     assert all("size=4" in (s.booking_url or "") for s in stops)
+
+
+def test_enrich_populates_card_fields_from_details() -> None:
+    """address/rating/price_level flow from PlaceDetails onto Stop."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
+        return BookingProposal(place_id=details.place_id, provider="tock", booking_url="https://x")
+
+    with (
+        patch(
+            "app.agent.graph.get_details_many",
+            return_value={"p1": _rich_details_for("p1")},
+        ),
+        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+    ):
+        enrich_stops_with_booking(stops, state)
+
+    assert stops[0].address == "p1 Main St, San Francisco"
+    assert stops[0].rating == 4.4
+    assert stops[0].price_level == 2
+
+
+def test_enrich_card_fields_set_even_when_no_booking_time() -> None:
+    """Regression guard: the no-time path skips booking but must NOT skip
+    address/rating/price. These do not depend on `when`."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(constraints=UserConstraints(party_size=2))  # when=None
+
+    with (
+        patch(
+            "app.agent.graph.get_details_many",
+            return_value={"p1": _rich_details_for("p1")},
+        ),
+        patch("app.agent.graph.propose_booking_from_details") as mock_build,
+    ):
+        enrich_stops_with_booking(stops, state)
+
+    mock_build.assert_not_called()  # no booking without a time
+    assert stops[0].booking_url is None
+    assert stops[0].address == "p1 Main St, San Francisco"
+    assert stops[0].rating == 4.4
+    assert stops[0].price_level == 2
+
+
+def test_enrich_card_fields_none_when_details_missing() -> None:
+    """place_id missing from DB at enrichment time -> fields stay None
+    (same degradation as booking links)."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    with patch("app.agent.graph.get_details_many", return_value={}):
+        enrich_stops_with_booking(stops, state)
+
+    assert stops[0].address is None
+    assert stops[0].rating is None
+    assert stops[0].price_level is None
 
 
 def test_enrich_skipped_when_no_time_anywhere() -> None:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,0 +1,41 @@
+"""Unit tests for app.agent.io projection."""
+
+from __future__ import annotations
+
+from app.agent.io import state_to_cards
+from app.agent.state import ItineraryState, Stop
+
+
+def test_state_to_cards_carries_address_rating_price() -> None:
+    state = ItineraryState(
+        stops=[
+            Stop(
+                place_id="p1",
+                name="Tartine",
+                address="600 Guerrero St, San Francisco",
+                rating=4.5,
+                price_level=2,
+                rationale="great pastries",
+                source="google_places",
+            )
+        ]
+    )
+
+    cards = state_to_cards(state)
+
+    assert len(cards) == 1
+    assert cards[0]["address"] == "600 Guerrero St, San Francisco"
+    assert cards[0]["rating"] == 4.5
+    assert cards[0]["price_level"] == 2
+
+
+def test_state_to_cards_defaults_missing_fields_to_none() -> None:
+    state = ItineraryState(
+        stops=[Stop(place_id="p1", name="X", rationale="r", source="google_places")]
+    )
+
+    cards = state_to_cards(state)
+
+    assert cards[0]["address"] is None
+    assert cards[0]["rating"] is None
+    assert cards[0]["price_level"] is None

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,0 +1,32 @@
+"""Unit tests for app.agent.state helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agent.state import Stop, price_level_to_rank
+
+
+@pytest.mark.parametrize(
+    ("enum", "expected"),
+    [
+        ("PRICE_LEVEL_FREE", 0),
+        ("PRICE_LEVEL_INEXPENSIVE", 1),
+        ("PRICE_LEVEL_MODERATE", 2),
+        ("PRICE_LEVEL_EXPENSIVE", 3),
+        ("PRICE_LEVEL_VERY_EXPENSIVE", 4),
+        ("PRICE_LEVEL_UNSPECIFIED", None),
+        ("garbage", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_price_level_to_rank(enum: str | None, expected: int | None) -> None:
+    assert price_level_to_rank(enum) == expected
+
+
+def test_stop_defaults_new_fields_to_none() -> None:
+    s = Stop(place_id="p1", name="A", rationale="r", source="google_places")
+    assert s.address is None
+    assert s.rating is None
+    assert s.price_level is None


### PR DESCRIPTION
## Summary

Resolves the FUTURE_WATCH item "`PlaceCard` is missing address / rating / price_level". Every itinerary card the frontend rendered shipped `address: null, rating: null, price_level: null` even though `places_raw` had all three — the fields were in the documented contract but the backend never populated them.

- `Stop` gains `address` / `rating` / `price_level`; `price_level_to_rank()` maps Google's enum string → int 0..4, mirroring the SQL `price_level_rank()` (alembic `c428add573d7`).
- Populated inside the **existing** batched `get_details_many` read in `enrich_stops_with_booking` — **zero new DB calls**. Card fields are stamped *before* the `when is None` booking skip, so timeless stops still render full cards (booking link still correctly skipped without a time).
- `state_to_cards` passes the fields through. No `PlaceCard` shape change — the contract already declared them.
- Docs synced: FUTURE_WATCH item marked resolved, `chat_contract.md` freshness note.

## Test Plan

- [x] `tests/unit/test_state.py` — `price_level_to_rank` (all enums + unknown/""/None), `Stop` defaults
- [x] `tests/unit/test_agent_graph.py` — fields populated; **no-time regression guard** (booking skipped, card fields still set); details-missing → None; all pre-existing enrichment tests still green
- [x] `tests/unit/test_io.py` — `state_to_cards` carry-through + None defaults
- [x] Full unit suite: 416 pass. (`test_chat_functional::test_chat_runs_real_graph_with_tool_call` fails in full-suite run — **pre-existing test pollution proven identical on `main`**, passes in isolation, unrelated to this change.)
- [x] `mypy app/` clean; `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)