### PR TITLE
refactor(agent): split 604-line graph.py into graph/commit/revision

### DIFF
--- a/app/agent/commit.py
+++ b/app/agent/commit.py
@@ -1,0 +1,133 @@
+"""Commit LLM-proposed stops into validated Stops + enrich with booking/card data.
+
+Split out of graph.py (FUTURE_WATCH: app/agent/ directory size). `commit_stops`
+is the cross-module entry point called by the graph's `act` node;
+`enrich_stops_with_booking` is also public so a future constraint-edit path can
+refresh booking URLs in place without re-committing through the LLM.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import psycopg2
+
+from app.agent.state import ItineraryState, Stop, price_level_to_rank
+from app.tools.booking import propose_booking_from_details
+from app.tools.retrieval import get_details_many
+
+logger = logging.getLogger(__name__)
+
+
+def _grounded_place_ids(scratch: dict[str, Any]) -> set[str]:
+    """All place_ids the agent has actually seen via prior tool results."""
+    grounded: set[str] = set()
+    for entries in scratch.values():
+        for entry in entries:
+            result = entry.get("result")
+            if isinstance(result, list):
+                for hit in result:
+                    pid = getattr(hit, "place_id", None) or (
+                        hit.get("place_id") if isinstance(hit, dict) else None
+                    )
+                    if pid:
+                        grounded.add(pid)
+            elif result is not None:
+                pid = getattr(result, "place_id", None) or (
+                    result.get("place_id") if isinstance(result, dict) else None
+                )
+                if pid:
+                    grounded.add(pid)
+    return grounded
+
+
+def commit_stops(state: ItineraryState, raw_stops: Any) -> tuple[list[Stop], dict[str, Any]]:
+    """Validate and coerce LLM-supplied stops into Stop models.
+
+    Returns (committed_stops, tool_result_payload). The payload is what the
+    LLM sees back as the tool result; rejected place_ids surface there so the
+    model can self-correct in W3.
+    """
+    if not isinstance(raw_stops, list):
+        return [], {"error": "stops must be a list"}
+    grounded = _grounded_place_ids(state.scratch)
+    committed: list[Stop] = []
+    rejected: list[dict[str, Any]] = []
+    for raw in raw_stops:
+        if not isinstance(raw, dict):
+            rejected.append({"reason": "stop must be an object", "value": str(raw)})
+            continue
+        pid = raw.get("place_id")
+        if not pid or pid not in grounded:
+            rejected.append({"place_id": pid, "reason": "place_id not seen via prior tool result"})
+            continue
+        try:
+            committed.append(Stop(**raw))
+        except Exception as e:  # noqa: BLE001
+            rejected.append({"place_id": pid, "reason": f"invalid stop: {e}"})
+    enrich_stops_with_booking(committed, state)
+    return committed, {
+        "committed": [s.place_id for s in committed],
+        "rejected": rejected,
+    }
+
+
+def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
+    """Stamp booking_url + booking_provider on each committed stop in-place.
+
+    Deterministic — URL construction is a pure transform of (PlaceDetails,
+    when, party_size), so the LLM is not involved.
+
+    One batched DB read (get_details_many) covers all stops; previously this
+    was an N+1 over commit_itinerary. Per-stop URL building is pure and
+    cannot raise ValueError/psycopg2.Error, so the error-handling moved to
+    the single batched read: a DB blip skips enrichment for this commit
+    (cards ship without booking links), bugs propagate.
+
+    Called by commit_stops on initial commit. Public (no leading underscore)
+    so a future constraint-edit path — "make it 4 people instead of 2" or
+    "shift dinner to 8pm" — can refresh URLs in place without round-tripping
+    through the LLM and re-committing the same place_ids.
+    """
+    party_size = state.constraints.party_size or 2
+    place_ids = [stop.place_id for stop in stops]
+    try:
+        details_by_id = get_details_many(place_ids)
+    except psycopg2.Error:
+        # Single point of DB failure for the whole enrichment. Skip enrichment
+        # for the entire commit; cards still ship without booking links.
+        logger.warning(
+            "booking enrichment DB read failed for %d stops",
+            len(place_ids),
+            exc_info=True,
+        )
+        return
+
+    for stop in stops:
+        details = details_by_id.get(stop.place_id)
+        if details is None:
+            # place_id grounded in scratch but missing from DB at enrichment
+            # time — race condition on the deletion side, or a stale id. Same
+            # recoverable case as the old ValueError("unknown place_id"): skip
+            # both card-field and booking enrichment for this stop.
+            logger.warning("enrichment skipped: place_id=%s not in DB", stop.place_id)
+            continue
+
+        # Card fields do NOT depend on a booking time — stamp them before the
+        # `when is None` skip so a timeless stop still renders a full card.
+        stop.address = details.formatted_address
+        stop.rating = details.rating
+        stop.price_level = price_level_to_rank(details.price_level)
+
+        when = stop.arrival_time or state.constraints.when
+        if when is None:
+            # No time → no booking link. Falling back to datetime.now() would
+            # embed wall-clock time in the URL, breaking re-commit idempotency
+            # (same inputs, different URL each call) and meaning nothing to
+            # the user. The card ships without a booking link; downstream can
+            # re-enrich once the user supplies a time.
+            continue
+        proposal = propose_booking_from_details(details, when, party_size)
+        stop.booking_url = proposal.booking_url
+        stop.booking_provider = proposal.provider

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -17,12 +17,12 @@ import json
 import logging
 from typing import Any, Literal
 
-import psycopg2
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, StateGraph
 from pydantic import BaseModel
 
+from app.agent.commit import commit_stops
 from app.agent.critique import (
     CRITIQUE_ITINERARY,
     CRITIQUE_STEP,
@@ -31,128 +31,13 @@ from app.agent.critique import (
 )
 from app.agent.critique.checks import itinerary_violations
 from app.agent.prompts import SYSTEM_PROMPT
-from app.agent.state import ItineraryState, RevisionHint, Stop, price_level_to_rank
+from app.agent.state import ItineraryState, RevisionHint, Stop
 from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
-from app.tools.booking import propose_booking_from_details
-from app.tools.retrieval import get_details_many
 
 logger = logging.getLogger(__name__)
 
 LOW_SIMILARITY_THRESHOLD = 0.55
 MAX_REVISIONS_PER_REASON = 2
-
-
-def _grounded_place_ids(scratch: dict[str, Any]) -> set[str]:
-    """All place_ids the agent has actually seen via prior tool results."""
-    grounded: set[str] = set()
-    for entries in scratch.values():
-        for entry in entries:
-            result = entry.get("result")
-            if isinstance(result, list):
-                for hit in result:
-                    pid = getattr(hit, "place_id", None) or (
-                        hit.get("place_id") if isinstance(hit, dict) else None
-                    )
-                    if pid:
-                        grounded.add(pid)
-            elif result is not None:
-                pid = getattr(result, "place_id", None) or (
-                    result.get("place_id") if isinstance(result, dict) else None
-                )
-                if pid:
-                    grounded.add(pid)
-    return grounded
-
-
-def _commit_stops(state: ItineraryState, raw_stops: Any) -> tuple[list[Stop], dict[str, Any]]:
-    """Validate and coerce LLM-supplied stops into Stop models.
-
-    Returns (committed_stops, tool_result_payload). The payload is what the
-    LLM sees back as the tool result; rejected place_ids surface there so the
-    model can self-correct in W3.
-    """
-    if not isinstance(raw_stops, list):
-        return [], {"error": "stops must be a list"}
-    grounded = _grounded_place_ids(state.scratch)
-    committed: list[Stop] = []
-    rejected: list[dict[str, Any]] = []
-    for raw in raw_stops:
-        if not isinstance(raw, dict):
-            rejected.append({"reason": "stop must be an object", "value": str(raw)})
-            continue
-        pid = raw.get("place_id")
-        if not pid or pid not in grounded:
-            rejected.append({"place_id": pid, "reason": "place_id not seen via prior tool result"})
-            continue
-        try:
-            committed.append(Stop(**raw))
-        except Exception as e:  # noqa: BLE001
-            rejected.append({"place_id": pid, "reason": f"invalid stop: {e}"})
-    enrich_stops_with_booking(committed, state)
-    return committed, {
-        "committed": [s.place_id for s in committed],
-        "rejected": rejected,
-    }
-
-
-def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
-    """Stamp booking_url + booking_provider on each committed stop in-place.
-
-    Deterministic — URL construction is a pure transform of (PlaceDetails,
-    when, party_size), so the LLM is not involved.
-
-    One batched DB read (get_details_many) covers all stops; previously this
-    was an N+1 over commit_itinerary. Per-stop URL building is pure and
-    cannot raise ValueError/psycopg2.Error, so the error-handling moved to
-    the single batched read: a DB blip skips enrichment for this commit
-    (cards ship without booking links), bugs propagate.
-
-    Called by _commit_stops on initial commit. Public (no leading underscore)
-    so a future constraint-edit path — "make it 4 people instead of 2" or
-    "shift dinner to 8pm" — can refresh URLs in place without round-tripping
-    through the LLM and re-committing the same place_ids.
-    """
-    party_size = state.constraints.party_size or 2
-    place_ids = [stop.place_id for stop in stops]
-    try:
-        details_by_id = get_details_many(place_ids)
-    except psycopg2.Error:
-        # Single point of DB failure for the whole enrichment. Skip enrichment
-        # for the entire commit; cards still ship without booking links.
-        logger.warning(
-            "booking enrichment DB read failed for %d stops",
-            len(place_ids),
-            exc_info=True,
-        )
-        return
-
-    for stop in stops:
-        details = details_by_id.get(stop.place_id)
-        if details is None:
-            # place_id grounded in scratch but missing from DB at enrichment
-            # time — race condition on the deletion side, or a stale id. Same
-            # recoverable case as the old ValueError("unknown place_id"): skip
-            # both card-field and booking enrichment for this stop.
-            logger.warning("enrichment skipped: place_id=%s not in DB", stop.place_id)
-            continue
-
-        # Card fields do NOT depend on a booking time — stamp them before the
-        # `when is None` skip so a timeless stop still renders a full card.
-        stop.address = details.formatted_address
-        stop.rating = details.rating
-        stop.price_level = price_level_to_rank(details.price_level)
-
-        when = stop.arrival_time or state.constraints.when
-        if when is None:
-            # No time → no booking link. Falling back to datetime.now() would
-            # embed wall-clock time in the URL, breaking re-commit idempotency
-            # (same inputs, different URL each call) and meaning nothing to
-            # the user. The card ships without a booking link; downstream can
-            # re-enrich once the user supplies a time.
-            continue
-        proposal = propose_booking_from_details(details, when, party_size)
-        stop.booking_url = proposal.booking_url
-        stop.booking_provider = proposal.provider
 
 
 _RECENT_TOOL_EXCHANGES_KEPT = 2
@@ -512,7 +397,7 @@ def build_agent_graph(
 
         for tc in ai.tool_calls:
             if tc["name"] == COMMIT_ITINERARY_TOOL_NAME:
-                stops, payload = _commit_stops(state, tc["args"].get("stops"))
+                stops, payload = commit_stops(state, tc["args"].get("stops"))
                 committed_stops = stops
                 new_messages.append(
                     ToolMessage(content=_serialize_tool_result(payload), tool_call_id=tc["id"])

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -18,26 +18,23 @@ import logging
 from typing import Any, Literal
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, StateGraph
 from pydantic import BaseModel
 
 from app.agent.commit import commit_stops
-from app.agent.critique import (
-    CRITIQUE_ITINERARY,
-    CRITIQUE_STEP,
-    CRITIQUE_VIBE,
-    vibe,
-)
-from app.agent.critique.checks import itinerary_violations
+from app.agent.critique import vibe
 from app.agent.prompts import SYSTEM_PROMPT
-from app.agent.state import ItineraryState, RevisionHint, Stop
+from app.agent.revision import (
+    critique_final_with_stops,
+    critique_step,
+    finalize_as_is,
+    short_circuit_max_steps,
+)
+from app.agent.state import ItineraryState, Stop
 from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
 
 logger = logging.getLogger(__name__)
-
-LOW_SIMILARITY_THRESHOLD = 0.55
-MAX_REVISIONS_PER_REASON = 2
 
 
 _RECENT_TOOL_EXCHANGES_KEPT = 2
@@ -98,256 +95,6 @@ def _serialize_tool_result(result: Any) -> str:
     if isinstance(result, list) and result and isinstance(result[0], BaseModel):
         return json.dumps([m.model_dump(mode="json") for m in result])
     return json.dumps(result, default=str)
-
-
-def _can_retry(state: ItineraryState, reason: str) -> bool:
-    return state.revision_counts.get(reason, 0) < MAX_REVISIONS_PER_REASON
-
-
-def _bumped_counts(state: ItineraryState, reason: str) -> dict[str, int]:
-    counts = dict(state.revision_counts)
-    counts[reason] = counts.get(reason, 0) + 1
-    return counts
-
-
-def _scratch_entries_for_last_round(
-    state: ItineraryState,
-) -> list[tuple[str, dict[str, Any]]]:
-    """Return (tool_name, scratch_entry) pairs for every tool_call in the most
-    recent issuing AIMessage, in tool_call order.
-
-    Pairings are matched by tool_call id when present, falling back to the
-    highest-step entry for that tool name (handles legacy entries that
-    pre-date id tracking)."""
-    last_tool_idx = None
-    for i in range(len(state.messages) - 1, -1, -1):
-        if isinstance(state.messages[i], ToolMessage):
-            last_tool_idx = i
-            break
-    if last_tool_idx is None:
-        return []
-    issuing_ai: AIMessage | None = None
-    for i in range(last_tool_idx - 1, -1, -1):
-        m = state.messages[i]
-        if isinstance(m, AIMessage) and m.tool_calls:
-            issuing_ai = m
-            break
-    if issuing_ai is None or not issuing_ai.tool_calls:
-        return []
-    pairs: list[tuple[str, dict[str, Any]]] = []
-    for tc in issuing_ai.tool_calls:
-        name = tc["name"]
-        entries = state.scratch.get(name) or []
-        if not entries:
-            continue
-        match = next((e for e in entries if e.get("id") == tc["id"]), None)
-        if match is None:
-            match = max(entries, key=lambda e: e.get("step", -1))
-        pairs.append((name, match))
-    return pairs
-
-
-def _most_restrictive_filter(filters: dict[str, Any] | None) -> str:
-    """Deterministic priority order for which filter to drop first."""
-    if not filters:
-        return "none"
-    for f in ("open_at", "price_level_max", "min_rating", "neighborhood", "types_any"):
-        if filters.get(f) is not None:
-            return f
-    return "none"
-
-
-def _diagnose_one(tool_name: str, entry: dict[str, Any]) -> RevisionHint | None:
-    """Inspect a single tool call+result pair. Returns a hint or None."""
-    result = entry.get("result")
-    args = entry.get("args") or {}
-
-    if isinstance(result, dict) and "error" in result:
-        return RevisionHint(
-            reason="tool_error",
-            detail=str(result["error"]),
-            suggested_action="try_different_tool",
-            target={"tool": tool_name},
-        )
-
-    if isinstance(result, list):
-        if not result:
-            return RevisionHint(
-                reason="empty_results",
-                detail=f"No matches for {args}.",
-                suggested_action="drop_filter",
-                target={"filter": _most_restrictive_filter(args.get("filters"))},
-            )
-        if all(getattr(h, "business_status", None) != "OPERATIONAL" for h in result):
-            return RevisionHint(
-                reason="all_closed",
-                detail="Every result is closed or permanently_closed.",
-                suggested_action="broaden_query",
-                target={"filter": "business_status"},
-            )
-        top = result[0]
-        sim = getattr(top, "similarity", 0.0) or 0.0
-        if sim < LOW_SIMILARITY_THRESHOLD:
-            return RevisionHint(
-                reason="low_similarity",
-                detail=f"Top similarity {sim:.2f} below threshold {LOW_SIMILARITY_THRESHOLD}.",
-                suggested_action="broaden_query",
-                target={"query": args.get("query")},
-            )
-    return None
-
-
-def _diagnose_last_tool_result(state: ItineraryState) -> RevisionHint | None:
-    """Diagnose every tool_call in the most recent issuing AIMessage and
-    return the first hint in tool_call order. Returns None if every call was
-    healthy. The agent revises one issue per round; later issues, if any,
-    will be diagnosed on the next round."""
-    for tool_name, entry in _scratch_entries_for_last_round(state):
-        hint = _diagnose_one(tool_name, entry)
-        if hint is not None:
-            return hint
-    return None
-
-
-def _hint_for_violation(reason: str, state: ItineraryState) -> RevisionHint:
-    """Map a check name from itinerary_violations() to a structured hint."""
-    if reason == "geographic_coherence":
-        return RevisionHint(
-            reason="geographic_incoherence",
-            detail="One or more consecutive stops exceed the per-leg walking budget.",
-            suggested_action="tighten_radius",
-            target={"stops": list(range(1, len(state.stops)))},
-        )
-    if reason == "temporal_coherence":
-        return RevisionHint(
-            reason="temporal_incoherence",
-            detail="A stop is closed at its planned arrival time.",
-            suggested_action="shift_arrival_time",
-            target={},
-        )
-    if reason == "walking_budget_respected":
-        return RevisionHint(
-            reason="walking_budget_exceeded",
-            detail="Total walking exceeds the user's budget.",
-            suggested_action="rebalance_walking_budget",
-            target={},
-        )
-    if reason == "no_hallucinated_place_ids":
-        return RevisionHint(
-            reason="hallucinated_place_id",
-            detail="One or more place_ids do not exist in places_raw.",
-            suggested_action="swap_stop",
-            target={},
-        )
-    return RevisionHint(
-        reason="constraint_unmet_in_final",
-        detail="Final stops do not satisfy the shared user constraints.",
-        suggested_action="swap_stop",
-        target={},
-    )
-
-
-def _final_with_caveats(last_content: str, violations: list[str]) -> str:
-    """Compose a final reply that lists what didn't quite work. Better than
-    silently shipping a bad plan."""
-    caveats = (
-        "\n\nCaveats: I couldn't fully satisfy "
-        + ", ".join(violations)
-        + (" after revisions. You may want to adjust the plan.")
-    )
-    return (last_content or "") + caveats
-
-
-def _last_ai_content(last: BaseMessage | None) -> str:
-    return last.content if isinstance(last, AIMessage) and isinstance(last.content, str) else ""
-
-
-def _short_circuit_max_steps(state: ItineraryState) -> dict[str, Any]:
-    return {
-        "done": True,
-        "final_reply": state.final_reply
-        or "I hit the planning step limit. Here is the best plan I had so far.",
-    }
-
-
-def _finalize_as_is(state: ItineraryState, last: BaseMessage | None) -> dict[str, Any]:
-    return {"done": True, "final_reply": state.final_reply or _last_ai_content(last)}
-
-
-def _critique_final_with_stops(
-    state: ItineraryState,
-    last: BaseMessage | None,
-    judge_llm: BaseChatModel | None,
-) -> dict[str, Any]:
-    """Run deterministic checks; if any fail, drive a revision (or ship with
-    caveats once budgets are exhausted). If they all pass, run the optional
-    cheap-LLM vibe check; if that fails, drive a revision. Otherwise finalize."""
-    last_content = _last_ai_content(last)
-    violations = itinerary_violations(state)
-    if violations:
-        actionable = next((v for v in violations if _can_retry(state, v)), None)
-        if actionable is not None:
-            hint = _hint_for_violation(actionable, state)
-            return {
-                "revision_hints": [*state.revision_hints, hint],
-                "revision_counts": _bumped_counts(state, actionable),
-                "messages": [
-                    HumanMessage(
-                        content=(
-                            f"{CRITIQUE_ITINERARY} {actionable}: {hint.detail} "
-                            f"Suggested action: {hint.suggested_action}. "
-                            f"Revise the affected stop(s) and re-call commit_itinerary."
-                        )
-                    )
-                ],
-                "done": False,
-            }
-        return {"done": True, "final_reply": _final_with_caveats(last_content, violations)}
-
-    score = vibe.vibe_check(state, judge_llm)
-    if score is not None and score < vibe.VIBE_THRESHOLD and _can_retry(state, "vibe_mismatch"):
-        hint = RevisionHint(
-            reason="vibe_mismatch",
-            detail=f"Cross-stop vibe coherence scored {score:.1f}/5.",
-            suggested_action="swap_stop",
-            target={},
-        )
-        return {
-            "revision_hints": [*state.revision_hints, hint],
-            "revision_counts": _bumped_counts(state, "vibe_mismatch"),
-            "messages": [
-                HumanMessage(
-                    content=(
-                        f"{CRITIQUE_VIBE} cross-stop vibe coherence scored "
-                        f"{score:.1f}/5. Swap whichever stop feels off and "
-                        f"re-call commit_itinerary."
-                    )
-                )
-            ],
-            "done": False,
-        }
-
-    return {"done": True, "final_reply": state.final_reply or last_content}
-
-
-def _critique_step(state: ItineraryState) -> dict[str, Any]:
-    """React to the last tool result. Emit a per-step hint if it was empty,
-    all-closed, low-similarity, or errored. Bounded by retry budget."""
-    hint = _diagnose_last_tool_result(state)
-    if hint is None or not _can_retry(state, hint.reason):
-        return {}
-    return {
-        "revision_hints": [*state.revision_hints, hint],
-        "revision_counts": _bumped_counts(state, hint.reason),
-        "messages": [
-            HumanMessage(
-                content=(
-                    f"{CRITIQUE_STEP} {hint.reason}: {hint.detail} "
-                    f"Suggested next action: {hint.suggested_action} on {hint.target}."
-                )
-            )
-        ],
-    }
 
 
 def build_agent_graph(
@@ -460,16 +207,16 @@ def build_agent_graph(
         per-step diagnose. Each branch is a pure function returning the
         LangGraph update dict."""
         if state.step_count >= max_steps:
-            return _short_circuit_max_steps(state)
+            return short_circuit_max_steps(state)
 
         last = state.messages[-1] if state.messages else None
         finalizing = isinstance(last, AIMessage) and not last.tool_calls
 
         if finalizing and state.stops:
-            return _critique_final_with_stops(state, last, judge_llm)
+            return critique_final_with_stops(state, last, judge_llm)
         if finalizing:
-            return _finalize_as_is(state, last)
-        return _critique_step(state)
+            return finalize_as_is(state, last)
+        return critique_step(state)
 
     def route_after_plan(state: ItineraryState) -> Literal["act", "critique"]:
         last = state.messages[-1]

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -8,6 +8,10 @@ Edge logic:
   plan -> act (if tool call) | END (if final)
   act  -> critique
   critique -> plan (if revise or more work) | END (if good)
+
+Stop-commit + booking enrichment lives in app.agent.commit; critique/
+revision-diagnosis branch logic lives in app.agent.revision (split out of
+graph.py per FUTURE_WATCH: app/agent/ directory size).
 """
 
 from __future__ import annotations

--- a/app/agent/revision.py
+++ b/app/agent/revision.py
@@ -1,0 +1,272 @@
+"""Critique / revision-diagnosis logic for the agent graph.
+
+Split out of graph.py (FUTURE_WATCH: app/agent/ directory size). Public entry
+points (critique_step, critique_final_with_stops, short_circuit_max_steps,
+finalize_as_is) are called by the graph's `critique` node. Everything else is
+module-internal (underscore-prefixed); white-box tests import those by their
+private name, matching the existing test pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+
+from app.agent.critique import CRITIQUE_ITINERARY, CRITIQUE_STEP, CRITIQUE_VIBE, vibe
+from app.agent.critique.checks import itinerary_violations
+from app.agent.state import ItineraryState, RevisionHint
+
+LOW_SIMILARITY_THRESHOLD = 0.55
+MAX_REVISIONS_PER_REASON = 2
+
+
+def _can_retry(state: ItineraryState, reason: str) -> bool:
+    return state.revision_counts.get(reason, 0) < MAX_REVISIONS_PER_REASON
+
+
+def _bumped_counts(state: ItineraryState, reason: str) -> dict[str, int]:
+    counts = dict(state.revision_counts)
+    counts[reason] = counts.get(reason, 0) + 1
+    return counts
+
+
+def _scratch_entries_for_last_round(
+    state: ItineraryState,
+) -> list[tuple[str, dict[str, Any]]]:
+    """Return (tool_name, scratch_entry) pairs for every tool_call in the most
+    recent issuing AIMessage, in tool_call order.
+
+    Pairings are matched by tool_call id when present, falling back to the
+    highest-step entry for that tool name (handles legacy entries that
+    pre-date id tracking)."""
+    last_tool_idx = None
+    for i in range(len(state.messages) - 1, -1, -1):
+        if isinstance(state.messages[i], ToolMessage):
+            last_tool_idx = i
+            break
+    if last_tool_idx is None:
+        return []
+    issuing_ai: AIMessage | None = None
+    for i in range(last_tool_idx - 1, -1, -1):
+        m = state.messages[i]
+        if isinstance(m, AIMessage) and m.tool_calls:
+            issuing_ai = m
+            break
+    if issuing_ai is None or not issuing_ai.tool_calls:
+        return []
+    pairs: list[tuple[str, dict[str, Any]]] = []
+    for tc in issuing_ai.tool_calls:
+        name = tc["name"]
+        entries = state.scratch.get(name) or []
+        if not entries:
+            continue
+        match = next((e for e in entries if e.get("id") == tc["id"]), None)
+        if match is None:
+            match = max(entries, key=lambda e: e.get("step", -1))
+        pairs.append((name, match))
+    return pairs
+
+
+def _most_restrictive_filter(filters: dict[str, Any] | None) -> str:
+    """Deterministic priority order for which filter to drop first."""
+    if not filters:
+        return "none"
+    for f in ("open_at", "price_level_max", "min_rating", "neighborhood", "types_any"):
+        if filters.get(f) is not None:
+            return f
+    return "none"
+
+
+def _diagnose_one(tool_name: str, entry: dict[str, Any]) -> RevisionHint | None:
+    """Inspect a single tool call+result pair. Returns a hint or None."""
+    result = entry.get("result")
+    args = entry.get("args") or {}
+
+    if isinstance(result, dict) and "error" in result:
+        return RevisionHint(
+            reason="tool_error",
+            detail=str(result["error"]),
+            suggested_action="try_different_tool",
+            target={"tool": tool_name},
+        )
+
+    if isinstance(result, list):
+        if not result:
+            return RevisionHint(
+                reason="empty_results",
+                detail=f"No matches for {args}.",
+                suggested_action="drop_filter",
+                target={"filter": _most_restrictive_filter(args.get("filters"))},
+            )
+        if all(getattr(h, "business_status", None) != "OPERATIONAL" for h in result):
+            return RevisionHint(
+                reason="all_closed",
+                detail="Every result is closed or permanently_closed.",
+                suggested_action="broaden_query",
+                target={"filter": "business_status"},
+            )
+        top = result[0]
+        sim = getattr(top, "similarity", 0.0) or 0.0
+        if sim < LOW_SIMILARITY_THRESHOLD:
+            return RevisionHint(
+                reason="low_similarity",
+                detail=f"Top similarity {sim:.2f} below threshold {LOW_SIMILARITY_THRESHOLD}.",
+                suggested_action="broaden_query",
+                target={"query": args.get("query")},
+            )
+    return None
+
+
+def _diagnose_last_tool_result(state: ItineraryState) -> RevisionHint | None:
+    """Diagnose every tool_call in the most recent issuing AIMessage and
+    return the first hint in tool_call order. Returns None if every call was
+    healthy. The agent revises one issue per round; later issues, if any,
+    will be diagnosed on the next round."""
+    for tool_name, entry in _scratch_entries_for_last_round(state):
+        hint = _diagnose_one(tool_name, entry)
+        if hint is not None:
+            return hint
+    return None
+
+
+def _hint_for_violation(reason: str, state: ItineraryState) -> RevisionHint:
+    """Map a check name from itinerary_violations() to a structured hint."""
+    if reason == "geographic_coherence":
+        return RevisionHint(
+            reason="geographic_incoherence",
+            detail="One or more consecutive stops exceed the per-leg walking budget.",
+            suggested_action="tighten_radius",
+            target={"stops": list(range(1, len(state.stops)))},
+        )
+    if reason == "temporal_coherence":
+        return RevisionHint(
+            reason="temporal_incoherence",
+            detail="A stop is closed at its planned arrival time.",
+            suggested_action="shift_arrival_time",
+            target={},
+        )
+    if reason == "walking_budget_respected":
+        return RevisionHint(
+            reason="walking_budget_exceeded",
+            detail="Total walking exceeds the user's budget.",
+            suggested_action="rebalance_walking_budget",
+            target={},
+        )
+    if reason == "no_hallucinated_place_ids":
+        return RevisionHint(
+            reason="hallucinated_place_id",
+            detail="One or more place_ids do not exist in places_raw.",
+            suggested_action="swap_stop",
+            target={},
+        )
+    return RevisionHint(
+        reason="constraint_unmet_in_final",
+        detail="Final stops do not satisfy the shared user constraints.",
+        suggested_action="swap_stop",
+        target={},
+    )
+
+
+def _final_with_caveats(last_content: str, violations: list[str]) -> str:
+    """Compose a final reply that lists what didn't quite work. Better than
+    silently shipping a bad plan."""
+    caveats = (
+        "\n\nCaveats: I couldn't fully satisfy "
+        + ", ".join(violations)
+        + (" after revisions. You may want to adjust the plan.")
+    )
+    return (last_content or "") + caveats
+
+
+def _last_ai_content(last: BaseMessage | None) -> str:
+    return last.content if isinstance(last, AIMessage) and isinstance(last.content, str) else ""
+
+
+def short_circuit_max_steps(state: ItineraryState) -> dict[str, Any]:
+    return {
+        "done": True,
+        "final_reply": state.final_reply
+        or "I hit the planning step limit. Here is the best plan I had so far.",
+    }
+
+
+def finalize_as_is(state: ItineraryState, last: BaseMessage | None) -> dict[str, Any]:
+    return {"done": True, "final_reply": state.final_reply or _last_ai_content(last)}
+
+
+def critique_final_with_stops(
+    state: ItineraryState,
+    last: BaseMessage | None,
+    judge_llm: BaseChatModel | None,
+) -> dict[str, Any]:
+    """Run deterministic checks; if any fail, drive a revision (or ship with
+    caveats once budgets are exhausted). If they all pass, run the optional
+    cheap-LLM vibe check; if that fails, drive a revision. Otherwise finalize."""
+    last_content = _last_ai_content(last)
+    violations = itinerary_violations(state)
+    if violations:
+        actionable = next((v for v in violations if _can_retry(state, v)), None)
+        if actionable is not None:
+            hint = _hint_for_violation(actionable, state)
+            return {
+                "revision_hints": [*state.revision_hints, hint],
+                "revision_counts": _bumped_counts(state, actionable),
+                "messages": [
+                    HumanMessage(
+                        content=(
+                            f"{CRITIQUE_ITINERARY} {actionable}: {hint.detail} "
+                            f"Suggested action: {hint.suggested_action}. "
+                            f"Revise the affected stop(s) and re-call commit_itinerary."
+                        )
+                    )
+                ],
+                "done": False,
+            }
+        return {"done": True, "final_reply": _final_with_caveats(last_content, violations)}
+
+    score = vibe.vibe_check(state, judge_llm)
+    if score is not None and score < vibe.VIBE_THRESHOLD and _can_retry(state, "vibe_mismatch"):
+        hint = RevisionHint(
+            reason="vibe_mismatch",
+            detail=f"Cross-stop vibe coherence scored {score:.1f}/5.",
+            suggested_action="swap_stop",
+            target={},
+        )
+        return {
+            "revision_hints": [*state.revision_hints, hint],
+            "revision_counts": _bumped_counts(state, "vibe_mismatch"),
+            "messages": [
+                HumanMessage(
+                    content=(
+                        f"{CRITIQUE_VIBE} cross-stop vibe coherence scored "
+                        f"{score:.1f}/5. Swap whichever stop feels off and "
+                        f"re-call commit_itinerary."
+                    )
+                )
+            ],
+            "done": False,
+        }
+
+    return {"done": True, "final_reply": state.final_reply or last_content}
+
+
+def critique_step(state: ItineraryState) -> dict[str, Any]:
+    """React to the last tool result. Emit a per-step hint if it was empty,
+    all-closed, low-similarity, or errored. Bounded by retry budget."""
+    hint = _diagnose_last_tool_result(state)
+    if hint is None or not _can_retry(state, hint.reason):
+        return {}
+    return {
+        "revision_hints": [*state.revision_hints, hint],
+        "revision_counts": _bumped_counts(state, hint.reason),
+        "messages": [
+            HumanMessage(
+                content=(
+                    f"{CRITIQUE_STEP} {hint.reason}: {hint.detail} "
+                    f"Suggested next action: {hint.suggested_action} on {hint.target}."
+                )
+            )
+        ],
+    }

--- a/docs/superpowers/plans/2026-05-16-graph-py-decomposition.md
+++ b/docs/superpowers/plans/2026-05-16-graph-py-decomposition.md
@@ -1,0 +1,431 @@
+# `app/agent/graph.py` Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the 604-line `app/agent/graph.py` into three flat sibling modules (`graph.py`, `commit.py`, `revision.py`) with zero behavior change.
+
+**Architecture:** Pure code-move refactor. Two cohesive clusters (stop-commit/booking enrichment; critique/revision-diagnosis) move to new flat modules mirroring the existing `planning.py`/`io.py` pattern. Cross-module entry points get public names (underscore dropped); test-only internals keep their underscore. Behavior preservation is proven by the existing test suite passing with only import-line edits.
+
+**Tech Stack:** Python 3.10, pytest (asyncio_mode=auto), mypy, poetry editable-install.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-graph-py-decomposition-design.md`
+
+**CRITICAL — this is a MOVE, not a rewrite.** When a step says "move function `X`", copy the function body **verbatim** from the source — do not retype, re-paraphrase, reformat, or "improve" it. The only permitted edits are: (a) renaming `_commit_stops`→`commit_stops` and the 4 revision entry points (and their call sites), (b) import statements. Any logic/comment/whitespace change is a plan violation. Verify with `git diff` that moved code is identical modulo the rename.
+
+---
+
+### Task 1: Extract `app/agent/commit.py`
+
+**Files:**
+- Create: `app/agent/commit.py`
+- Modify: `app/agent/graph.py` (remove `_grounded_place_ids`, `_commit_stops`, `enrich_stops_with_booking`; update imports + the `act` closure call site)
+- Modify: `tests/unit/test_agent_graph.py` (import lines 17-22 + `_commit_stops` call-site renames)
+- Modify: `tests/unit/test_booking.py` (import line 8 + `_commit_stops` call-site renames + comment line ~286)
+
+- [ ] **Step 1: Create `app/agent/commit.py`**
+
+Create the file with this exact content (the three functions are moved verbatim from `graph.py` lines 45-148; `_commit_stops` is renamed to `commit_stops` and its internal call to `enrich_stops_with_booking` is unchanged):
+
+```python
+"""Commit LLM-proposed stops into validated Stops + enrich with booking/card data.
+
+Split out of graph.py (FUTURE_WATCH: app/agent/ directory size). `commit_stops`
+is the cross-module entry point called by the graph's `act` node;
+`enrich_stops_with_booking` is also public so a future constraint-edit path can
+refresh booking URLs in place without re-committing through the LLM.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import psycopg2
+
+from app.agent.state import ItineraryState, Stop, price_level_to_rank
+from app.tools.booking import propose_booking_from_details
+from app.tools.retrieval import get_details_many
+
+logger = logging.getLogger(__name__)
+
+
+def _grounded_place_ids(scratch: dict[str, Any]) -> set[str]:
+    """All place_ids the agent has actually seen via prior tool results."""
+    grounded: set[str] = set()
+    for entries in scratch.values():
+        for entry in entries:
+            result = entry.get("result")
+            if isinstance(result, list):
+                for hit in result:
+                    pid = getattr(hit, "place_id", None) or (
+                        hit.get("place_id") if isinstance(hit, dict) else None
+                    )
+                    if pid:
+                        grounded.add(pid)
+            elif result is not None:
+                pid = getattr(result, "place_id", None) or (
+                    result.get("place_id") if isinstance(result, dict) else None
+                )
+                if pid:
+                    grounded.add(pid)
+    return grounded
+
+
+def commit_stops(state: ItineraryState, raw_stops: Any) -> tuple[list[Stop], dict[str, Any]]:
+    """Validate and coerce LLM-supplied stops into Stop models.
+
+    Returns (committed_stops, tool_result_payload). The payload is what the
+    LLM sees back as the tool result; rejected place_ids surface there so the
+    model can self-correct in W3.
+    """
+    if not isinstance(raw_stops, list):
+        return [], {"error": "stops must be a list"}
+    grounded = _grounded_place_ids(state.scratch)
+    committed: list[Stop] = []
+    rejected: list[dict[str, Any]] = []
+    for raw in raw_stops:
+        if not isinstance(raw, dict):
+            rejected.append({"reason": "stop must be an object", "value": str(raw)})
+            continue
+        pid = raw.get("place_id")
+        if not pid or pid not in grounded:
+            rejected.append({"place_id": pid, "reason": "place_id not seen via prior tool result"})
+            continue
+        try:
+            committed.append(Stop(**raw))
+        except Exception as e:  # noqa: BLE001
+            rejected.append({"place_id": pid, "reason": f"invalid stop: {e}"})
+    enrich_stops_with_booking(committed, state)
+    return committed, {
+        "committed": [s.place_id for s in committed],
+        "rejected": rejected,
+    }
+
+
+def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
+    """Stamp booking_url + booking_provider on each committed stop in-place.
+
+    Deterministic — URL construction is a pure transform of (PlaceDetails,
+    when, party_size), so the LLM is not involved.
+
+    One batched DB read (get_details_many) covers all stops; previously this
+    was an N+1 over commit_itinerary. Per-stop URL building is pure and
+    cannot raise ValueError/psycopg2.Error, so the error-handling moved to
+    the single batched read: a DB blip skips enrichment for this commit
+    (cards ship without booking links), bugs propagate.
+
+    Called by commit_stops on initial commit. Public (no leading underscore)
+    so a future constraint-edit path — "make it 4 people instead of 2" or
+    "shift dinner to 8pm" — can refresh URLs in place without round-tripping
+    through the LLM and re-committing the same place_ids.
+    """
+    party_size = state.constraints.party_size or 2
+    place_ids = [stop.place_id for stop in stops]
+    try:
+        details_by_id = get_details_many(place_ids)
+    except psycopg2.Error:
+        # Single point of DB failure for the whole enrichment. Skip enrichment
+        # for the entire commit; cards still ship without booking links.
+        logger.warning(
+            "booking enrichment DB read failed for %d stops",
+            len(place_ids),
+            exc_info=True,
+        )
+        return
+
+    for stop in stops:
+        details = details_by_id.get(stop.place_id)
+        if details is None:
+            # place_id grounded in scratch but missing from DB at enrichment
+            # time — race condition on the deletion side, or a stale id. Same
+            # recoverable case as the old ValueError("unknown place_id"): skip
+            # both card-field and booking enrichment for this stop.
+            logger.warning("enrichment skipped: place_id=%s not in DB", stop.place_id)
+            continue
+
+        # Card fields do NOT depend on a booking time — stamp them before the
+        # `when is None` skip so a timeless stop still renders a full card.
+        stop.address = details.formatted_address
+        stop.rating = details.rating
+        stop.price_level = price_level_to_rank(details.price_level)
+
+        when = stop.arrival_time or state.constraints.when
+        if when is None:
+            # No time → no booking link. Falling back to datetime.now() would
+            # embed wall-clock time in the URL, breaking re-commit idempotency
+            # (same inputs, different URL each call) and meaning nothing to
+            # the user. The card ships without a booking link; downstream can
+            # re-enrich once the user supplies a time.
+            continue
+        proposal = propose_booking_from_details(details, when, party_size)
+        stop.booking_url = proposal.booking_url
+        stop.booking_provider = proposal.provider
+```
+
+- [ ] **Step 2: Remove the three functions from `graph.py`**
+
+In `app/agent/graph.py`, delete `_grounded_place_ids`, `_commit_stops`, and `enrich_stops_with_booking` (the contiguous block, original lines 45-148 — from `def _grounded_place_ids` through the end of `enrich_stops_with_booking`, up to but NOT including `_RECENT_TOOL_EXCHANGES_KEPT = 2`). Leave `_RECENT_TOOL_EXCHANGES_KEPT` and everything after it.
+
+- [ ] **Step 3: Fix `graph.py` imports and the `act` call site**
+
+In `graph.py`, the import block currently has (lines ~13-37):
+```python
+from app.agent.state import ItineraryState, RevisionHint, Stop, price_level_to_rank
+from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
+from app.tools.booking import propose_booking_from_details
+from app.tools.retrieval import get_details_many
+```
+`price_level_to_rank`, `propose_booking_from_details`, `get_details_many` are now used ONLY by the moved code. Change these lines to:
+```python
+from app.agent.commit import commit_stops
+from app.agent.state import ItineraryState, RevisionHint, Stop
+from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
+```
+Delete the now-unused `from app.tools.booking import propose_booking_from_details` and `from app.tools.retrieval import get_details_many` lines, and remove `price_level_to_rank` from the `app.agent.state` import. Also check: `import psycopg2` (line ~20) — `git grep -n "psycopg2" app/agent/graph.py` after the move; if no references remain, delete the `import psycopg2` line. Keep `import asyncio`, `import json`, `import logging` (still used by remaining code — verify each with grep; remove any with zero remaining references).
+
+In the `act` closure, the call site (original line ~515):
+```python
+                stops, payload = _commit_stops(state, tc["args"].get("stops"))
+```
+becomes:
+```python
+                stops, payload = commit_stops(state, tc["args"].get("stops"))
+```
+
+- [ ] **Step 4: Update `tests/unit/test_agent_graph.py`**
+
+Current import block (lines 17-22):
+```python
+from app.agent.graph import (
+    _commit_stops,
+    _prune_for_llm,
+    build_agent_graph,
+    enrich_stops_with_booking,
+)
+```
+Replace with:
+```python
+from app.agent.commit import commit_stops, enrich_stops_with_booking
+from app.agent.graph import _prune_for_llm, build_agent_graph
+```
+Then rename every `_commit_stops(` call to `commit_stops(` in this file (run `grep -n "_commit_stops" tests/unit/test_agent_graph.py` — expect call sites near lines 355, 376, 395, 418, 442-443, plus a docstring/comment mention near 322; rename the comment too for accuracy).
+
+- [ ] **Step 5: Update `tests/unit/test_booking.py`**
+
+Line 8: `from app.agent.graph import _commit_stops` → `from app.agent.commit import commit_stops`.
+Rename every `_commit_stops(` → `commit_stops(` (run `grep -n "_commit_stops" tests/unit/test_booking.py` — expect ~327, 352, 369, 384) and update the prose comment at ~line 286 (`# These tests drive _commit_stops end-to-end`) to say `commit_stops`.
+
+- [ ] **Step 6: Run the affected suites + mypy**
+
+Run:
+```bash
+poetry run pytest tests/unit/test_agent_graph.py tests/unit/test_booking.py -q
+poetry run mypy app/
+```
+Expected: all pass; mypy `Success: no issues found`. If mypy reports an unused-import or undefined-name error in `graph.py`, fix the import per Step 3's grep instruction and re-run.
+
+- [ ] **Step 7: Verify the move was verbatim**
+
+Run:
+```bash
+git stash --include-untracked --quiet 2>/dev/null; git stash pop --quiet 2>/dev/null
+git diff --stat
+poetry run pytest tests/unit/ -q 2>&1 | tail -2
+```
+Expected: full unit suite shows the SAME pass/fail counts as `main` — i.e. all pass EXCEPT the known pre-existing `tests/unit/test_chat_functional.py::test_chat_runs_real_graph_with_tool_call` full-suite pollution flake (proven identical on `main`, unrelated to this change; passes in isolation). If ANY other test fails, the move was not verbatim — `git diff main -- app/agent/` and find the unintended change.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/agent/commit.py app/agent/graph.py tests/unit/test_agent_graph.py tests/unit/test_booking.py
+git commit -m "refactor(agent): extract commit.py from graph.py
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Extract `app/agent/revision.py`
+
+**Files:**
+- Create: `app/agent/revision.py`
+- Modify: `app/agent/graph.py` (remove the critique/revision cluster + 2 constants; update imports + the `critique` closure call sites)
+- Modify: `tests/unit/test_agent_self_correct.py` (top import block + 3 inline imports)
+
+The cluster to move is `graph.py` original lines 218-465: `_can_retry`, `_bumped_counts`, `_scratch_entries_for_last_round`, `_most_restrictive_filter`, `_diagnose_one`, `_diagnose_last_tool_result`, `_hint_for_violation`, `_final_with_caveats`, `_last_ai_content`, `_short_circuit_max_steps`, `_finalize_as_is`, `_critique_final_with_stops`, `_critique_step`. Plus the 2 constants `LOW_SIMILARITY_THRESHOLD = 0.55` and `MAX_REVISIONS_PER_REASON = 2` (original lines 41-42). Four functions are renamed (underscore dropped): `_short_circuit_max_steps`→`short_circuit_max_steps`, `_critique_final_with_stops`→`critique_final_with_stops`, `_finalize_as_is`→`finalize_as_is`, `_critique_step`→`critique_step`. All other functions keep their underscore names. Internal call sites between moved functions must use the renamed names (e.g. `_critique_step` is only called from `graph.py`'s `critique` closure, but `_critique_final_with_stops` calls `_can_retry`/`_bumped_counts`/`_hint_for_violation`/`_final_with_caveats`/`vibe.*` which all move together and keep their names).
+
+- [ ] **Step 1: Create `app/agent/revision.py`**
+
+Create `app/agent/revision.py`. Header:
+```python
+"""Critique / revision-diagnosis logic for the agent graph.
+
+Split out of graph.py (FUTURE_WATCH: app/agent/ directory size). Public entry
+points (critique_step, critique_final_with_stops, short_circuit_max_steps,
+finalize_as_is) are called by the graph's `critique` node. Everything else is
+module-internal (underscore-prefixed); white-box tests import those by their
+private name, matching the existing test pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+
+from app.agent.critique import CRITIQUE_ITINERARY, CRITIQUE_STEP, CRITIQUE_VIBE, vibe
+from app.agent.critique.checks import itinerary_violations
+from app.agent.state import ItineraryState, RevisionHint
+
+LOW_SIMILARITY_THRESHOLD = 0.55
+MAX_REVISIONS_PER_REASON = 2
+```
+Then move the 13-function cluster from `graph.py` (original lines 218-465) **verbatim** below the header, applying ONLY these renames at definition + call sites:
+- `def _short_circuit_max_steps` → `def short_circuit_max_steps`
+- `def _critique_final_with_stops` → `def critique_final_with_stops`
+- `def _finalize_as_is` → `def finalize_as_is`
+- `def _critique_step` → `def critique_step`
+
+No other function is renamed. Inside the moved code, the only inter-function calls are: `_critique_final_with_stops` (now `critique_final_with_stops`) calls `itinerary_violations`, `_can_retry`, `_hint_for_violation`, `_bumped_counts`, `_final_with_caveats`, `_last_ai_content`, `vibe.vibe_check`, `vibe.VIBE_THRESHOLD`; `_critique_step` (now `critique_step`) calls `_diagnose_last_tool_result`, `_can_retry`, `_bumped_counts`; `_diagnose_last_tool_result` calls `_scratch_entries_for_last_round` + `_diagnose_one`; `_diagnose_one` calls `_most_restrictive_filter`. None of these callees are renamed, so only the 4 `def` lines change. Confirm no callee rename is needed by `grep -n "_short_circuit_max_steps\|_critique_final_with_stops\|_finalize_as_is\|_critique_step" app/agent/revision.py` after writing — these 4 tokens must appear ONLY at their `def` line within revision.py.
+
+- [ ] **Step 2: Remove the cluster + constants from `graph.py`**
+
+In `graph.py`: delete the 2 constants `LOW_SIMILARITY_THRESHOLD`/`MAX_REVISIONS_PER_REASON` (they now live in `revision.py`), and delete the contiguous function block (original lines 218-465, `def _can_retry` through the end of `def _critique_step`). Everything between `_serialize_tool_result` (stays) and `build_agent_graph` (stays) that is part of the cluster is removed.
+
+- [ ] **Step 3: Fix `graph.py` imports + `critique` call sites**
+
+After Task 1, `graph.py`'s critique-related imports are:
+```python
+from app.agent.critique import (
+    CRITIQUE_ITINERARY,
+    CRITIQUE_STEP,
+    CRITIQUE_VIBE,
+    vibe,
+)
+from app.agent.critique.checks import itinerary_violations
+```
+The `critique` closure uses `vibe.is_enabled()` / `vibe.make_judge()` (in `build_agent_graph`) — so `vibe` is still needed. But `CRITIQUE_ITINERARY`, `CRITIQUE_STEP`, `CRITIQUE_VIBE`, `itinerary_violations`, `RevisionHint` are now used ONLY by moved code. Run `grep -n "CRITIQUE_ITINERARY\|CRITIQUE_STEP\|CRITIQUE_VIBE\|itinerary_violations\|RevisionHint\|HumanMessage\|ToolMessage" app/agent/graph.py` and remove every import token with zero remaining references. Expected end state for the critique import:
+```python
+from app.agent.critique import vibe
+```
+(Remove `from app.agent.critique.checks import itinerary_violations` entirely; remove `RevisionHint` from the `app.agent.state` import; `HumanMessage`/`ToolMessage` — keep only if still referenced by `_prune_for_llm`/`_serialize_tool_result`/closures per grep.)
+
+Add the revision import:
+```python
+from app.agent.revision import (
+    critique_final_with_stops,
+    critique_step,
+    finalize_as_is,
+    short_circuit_max_steps,
+)
+```
+
+In the `critique` closure (original lines ~570-587), the 4 call sites:
+```python
+        if state.step_count >= max_steps:
+            return _short_circuit_max_steps(state)
+        ...
+        if finalizing and state.stops:
+            return _critique_final_with_stops(state, last, judge_llm)
+        if finalizing:
+            return _finalize_as_is(state, last)
+        return _critique_step(state)
+```
+become `short_circuit_max_steps(state)`, `critique_final_with_stops(state, last, judge_llm)`, `finalize_as_is(state, last)`, `critique_step(state)` respectively.
+
+- [ ] **Step 4: Update `tests/unit/test_agent_self_correct.py`**
+
+Top import block (lines 24-28):
+```python
+from app.agent.graph import (
+    LOW_SIMILARITY_THRESHOLD,
+    MAX_REVISIONS_PER_REASON,
+    build_agent_graph,
+)
+```
+Replace with:
+```python
+from app.agent.graph import build_agent_graph
+from app.agent.revision import LOW_SIMILARITY_THRESHOLD, MAX_REVISIONS_PER_REASON
+```
+Inline imports inside test bodies — change the module path only (names unchanged, they stay private):
+- line ~530: `from app.agent.graph import _diagnose_last_tool_result` → `from app.agent.revision import _diagnose_last_tool_result`
+- line ~542: same rename as above
+- line ~581: `from app.agent.graph import _final_with_caveats` → `from app.agent.revision import _final_with_caveats`
+- line ~593: same `_final_with_caveats` rename
+- line ~620: `from app.agent.graph import _hint_for_violation` → `from app.agent.revision import _hint_for_violation`
+- line ~633: `from app.agent.graph import _diagnose_last_tool_result` → `from app.agent.revision import _diagnose_last_tool_result`
+
+Run `grep -n "from app.agent.graph import" tests/unit/test_agent_self_correct.py` after — the only remaining one should be `build_agent_graph`.
+
+- [ ] **Step 5: Run affected suites + mypy**
+
+```bash
+poetry run pytest tests/unit/test_agent_self_correct.py tests/unit/test_agent_graph.py tests/unit/test_booking.py tests/unit/test_agent_smoke.py -q
+poetry run mypy app/
+```
+Expected: all pass; mypy clean. mypy will catch any circular import (`graph → revision → ...` is acyclic per spec; `revision` imports nothing from `graph`/`commit`).
+
+- [ ] **Step 6: Verify verbatim + full suite parity**
+
+```bash
+git diff --stat
+poetry run pytest tests/unit/ -q 2>&1 | tail -2
+wc -l app/agent/graph.py app/agent/commit.py app/agent/revision.py
+```
+Expected: full suite same pass/fail as `main` (only the known `test_chat_runs_real_graph_with_tool_call` full-suite flake may fail — proven pre-existing on `main`). Approximate post-split sizes (exact values from `wc -l`, not asserted): `graph.py` ~255, `commit.py` ~140, `revision.py` ~255 — all well under the 400-line trigger. If any unexpected test fails, `git diff main -- app/agent/graph.py` and find the non-verbatim edit.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/agent/revision.py app/agent/graph.py tests/unit/test_agent_self_correct.py
+git commit -m "refactor(agent): extract revision.py from graph.py
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Mark FUTURE_WATCH item resolved
+
+**Files:**
+- Modify: `implementation_plan/james/FUTURE_WATCH.md` (the "`app/agent/` directory size" section, the `**Trigger:**` paragraph at lines 79-84)
+
+- [ ] **Step 1: Replace the Trigger paragraph**
+
+In `implementation_plan/james/FUTURE_WATCH.md`, find the section `### \`app/agent/\` directory size`. Replace its `**Trigger:**` paragraph (the one starting "when `app/agent/graph.py` exceeds ~400 lines OR a flat directory") with:
+
+```markdown
+**Resolved (2026-05-16):** `graph.py` (604 lines, post-#84) split on branch
+`refactor/split-agent-graph` into `graph.py` (~255: node closures + graph
+assembly + `_prune_for_llm`/`_serialize_tool_result`), `app/agent/commit.py`
+(~140: `commit_stops` + `enrich_stops_with_booking`), and
+`app/agent/revision.py` (~255: critique/revision-diagnosis). Flat-module
+pattern kept — no subdir, per the "do NOT pre-split" guidance. The 10+
+top-level-file trigger was never met (still 9 after the split), so
+`critique/` remains the only subdir; `booking/` and `kg/` subdirs stay
+deferred until that count is actually reached.
+```
+
+(If the resulting top-level `.py` count differs from 9, state the real number — count with `git ls-tree --name-only HEAD app/agent/ | grep -vE '/$' | grep '\.py$' | wc -l` before writing.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add implementation_plan/james/FUTURE_WATCH.md
+git commit -m "docs(future-watch): mark app/agent size item resolved
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Notes for the executor
+
+- This is a behavior-preserving MOVE. The proof of correctness is: existing tests pass with ONLY import-line + rename edits, and `mypy app/` is clean. If you find yourself editing test assertions or function logic, STOP — you've deviated from the plan.
+- Use `poetry run` for pytest/mypy. Never add `sys.path` hacks (app is poetry editable-installed).
+- Pre-commit hook owns ruff — if it reformats on commit, re-stage and amend (do not pre-run ruff as a gate).
+- The pre-existing `tests/unit/test_chat_functional.py::test_chat_runs_real_graph_with_tool_call` full-suite flake is OUT OF SCOPE and proven identical on `main` — do not try to fix it; it passes in isolation.
+- User merges PRs themselves — stop after CI is green; do not `gh pr merge`.
+- Single-line commit messages per project convention.

--- a/docs/superpowers/specs/2026-05-16-graph-py-decomposition-design.md
+++ b/docs/superpowers/specs/2026-05-16-graph-py-decomposition-design.md
@@ -1,0 +1,168 @@
+# `app/agent/graph.py` decomposition — design
+
+**Date:** 2026-05-16
+**Branch:** `refactor/split-agent-graph` (off `main` *after* PR #84 merged — `main` is at `aaea296`)
+**Source:** `implementation_plan/james/FUTURE_WATCH.md` → "`app/agent/` directory size"
+
+## Problem
+
+`app/agent/graph.py` is **604 lines** (post-#84). The FUTURE_WATCH trigger fires
+when `graph.py` exceeds ~400 lines OR `app/agent/` exceeds 10 top-level files.
+The line trigger is met; the file-count trigger is not (7 top-level files). So
+this is a single-file decomposition, **not** a subdir restructure. FUTURE_WATCH
+explicitly warns "do NOT pre-split — empty subdirs hurt readability."
+
+## Goal
+
+Split `graph.py` into three flat sibling modules (mirroring the existing
+`planning.py` / `io.py` pattern) with **zero behavior change**, verified by the
+existing test suite passing with only import lines updated.
+
+## Module breakdown
+
+### `app/agent/commit.py` (~105 lines)
+
+Turn LLM-proposed stops into validated `Stop`s + enrich with booking/card data.
+
+| Symbol | Visibility | Note |
+|---|---|---|
+| `commit_stops(state, raw_stops) -> tuple[list[Stop], dict]` | **public** | renamed from `_commit_stops` (now cross-module entry point) |
+| `enrich_stops_with_booking(stops, state) -> None` | public | already public, unchanged name |
+| `_grounded_place_ids(scratch) -> set[str]` | private | module-internal helper of `commit.py` |
+
+Imports: `app.agent.state`, `app.tools.booking`, `app.tools.retrieval`,
+stdlib `logging`/`psycopg2`. Owns its own `logger = logging.getLogger(__name__)`.
+
+### `app/agent/revision.py` (~250 lines)
+
+All critique / revision-diagnosis logic.
+
+| Symbol | Visibility |
+|---|---|
+| `critique_step(state) -> dict` | **public** (renamed from `_critique_step`) |
+| `critique_final_with_stops(state, last, judge_llm) -> dict` | **public** (renamed from `_critique_final_with_stops`) |
+| `short_circuit_max_steps(state) -> dict` | **public** (renamed from `_short_circuit_max_steps`) |
+| `finalize_as_is(state, last) -> dict` | **public** (renamed from `_finalize_as_is`) |
+| `_can_retry`, `_bumped_counts`, `_scratch_entries_for_last_round`, `_most_restrictive_filter`, `_diagnose_one`, `_diagnose_last_tool_result`, `_hint_for_violation`, `_final_with_caveats`, `_last_ai_content` | private (module-internal) |
+| `LOW_SIMILARITY_THRESHOLD = 0.55`, `MAX_REVISIONS_PER_REASON = 2` | module constants |
+
+Imports: `app.agent.state`, `app.agent.critique` (`CRITIQUE_ITINERARY`,
+`CRITIQUE_STEP`, `CRITIQUE_VIBE`, `vibe`), `app.agent.critique.checks`
+(`itinerary_violations`).
+
+**Naming rule:** a symbol gets a public (no-underscore) name *only* if it is
+called across module boundaries (by `graph.py`). Symbols that are conceptually
+internal but reached by white-box tests (`_diagnose_last_tool_result`,
+`_final_with_caveats`, `_hint_for_violation`) keep their underscore — tests
+import them by their private name from `revision.py`. We do not inflate the
+public API to satisfy a test reaching into internals (that white-box pattern
+already exists in `test_agent_self_correct.py` and is accepted).
+
+### `app/agent/graph.py` (~250 lines, remains)
+
+Keeps: module docstring, `_prune_for_llm`, `_serialize_tool_result` (LLM-wire
+concerns, tightly coupled to the `plan`/`act` node closures), and
+`build_agent_graph` with its closures (`plan`, `act`, `critique`,
+`route_after_plan`, `route_after_critique`).
+
+New imports:
+```python
+from app.agent.commit import commit_stops
+from app.agent.revision import (
+    critique_final_with_stops,
+    critique_step,
+    finalize_as_is,
+    short_circuit_max_steps,
+)
+```
+Call sites inside the closures change `_commit_stops(...)` → `commit_stops(...)`,
+`_critique_step(state)` → `critique_step(state)`, etc.
+
+**`enrich_stops_with_booking` is NOT imported by `graph.py`.** Verified: its
+only call site is line 91, *inside* `_commit_stops` itself. It moves to
+`commit.py` alongside `commit_stops`, which calls it internally. `graph.py`
+never references it directly, so importing it there would be a dead import.
+`test_agent_graph.py` imports it directly from `commit.py`.
+
+## Blast radius — test files to update (imports only)
+
+Pure code-move ⇒ **only import statements change, no assertion/logic edits.**
+
+1. **`tests/unit/test_agent_graph.py`** (lines 17-22): split the
+   `from app.agent.graph import (...)` block —
+   - `_commit_stops` → `from app.agent.commit import commit_stops` (and rename
+     all ~7 call sites `_commit_stops(` → `commit_stops(` in this file)
+   - `enrich_stops_with_booking` → `from app.agent.commit import enrich_stops_with_booking`
+   - `_prune_for_llm`, `build_agent_graph` → stay `from app.agent.graph import ...`
+
+2. **`tests/unit/test_booking.py`** (line 8 + ~6 call sites): `from
+   app.agent.graph import _commit_stops` → `from app.agent.commit import
+   commit_stops`; rename call sites `_commit_stops(` → `commit_stops(` (lines
+   ~327, 352, 369, 384). Comment at line 286 mentioning `_commit_stops` updated
+   to `commit_stops` for accuracy.
+
+3. **`tests/unit/test_agent_self_correct.py`**:
+   - top import block (lines 24-28): `LOW_SIMILARITY_THRESHOLD`,
+     `MAX_REVISIONS_PER_REASON` → `from app.agent.revision import ...`;
+     `build_agent_graph` stays from `app.agent.graph`
+   - inline imports inside test bodies: `from app.agent.graph import
+     _diagnose_last_tool_result` (lines 530, 542, 633) →
+     `from app.agent.revision import _diagnose_last_tool_result`;
+     `_final_with_caveats` (581, 593) → `from app.agent.revision import
+     _final_with_caveats`; `_hint_for_violation` (620) →
+     `from app.agent.revision import _hint_for_violation`
+
+No other files reference moved symbols (`test_agent_smoke.py` and
+`test_chat_functional.py` only import `build_agent_graph`, which stays).
+
+## Test strategy
+
+No new tests — moving code adds no behavior. Verification = behavior-preserving
+proof:
+
+- `poetry run pytest tests/unit/test_agent_graph.py tests/unit/test_booking.py
+  tests/unit/test_agent_self_correct.py tests/unit/test_agent_smoke.py
+  tests/unit/test_chat_functional.py -q` → all green with only import-line edits
+- `poetry run mypy app/` → clean (catches any missed reference / circular import)
+- Full `poetry run pytest tests/unit/ -q` → same pass count as `main`
+  (the pre-existing `test_chat_runs_real_graph_with_tool_call` full-suite
+  pollution flake — proven on `main`, unrelated — is the only acceptable
+  non-pass, identical to before)
+
+## Circular-import check
+
+`commit.py` and `revision.py` both import only from `app.agent.state`,
+`app.agent.critique`, `app.tools.*` — none import each other or `graph.py`.
+`graph.py` imports both. Acyclic: `graph → {commit, revision} → {state,
+critique, tools}`. `mypy` + import at test collection time will catch any
+violation.
+
+## Commit sequencing
+
+Three atomic commits, each independently green (code move + every referencing
+import fixed in the *same* commit so the suite never goes red mid-series):
+
+1. `refactor(agent): extract commit.py from graph.py` — create `commit.py`,
+   remove the 3 functions from `graph.py`, update `graph.py` call sites +
+   imports, update `test_agent_graph.py` + `test_booking.py`.
+2. `refactor(agent): extract revision.py from graph.py` — create `revision.py`,
+   remove the ~13 symbols + 2 constants from `graph.py`, update `graph.py` +
+   `test_agent_self_correct.py`.
+3. `docs(future-watch): mark app/agent size item resolved` — FUTURE_WATCH note.
+
+## FUTURE_WATCH resolution note (commit 3)
+
+Replace the **Trigger** paragraph of the "`app/agent/` directory size" section
+with a resolution note: `graph.py` split into `graph.py` (~250) / `commit.py`
+(~105) / `revision.py` (~250) on `refactor/split-agent-graph`; flat-module
+pattern kept (no subdir, per the "do NOT pre-split" guidance); file-count
+trigger (10+) still not met so `critique/` stays the only subdir.
+
+## Out of scope
+
+- `app/agent/critique/` is already its own dir — untouched.
+- No `booking/` or `kg/` subdir (FUTURE_WATCH lists these as *future*
+  considerations gated on the file-count trigger, which is not met).
+- No behavior, signature, or logic changes — imports/names/file-location only.
+- `_prune_for_llm` / `_serialize_tool_result` stay in `graph.py` (LLM-wire
+  concern bound to node closures; moving them adds churn without cohesion gain).

--- a/implementation_plan/james/FUTURE_WATCH.md
+++ b/implementation_plan/james/FUTURE_WATCH.md
@@ -76,11 +76,17 @@ lands, expect: `state.py`, `tools.py`, `prompts.py`, `graph.py`, `planning.py`,
 `graph.py`) pushes past ~400 lines or `app/agent/` exceeds ~10 top-level
 files, navigation gets harder.
 
-**Trigger:** when `app/agent/graph.py` exceeds ~400 lines OR a flat directory
-has 10+ files, split: `app/agent/critique/` is already its own dir; consider
-`app/agent/booking/` (W4) and `app/agent/kg/` (W7 wrapping) at that point. Do
-NOT pre-split — empty subdirs hurt readability more than a flat list of 6
-files.
+**Resolved (2026-05-16):** `graph.py` (604 lines, post-#84) hit the ~400-line
+trigger and was split on branch `refactor/split-agent-graph` into three flat
+sibling modules: `graph.py` (240 — node closures, graph assembly,
+`_prune_for_llm`/`_serialize_tool_result`), `app/agent/commit.py` (133 —
+`commit_stops` + `enrich_stops_with_booking`), and `app/agent/revision.py`
+(272 — critique/revision-diagnosis). Behavior-preserving verbatim move (existing
+suite green with import/rename edits only; mypy clean). Flat-module pattern
+kept — no subdir, per the "do NOT pre-split" guidance. The 10+ top-level-file
+trigger was never met (9 `.py` files after the split), so `critique/` remains
+the only subdir; `app/agent/booking/` and `app/agent/kg/` subdirs stay deferred
+until the file-count trigger is actually reached.
 
 ### W7 KG builder is unscoped O(n²); integration test slow + non-isolated
 

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -14,12 +14,8 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 
-from app.agent.graph import (
-    _commit_stops,
-    _prune_for_llm,
-    build_agent_graph,
-    enrich_stops_with_booking,
-)
+from app.agent.commit import commit_stops, enrich_stops_with_booking
+from app.agent.graph import _prune_for_llm, build_agent_graph
 from app.agent.state import ItineraryState, Stop, UserConstraints
 from app.tools.booking import BookingProposal
 from app.tools.retrieval import PlaceDetails, PlaceHit
@@ -54,7 +50,7 @@ def _patch_details_many_for(place_ids: list[str]):
     """Patch get_details_many to return a minimal PlaceDetails for each id.
     Returns the patcher so tests can also assert call_count if they care."""
     return patch(
-        "app.agent.graph.get_details_many",
+        "app.agent.commit.get_details_many",
         return_value={pid: _details_for(pid) for pid in place_ids},
     )
 
@@ -319,7 +315,7 @@ def test_prune_for_llm_drops_oldest_tool_exchanges() -> None:
 
 def _state_with_grounded(place_ids: list[str], party_size: int = 2) -> ItineraryState:
     """Build a state where the given place_ids appear in scratch, so
-    _commit_stops considers them grounded."""
+    commit_stops considers them grounded."""
     hits = [
         PlaceHit(place_id=pid, name=f"Place {pid}", source="google_places", similarity=0.9)
         for pid in place_ids
@@ -350,9 +346,9 @@ def test_commit_stops_enriches_with_booking() -> None:
 
     with (
         _patch_details_many_for(["p1", "p2"]) as mock_get,
-        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
     ):
-        committed, payload = _commit_stops(state, raw_stops)
+        committed, payload = commit_stops(state, raw_stops)
 
     assert payload["committed"] == ["p1", "p2"]
     assert all(s.booking_url is not None for s in committed)
@@ -372,8 +368,8 @@ def test_commit_stops_skips_enrichment_for_place_id_missing_from_db() -> None:
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with patch("app.agent.graph.get_details_many", return_value={}):
-        committed, payload = _commit_stops(state, raw_stops)
+    with patch("app.agent.commit.get_details_many", return_value={}):
+        committed, payload = commit_stops(state, raw_stops)
 
     assert payload["committed"] == ["p1"]
     assert committed[0].booking_url is None
@@ -389,10 +385,10 @@ def test_commit_stops_enrichment_swallows_psycopg_db_blip() -> None:
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
     with patch(
-        "app.agent.graph.get_details_many",
+        "app.agent.commit.get_details_many",
         side_effect=psycopg2.OperationalError("connection blip"),
     ):
-        committed, payload = _commit_stops(state, raw_stops)
+        committed, payload = commit_stops(state, raw_stops)
 
     assert payload["committed"] == ["p1"]
     assert committed[0].booking_url is None
@@ -410,12 +406,12 @@ def test_commit_stops_enrichment_propagates_programmer_errors() -> None:
     with (
         _patch_details_many_for(["p1"]),
         patch(
-            "app.agent.graph.propose_booking_from_details",
+            "app.agent.commit.propose_booking_from_details",
             side_effect=TypeError("propose_booking_from_details() got an unexpected kwarg"),
         ),
         pytest.raises(TypeError),
     ):
-        _commit_stops(state, raw_stops)
+        commit_stops(state, raw_stops)
 
 
 def test_commit_stops_re_commit_is_idempotent() -> None:
@@ -437,10 +433,10 @@ def test_commit_stops_re_commit_is_idempotent() -> None:
 
     with (
         _patch_details_many_for(["p1"]),
-        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
     ):
-        first_committed, _ = _commit_stops(state, raw_stops)
-        second_committed, _ = _commit_stops(state, raw_stops)
+        first_committed, _ = commit_stops(state, raw_stops)
+        second_committed, _ = commit_stops(state, raw_stops)
 
     assert first_committed[0].booking_url == second_committed[0].booking_url
     assert first_committed[0].booking_provider == second_committed[0].booking_provider
@@ -468,12 +464,12 @@ def test_commit_stops_per_stop_independence_when_one_id_missing() -> None:
 
     with (
         patch(
-            "app.agent.graph.get_details_many",
+            "app.agent.commit.get_details_many",
             return_value={"p2": _details_for("p2")},
         ),
-        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
     ):
-        committed, _ = _commit_stops(state, raw_stops)
+        committed, _ = commit_stops(state, raw_stops)
 
     # p1 missing from DB → skipped, no booking fields populated.
     assert committed[0].place_id == "p1"
@@ -488,7 +484,7 @@ def test_commit_stops_per_stop_independence_when_one_id_missing() -> None:
 def test_enrich_stops_with_booking_mutates_in_place() -> None:
     """Direct coverage of the public helper. Future constraint-edit flows
     will call enrich_stops_with_booking on already-built Stop objects without
-    going through _commit_stops; the in-place-mutation contract is what makes
+    going through commit_stops; the in-place-mutation contract is what makes
     that re-enrichment cheap."""
     stops = [
         Stop(place_id="p1", name="A", rationale="r", source="google_places"),
@@ -508,7 +504,7 @@ def test_enrich_stops_with_booking_mutates_in_place() -> None:
     original_ids = [id(s) for s in stops]
     with (
         _patch_details_many_for(["p1", "p2"]),
-        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
     ):
         enrich_stops_with_booking(stops, state)
 
@@ -531,10 +527,10 @@ def test_enrich_populates_card_fields_from_details() -> None:
 
     with (
         patch(
-            "app.agent.graph.get_details_many",
+            "app.agent.commit.get_details_many",
             return_value={"p1": _rich_details_for("p1")},
         ),
-        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
     ):
         enrich_stops_with_booking(stops, state)
 
@@ -551,10 +547,10 @@ def test_enrich_card_fields_set_even_when_no_booking_time() -> None:
 
     with (
         patch(
-            "app.agent.graph.get_details_many",
+            "app.agent.commit.get_details_many",
             return_value={"p1": _rich_details_for("p1")},
         ),
-        patch("app.agent.graph.propose_booking_from_details") as mock_build,
+        patch("app.agent.commit.propose_booking_from_details") as mock_build,
     ):
         enrich_stops_with_booking(stops, state)
 
@@ -573,7 +569,7 @@ def test_enrich_card_fields_none_when_details_missing() -> None:
         constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
     )
 
-    with patch("app.agent.graph.get_details_many", return_value={}):
+    with patch("app.agent.commit.get_details_many", return_value={}):
         enrich_stops_with_booking(stops, state)
 
     assert stops[0].address is None
@@ -591,7 +587,7 @@ def test_enrich_skipped_when_no_time_anywhere() -> None:
 
     with (
         _patch_details_many_for(["p1"]),
-        patch("app.agent.graph.propose_booking_from_details") as mock_build,
+        patch("app.agent.commit.propose_booking_from_details") as mock_build,
     ):
         enrich_stops_with_booking(stops, state)
 
@@ -609,7 +605,7 @@ def test_enrich_idempotent_when_no_time_set() -> None:
 
     with (
         _patch_details_many_for(["p1"]),
-        patch("app.agent.graph.propose_booking_from_details") as mock_build,
+        patch("app.agent.commit.propose_booking_from_details") as mock_build,
     ):
         enrich_stops_with_booking(stops, state)
         first_url = stops[0].booking_url
@@ -638,7 +634,7 @@ def test_enrich_uses_constraints_when_when_arrival_time_missing() -> None:
 
     with (
         _patch_details_many_for(["p1"]),
-        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
     ):
         enrich_stops_with_booking(stops, state)
 
@@ -670,7 +666,7 @@ def test_enrich_party_size_defaulting(party_size_in: int | None, expected_in_cal
 
     with (
         _patch_details_many_for(["p1"]),
-        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
     ):
         enrich_stops_with_booking(stops, state)
 
@@ -711,7 +707,7 @@ def test_enrich_stops_with_booking_uses_arrival_time_per_stop() -> None:
 
     with (
         _patch_details_many_for(["p1", "p2"]),
-        patch("app.agent.graph.propose_booking_from_details", side_effect=fake_build),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
     ):
         enrich_stops_with_booking(stops, state)
 

--- a/tests/unit/test_agent_self_correct.py
+++ b/tests/unit/test_agent_self_correct.py
@@ -21,11 +21,8 @@ from app.agent.critique.checks import (
     geographic_coherence,
     walking_budget_respected,
 )
-from app.agent.graph import (
-    LOW_SIMILARITY_THRESHOLD,
-    MAX_REVISIONS_PER_REASON,
-    build_agent_graph,
-)
+from app.agent.graph import build_agent_graph
+from app.agent.revision import LOW_SIMILARITY_THRESHOLD, MAX_REVISIONS_PER_REASON
 from app.agent.state import ItineraryState, UserConstraints
 from tests.conftest import make_hit, make_stop
 
@@ -231,7 +228,7 @@ async def test_itinerary_violation_triggers_revision(monkeypatch) -> None:
     to plan."""
     # Stand in for the DB-backed check.
     monkeypatch.setattr(
-        "app.agent.graph.itinerary_violations",
+        "app.agent.revision.itinerary_violations",
         lambda _state: ["geographic_coherence"],
     )
     # Pre-seed state with stops to trigger the per-itinerary path.
@@ -262,7 +259,7 @@ async def test_itinerary_violation_triggers_revision(monkeypatch) -> None:
         calls["n"] += 1
         return ["geographic_coherence"] if calls["n"] == 1 else []
 
-    monkeypatch.setattr("app.agent.graph.itinerary_violations", _violations)
+    monkeypatch.setattr("app.agent.revision.itinerary_violations", _violations)
 
     out = await graph.ainvoke(state)
 
@@ -278,7 +275,7 @@ async def test_itinerary_violation_ships_with_caveats_after_exhaustion(monkeypat
     """If retries are exhausted on a violation, the final reply gets a
     caveat suffix instead of looping forever."""
     monkeypatch.setattr(
-        "app.agent.graph.itinerary_violations",
+        "app.agent.revision.itinerary_violations",
         lambda _state: ["geographic_coherence"],
     )
 
@@ -404,7 +401,7 @@ async def test_finalizing_with_no_stops_just_finalizes(monkeypatch) -> None:
         called["violations"] = True
         return []
 
-    monkeypatch.setattr("app.agent.graph.itinerary_violations", _violations)
+    monkeypatch.setattr("app.agent.revision.itinerary_violations", _violations)
     fake = _make_fake([AIMessage(content="how many stops?", tool_calls=[])])
     graph = build_agent_graph(fake, max_steps=4)
     out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="plan it")]))
@@ -418,7 +415,7 @@ async def test_multiple_violations_picks_first_actionable(monkeypatch) -> None:
     """When several checks fail, critique acts on the first one with retries
     left — not all of them at once."""
     monkeypatch.setattr(
-        "app.agent.graph.itinerary_violations",
+        "app.agent.revision.itinerary_violations",
         lambda _state: ["temporal_coherence", "geographic_coherence"],
     )
     state = ItineraryState(
@@ -443,7 +440,7 @@ async def test_multiple_violations_picks_first_actionable(monkeypatch) -> None:
         n["i"] += 1
         return ["temporal_coherence", "geographic_coherence"] if n["i"] == 1 else []
 
-    monkeypatch.setattr("app.agent.graph.itinerary_violations", _violations)
+    monkeypatch.setattr("app.agent.revision.itinerary_violations", _violations)
     graph = build_agent_graph(fake, max_steps=4)
     out = await graph.ainvoke(state)
 
@@ -527,7 +524,7 @@ async def test_critique_message_is_visible_to_plan(monkeypatch) -> None:
 async def test_diagnose_handles_no_scratch_entry() -> None:
     """If somehow critique fires without any scratch entry (defensive),
     don't crash and don't emit a hint."""
-    from app.agent.graph import _diagnose_last_tool_result
+    from app.agent.revision import _diagnose_last_tool_result
 
     state = ItineraryState(messages=[HumanMessage(content="hi")])
     assert _diagnose_last_tool_result(state) is None
@@ -539,7 +536,7 @@ async def test_diagnose_walks_every_tool_call_in_round() -> None:
     order — not just the last one."""
     from langchain_core.messages import ToolMessage
 
-    from app.agent.graph import _diagnose_last_tool_result
+    from app.agent.revision import _diagnose_last_tool_result
 
     state = ItineraryState(
         messages=[
@@ -578,7 +575,7 @@ async def test_diagnose_walks_every_tool_call_in_round() -> None:
 def test_final_with_caveats_includes_each_violation_name() -> None:
     """Caveats reply must lead with the agent's own body and list every
     violation name verbatim — that's what the user-facing UI relies on."""
-    from app.agent.graph import _final_with_caveats
+    from app.agent.revision import _final_with_caveats
 
     out = _final_with_caveats("my plan", ["v1", "v2"])
     assert out.startswith("my plan")
@@ -590,7 +587,7 @@ def test_final_with_caveats_includes_each_violation_name() -> None:
 def test_final_with_caveats_handles_empty_body() -> None:
     """If the LLM somehow ended up with no content, the caveat must still
     render coherently rather than NoneType-error."""
-    from app.agent.graph import _final_with_caveats
+    from app.agent.revision import _final_with_caveats
 
     out = _final_with_caveats("", ["v1"])
     assert "Caveats:" in out
@@ -617,7 +614,7 @@ def test_hint_for_violation_maps_each_check(
     """Every check name supported by itinerary_violations() must map to a
     structured RevisionHint. The catch-all (anything unmapped) must produce
     a `constraint_unmet_in_final` hint rather than crash."""
-    from app.agent.graph import _hint_for_violation
+    from app.agent.revision import _hint_for_violation
 
     state = ItineraryState(stops=[make_stop("p1", name="A"), make_stop("p2", name="B")])
     hint = _hint_for_violation(check, state)
@@ -630,7 +627,7 @@ async def test_diagnose_pairs_by_tool_call_id() -> None:
     scratch entry by id, not blur into max(step)."""
     from langchain_core.messages import ToolMessage
 
-    from app.agent.graph import _diagnose_last_tool_result
+    from app.agent.revision import _diagnose_last_tool_result
 
     state = ItineraryState(
         messages=[
@@ -682,7 +679,7 @@ class _StubJudge:
 async def test_vibe_pass_injects_revision_when_below_threshold(monkeypatch) -> None:
     """Deterministic checks pass, vibe scores below threshold -> hint and
     re-plan, not finalize."""
-    monkeypatch.setattr("app.agent.graph.itinerary_violations", lambda _state: [])
+    monkeypatch.setattr("app.agent.revision.itinerary_violations", lambda _state: [])
     monkeypatch.setenv(vibe.VIBE_ENV_VAR, "true")
 
     judge = _StubJudge(score=2.0)  # below VIBE_THRESHOLD=3.0
@@ -706,7 +703,7 @@ async def test_vibe_pass_injects_revision_when_below_threshold(monkeypatch) -> N
     def _fake_vibe_check(_state, _judge):
         return judges.pop(0)._score if judges else 4.5
 
-    monkeypatch.setattr("app.agent.graph.vibe.vibe_check", _fake_vibe_check)
+    monkeypatch.setattr("app.agent.revision.vibe.vibe_check", _fake_vibe_check)
 
     graph = build_agent_graph(fake, max_steps=4, judge_llm=judge)
     out = await graph.ainvoke(state)
@@ -720,7 +717,7 @@ async def test_vibe_pass_injects_revision_when_below_threshold(monkeypatch) -> N
 async def test_vibe_pass_skips_when_judge_none(monkeypatch) -> None:
     """No judge wired (env disabled, or make_judge returned None) -> finalize
     without a vibe pass even if vibe_check would normally fire."""
-    monkeypatch.setattr("app.agent.graph.itinerary_violations", lambda _state: [])
+    monkeypatch.setattr("app.agent.revision.itinerary_violations", lambda _state: [])
 
     state = ItineraryState(
         messages=[HumanMessage(content="date night")],
@@ -743,8 +740,8 @@ async def test_vibe_pass_skips_when_judge_none(monkeypatch) -> None:
 async def test_vibe_pass_respects_retry_budget(monkeypatch) -> None:
     """Once vibe_mismatch hits MAX_REVISIONS_PER_REASON, finalize with the
     current plan rather than loop forever."""
-    monkeypatch.setattr("app.agent.graph.itinerary_violations", lambda _state: [])
-    monkeypatch.setattr("app.agent.graph.vibe.vibe_check", lambda *_a, **_k: 1.0)
+    monkeypatch.setattr("app.agent.revision.itinerary_violations", lambda _state: [])
+    monkeypatch.setattr("app.agent.revision.vibe.vibe_check", lambda *_a, **_k: 1.0)
 
     state = ItineraryState(
         messages=[HumanMessage(content="date night")],
@@ -766,7 +763,7 @@ async def test_vibe_pass_skipped_when_violations_present(monkeypatch) -> None:
     """If deterministic checks fail, we never burn a vibe-judge call — the
     deterministic revision takes precedence."""
     monkeypatch.setattr(
-        "app.agent.graph.itinerary_violations",
+        "app.agent.revision.itinerary_violations",
         lambda _state: ["geographic_coherence"],
     )
     judge_calls = {"n": 0}
@@ -775,7 +772,7 @@ async def test_vibe_pass_skipped_when_violations_present(monkeypatch) -> None:
         judge_calls["n"] += 1
         return 1.0
 
-    monkeypatch.setattr("app.agent.graph.vibe.vibe_check", _vibe)
+    monkeypatch.setattr("app.agent.revision.vibe.vibe_check", _vibe)
 
     state = ItineraryState(
         messages=[HumanMessage(content="hi")],

--- a/tests/unit/test_agent_self_correct_functional.py
+++ b/tests/unit/test_agent_self_correct_functional.py
@@ -115,7 +115,7 @@ async def test_step_and_itinerary_critiques_compose(monkeypatch) -> None:
     in one run. Verifies that revision_counts tracks them as separate
     categories (each gets its own MAX_REVISIONS_PER_REASON budget)."""
     monkeypatch.setattr(
-        "app.agent.graph.itinerary_violations",
+        "app.agent.revision.itinerary_violations",
         lambda _state: [],
     )
     # First call empty, second succeeds.
@@ -209,7 +209,7 @@ async def test_step_then_itinerary_critique_compose_end_to_end(monkeypatch) -> N
         violation_calls["n"] += 1
         return ["geographic_coherence"] if violation_calls["n"] == 1 else []
 
-    monkeypatch.setattr("app.agent.graph.itinerary_violations", _violations)
+    monkeypatch.setattr("app.agent.revision.itinerary_violations", _violations)
 
     fake = _Scripted(
         scripted=[

--- a/tests/unit/test_booking.py
+++ b/tests/unit/test_booking.py
@@ -281,12 +281,12 @@ def test_notes_match_provider() -> None:
     assert "Resy" in b.notes
 
 
-# ─── Functional: graph commit -> real URL construction -> Stop fields ──────
+# ─── Functional: commit -> real URL construction -> Stop fields ──────
 #
 # These tests drive `commit_stops` end-to-end with the *real*
 # propose_booking_from_details implementation. Only the SQL boundary
 # (`get_details_many`, called once per commit) is mocked. This verifies the
-# composition: provider detection + URL building + graph enrichment all work
+# composition: provider detection + URL building + commit enrichment all work
 # together. Compare to the unit tests above (mock get_details, hit
 # propose_booking directly) and the test in test_agent_graph (mock the URL
 # builder entirely) — this layer is the in-between.
@@ -303,8 +303,8 @@ def _grounded_state(place_ids: list[str], party_size: int = 2) -> ItineraryState
     )
 
 
-def _patch_graph_details_many(place_id: str, details: PlaceDetails):
-    """Patch the graph's batched DB call to return one details row."""
+def _patch_commit_details_many(place_id: str, details: PlaceDetails):
+    """Patch the commit module's batched DB call to return one details row."""
     return patch(
         "app.agent.commit.get_details_many",
         return_value={place_id: details},
@@ -323,7 +323,7 @@ def test_functional_commit_attaches_resy_url_via_real_propose_booking() -> None:
             "arrival_time": datetime(2026, 5, 7, 19, 30).isoformat(),
         }
     ]
-    with _patch_graph_details_many("p1", _fake_details("https://resy.com/cities/sf/foo")):
+    with _patch_commit_details_many("p1", _fake_details("https://resy.com/cities/sf/foo")):
         committed, _ = commit_stops(state, raw_stops)
 
     assert len(committed) == 1
@@ -342,7 +342,7 @@ def test_functional_falls_back_to_venue_website_for_non_provider_site() -> None:
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with _patch_graph_details_many(
+    with _patch_commit_details_many(
         "p1",
         _fake_details(
             website_uri="https://random-cafe.example",
@@ -362,7 +362,7 @@ def test_functional_falls_back_to_maps_when_no_website() -> None:
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with _patch_graph_details_many(
+    with _patch_commit_details_many(
         "p1",
         _fake_details(website_uri=None, maps_uri="https://maps.google.com/?cid=999"),
     ):
@@ -380,7 +380,7 @@ def test_functional_uses_constraints_when_arrival_time_missing() -> None:
     raw_stops = [
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
-    with _patch_graph_details_many("p1", _fake_details("https://www.opentable.com/baz")):
+    with _patch_commit_details_many("p1", _fake_details("https://www.opentable.com/baz")):
         committed, _ = commit_stops(state, raw_stops)
 
     stop = committed[0]

--- a/tests/unit/test_booking.py
+++ b/tests/unit/test_booking.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.agent.graph import _commit_stops
+from app.agent.commit import commit_stops
 from app.agent.state import ItineraryState, UserConstraints
 from app.tools.booking import BookingProposal, detect_provider, propose_booking
 from app.tools.retrieval import PlaceDetails, PlaceHit
@@ -283,7 +283,7 @@ def test_notes_match_provider() -> None:
 
 # ─── Functional: graph commit -> real URL construction -> Stop fields ──────
 #
-# These tests drive `_commit_stops` end-to-end with the *real*
+# These tests drive `commit_stops` end-to-end with the *real*
 # propose_booking_from_details implementation. Only the SQL boundary
 # (`get_details_many`, called once per commit) is mocked. This verifies the
 # composition: provider detection + URL building + graph enrichment all work
@@ -306,7 +306,7 @@ def _grounded_state(place_ids: list[str], party_size: int = 2) -> ItineraryState
 def _patch_graph_details_many(place_id: str, details: PlaceDetails):
     """Patch the graph's batched DB call to return one details row."""
     return patch(
-        "app.agent.graph.get_details_many",
+        "app.agent.commit.get_details_many",
         return_value={place_id: details},
     )
 
@@ -324,7 +324,7 @@ def test_functional_commit_attaches_resy_url_via_real_propose_booking() -> None:
         }
     ]
     with _patch_graph_details_many("p1", _fake_details("https://resy.com/cities/sf/foo")):
-        committed, _ = _commit_stops(state, raw_stops)
+        committed, _ = commit_stops(state, raw_stops)
 
     assert len(committed) == 1
     stop = committed[0]
@@ -349,7 +349,7 @@ def test_functional_falls_back_to_venue_website_for_non_provider_site() -> None:
             maps_uri="https://maps.google.com/?cid=999",
         ),
     ):
-        committed, _ = _commit_stops(state, raw_stops)
+        committed, _ = commit_stops(state, raw_stops)
 
     stop = committed[0]
     assert stop.booking_provider == "unknown"
@@ -366,7 +366,7 @@ def test_functional_falls_back_to_maps_when_no_website() -> None:
         "p1",
         _fake_details(website_uri=None, maps_uri="https://maps.google.com/?cid=999"),
     ):
-        committed, _ = _commit_stops(state, raw_stops)
+        committed, _ = commit_stops(state, raw_stops)
 
     stop = committed[0]
     assert stop.booking_provider == "google_maps"
@@ -381,7 +381,7 @@ def test_functional_uses_constraints_when_arrival_time_missing() -> None:
         {"place_id": "p1", "name": "Place p1", "rationale": "x", "source": "google_places"},
     ]
     with _patch_graph_details_many("p1", _fake_details("https://www.opentable.com/baz")):
-        committed, _ = _commit_stops(state, raw_stops)
+        committed, _ = commit_stops(state, raw_stops)
 
     stop = committed[0]
     # constraints.when = 2026-05-07 19:00


### PR DESCRIPTION
## Summary

Resolves the FUTURE_WATCH item "`app/agent/` directory size". `graph.py` had grown to 604 lines (post-#84), past the ~400-line split trigger.

- **`app/agent/commit.py`** (133) — `commit_stops` (renamed from `_commit_stops`), `enrich_stops_with_booking`, `_grounded_place_ids`
- **`app/agent/revision.py`** (272) — the critique/revision-diagnosis cluster: 4 public entry points (`critique_step`, `critique_final_with_stops`, `short_circuit_max_steps`, `finalize_as_is`) + 9 private helpers + 2 tuning constants
- **`app/agent/graph.py`** (240) — now just graph topology + LLM-wire (`_prune_for_llm`, `_serialize_tool_result`, `build_agent_graph` + node closures); docstring breadcrumbs to the new modules
- Flat-module pattern kept (no subdir — the 10+ file trigger is not met; 9 `.py` files). `booking/`/`kg/` subdirs stay deferred per the "do NOT pre-split" guidance.

**Behavior-preserving verbatim move.** Only changes: code relocation, the documented renames, import adjustments, patch-where-used target repoints, one approved test-wording cleanup, one docstring breadcrumb. No assertion or test-logic edits anywhere.

## Test Plan

- [x] Full unit suite: 416 pass — same parity as `main`. (`test_chat_functional::test_chat_runs_real_graph_with_tool_call` fails in full-suite run only — **pre-existing pollution flake proven identical on `main`**, passes in isolation, unrelated.)
- [x] `mypy app/` clean (31 files); no circular imports (`graph → {commit,revision} → {state,critique,tools}`, acyclic)
- [x] Mechanically verified zero behavior change (set-diff of code lines = imports only, modulo documented renames)
- [x] `graph.py` 240 lines — split trigger cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)