### PR TITLE
W8a: propagate lat/lng through PlaceCard for the frontend map

### DIFF
--- a/app/agent/io.py
+++ b/app/agent/io.py
@@ -45,6 +45,8 @@ def state_to_cards(state: ItineraryState) -> list[dict[str, Any]]:
             rating=s.rating,
             price_level=s.price_level,
             primary_type=s.primary_type,
+            latitude=s.latitude,
+            longitude=s.longitude,
             arrival_time=s.arrival_time,
             rationale=s.rationale,
             booking_url=s.booking_url,

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -183,6 +183,8 @@ class PlaceCard(BaseModel):
     rating: float | None = None
     price_level: int | None = None
     primary_type: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
     arrival_time: datetime | None = None
     rationale: str
     booking_url: str | None = None

--- a/tests/unit/test_agent_state.py
+++ b/tests/unit/test_agent_state.py
@@ -135,6 +135,8 @@ def test_place_card_serialization_keys() -> None:
         "rating",
         "price_level",
         "primary_type",
+        "latitude",
+        "longitude",
         "arrival_time",
         "rationale",
         "booking_url",

--- a/tests/unit/test_chat_endpoint.py
+++ b/tests/unit/test_chat_endpoint.py
@@ -80,6 +80,8 @@ def test_chat_endpoint_returns_reply_places_raglabel(mocker) -> None:
         "rating",
         "price_level",
         "primary_type",
+        "latitude",
+        "longitude",
         "arrival_time",
         "rationale",
         "booking_url",

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -39,3 +39,47 @@ def test_state_to_cards_defaults_missing_fields_to_none() -> None:
     assert cards[0]["address"] is None
     assert cards[0]["rating"] is None
     assert cards[0]["price_level"] is None
+
+
+def test_state_to_cards_carries_coordinates() -> None:
+    state = ItineraryState(
+        stops=[
+            Stop(
+                place_id="p1",
+                name="Tartine",
+                latitude=37.7614,
+                longitude=-122.4241,
+                rationale="great pastries",
+                source="google_places",
+            )
+        ]
+    )
+
+    cards = state_to_cards(state)
+
+    assert cards[0]["latitude"] == 37.7614
+    assert cards[0]["longitude"] == -122.4241
+
+
+def test_state_to_cards_preserves_stop_order() -> None:
+    state = ItineraryState(
+        stops=[
+            Stop(place_id=f"p{i}", name=f"S{i}", rationale="r", source="google_places")
+            for i in range(5)
+        ]
+    )
+
+    cards = state_to_cards(state)
+
+    assert [c["place_id"] for c in cards] == ["p0", "p1", "p2", "p3", "p4"]
+
+
+def test_state_to_cards_null_coordinates_pass_through_as_none() -> None:
+    """An editorial stop without coords must yield null lat/lng, not be dropped."""
+    state = ItineraryState(stops=[Stop(place_id="p1", name="X", rationale="r", source="editorial")])
+
+    cards = state_to_cards(state)
+
+    assert len(cards) == 1
+    assert cards[0]["latitude"] is None
+    assert cards[0]["longitude"] is None


### PR DESCRIPTION
## What

Adds `latitude` / `longitude` to `PlaceCard` and passes them through
`state_to_cards()`, preserving stop order. `Stop` already carried coordinates
(from W1 retrieval); they were silently dropped at the frontend wire boundary.

This is the first, smallest slice of **W8** (live Google Map + itinerary
routing). It is **backward-compatible and behavior-neutral** — only adds two
optional fields to the response shape. Nothing consumes them until W8b
(frontend) lands.

See `implementation_plan/james/w8_live_map_routing.md` (note: that doc lives on
the `feature/agent-w8b-live-map` branch, not yet on main).

## Changes

- `app/agent/state.py`: `latitude` / `longitude` on `PlaceCard`
- `app/agent/io.py`: pass coords through in `state_to_cards()`
- `tests/unit/test_io.py`: coords survive, stop order preserved, null-coord
  stop yields null lat/lng (not dropped, not crashed)
- `tests/unit/test_agent_state.py`: updated `PlaceCard` serialization-keys
  contract test

## Verification

`57 backend tests green` (io + chat functional + agent state + graph + smoke).
Behavior-neutral; no API/contract break for existing consumers.

## Not in this PR

W8b (frontend map + `/chat` switch) and W8c (Directions re-timing) are separate
PRs. W8b is built but pending real-API visual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)