### PR TITLE
Fix agent convergence: 3 harness bugs (gpt-4o-mini 1/6 -> 6/6)

### DIFF
--- a/app/agent/prompts.py
+++ b/app/agent/prompts.py
@@ -103,8 +103,17 @@ CRITICAL BEHAVIORS:
    question. Do NOT pretend you found something you didn't. (Self-correction
    logic in W3.)
 
-8. STOP after at most {max_steps} tool calls. If you don't have a confident
-   answer by then, return what you have with an explicit caveat.
+8. COMMIT DECISIVELY — this is the most important rule. The moment you have
+   ONE VIABLE OPTION for each requested stop, call `commit_itinerary`
+   immediately. A viable option is one that matches the cuisine/type and is
+   in roughly the right area — it does NOT have to be the geometrically
+   optimal arrangement. Do NOT keep searching to perfect walkability,
+   re-rank candidates, or find a "better structure": a good plan committed
+   now beats a perfect plan you never commit. The self-correction loop will
+   tell you if a committed stop genuinely violates a constraint — that is
+   the ONLY reason to revise after committing. Hard backstop: stop after at
+   most {max_steps} tool calls and commit the best you have with a caveat;
+   but you should almost always commit well before that ceiling.
 
 9. KNOWLEDGE GRAPH (kg_traverse): call
    `kg_traverse(place_id, relation_type, k)` to pivot from a known place along

--- a/app/agent/revision.py
+++ b/app/agent/revision.py
@@ -107,15 +107,23 @@ def _diagnose_one(tool_name: str, entry: dict[str, Any]) -> RevisionHint | None:
                 suggested_action="broaden_query",
                 target={"filter": "business_status"},
             )
-        top = result[0]
-        sim = getattr(top, "similarity", 0.0) or 0.0
-        if sim < LOW_SIMILARITY_THRESHOLD:
-            return RevisionHint(
-                reason="low_similarity",
-                detail=f"Top similarity {sim:.2f} below threshold {LOW_SIMILARITY_THRESHOLD}.",
-                suggested_action="broaden_query",
-                target={"query": args.get("query")},
-            )
+        # low_similarity only makes sense for the vector tool. `nearby`,
+        # `kg_traverse` and `get_details` return similarity=0.0 BY DESIGN
+        # (geographic / graph / lookup — no cosine score), so flagging them
+        # emitted a bogus "Top similarity 0.00, broaden_query" critique that
+        # derailed models following the prompt's anchored-`nearby` pattern.
+        if tool_name == "semantic_search":
+            top = result[0]
+            sim = getattr(top, "similarity", 0.0) or 0.0
+            if sim < LOW_SIMILARITY_THRESHOLD:
+                return RevisionHint(
+                    reason="low_similarity",
+                    detail=(
+                        f"Top similarity {sim:.2f} below threshold {LOW_SIMILARITY_THRESHOLD}."
+                    ),
+                    suggested_action="broaden_query",
+                    target={"query": args.get("query")},
+                )
     return None
 
 

--- a/app/tools/filters.py
+++ b/app/tools/filters.py
@@ -9,8 +9,13 @@ not need to know about — it just sets `open_at`.
 from __future__ import annotations
 
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field, field_validator
+
+# The concierge is San Francisco-only; a naive open_at unambiguously means
+# SF local time.
+_CITY_TZ = ZoneInfo("America/Los_Angeles")
 
 
 class SearchFilters(BaseModel):
@@ -91,13 +96,15 @@ class SearchFilters(BaseModel):
 
     @field_validator("open_at")
     @classmethod
-    def _require_tz_aware(cls, v: datetime | None) -> datetime | None:
-        # Naive datetimes get interpreted in Postgres's session timezone, which
-        # silently produces wrong DOW/hour answers across DST boundaries.
+    def _ensure_tz_aware(cls, v: datetime | None) -> datetime | None:
+        # A naive datetime would be interpreted in Postgres's session timezone,
+        # silently producing wrong DOW/hour answers across DST boundaries.
+        # Hard-rejecting it derailed models that omit the offset (a very common
+        # LLM mistake — it broke gpt-4o-mini on its first tool call). The app
+        # is SF-only, so a naive time unambiguously means SF local: attach the
+        # city tz instead of rejecting. Same correctness, no derailment.
         if v is not None and v.tzinfo is None:
-            raise ValueError(
-                "open_at must be timezone-aware (e.g. ZoneInfo('America/Los_Angeles'))."
-            )
+            return v.replace(tzinfo=_CITY_TZ)
         return v
 
 

--- a/implementation_plan/james/convergence_investigation_log.md
+++ b/implementation_plan/james/convergence_investigation_log.md
@@ -209,3 +209,24 @@ DeepSeek all-fix number pending (regression guard; expect ≥4/6).
 - The "smart models can't do this" premise was always a harness artifact;
   with the harness fixed, even gpt-4o-mini does it 6/6 — proving the task
   is simple and the harness was the problem all along (as user argued).
+
+---
+## FINAL MATRIX (all 3 fixes, 6 runs each, current branch)
+
+| model | BEFORE | AFTER (all fixes) | latency/run | demo verdict |
+|---|---|---|---|---|
+| gpt-4o-mini | 1/6 | **6/6** | 31-59s | ✅ BEST demo model — reliable + fast |
+| deepseek-v4-pro | 4/6 | **5/6** | 57-164s | ✅ strong, all 3-stop, but slow |
+| kimi-k2.6 | 1/6 | 2/6 | 25-48s | ❌ model instruction-following defect |
+
+**The 3 harness fixes improved EVERY instruction-following model**
+(gpt-4o-mini 1→6/6, DeepSeek 4→5/6 with all PASSes now full 3-stop).
+Kimi unchanged (2/6) — confirmed Kimi-specific, not harness.
+
+**FINAL RECOMMENDATION (demo): gpt-4o-mini.** 6/6, ~40s/run, the fixes
+make it bulletproof and demo-fast. DeepSeek is the quality/smart pick
+(5/6, always full 3 stops) but ~2-3x slower per run — viable if a ~90s
+itinerary is acceptable and you want the "smart model" story. Avoid Kimi.
+
+Branch feature/agent-convergence-investigation: 4 commits (3 fixes + log),
+suite 469/0/39, mypy/ruff clean. Ready for PR/merge decision on waking.

--- a/implementation_plan/james/convergence_investigation_log.md
+++ b/implementation_plan/james/convergence_investigation_log.md
@@ -254,3 +254,29 @@ deepseek-v4-flash 6x, all fixes: **2/6**, 28-50s/run.
 **Recommendation stands: demo with gpt-4o-mini.** It is, empirically, both
 the most reliable AND among the fastest. v4-pro is the only viable
 "smart model" alt (5/6) but ~2-3x slower. v4-flash and kimi are out.
+
+---
+## Tool coverage (user question: does the model use all the tools?)
+
+Both viable models use **4 of 5 tools**; NEITHER calls `kg_traverse`.
+
+| tool | gpt-4o-mini (4 runs) | deepseek-v4-pro (4 runs) |
+|---|---|---|
+| semantic_search | 12 | 8 |
+| get_details | 12 | 10 |
+| nearby | 11 | 4 |
+| commit_itinerary | 5 | 3 |
+| kg_traverse | **0** | **0** |
+
+Core itinerary flow (search→nearby→details→commit) is fully exercised by
+both. `kg_traverse` (W7 knowledge graph) is never invoked for the standard
+3-stop query — semantic_search/nearby already satisfy every stop and the
+prompt lists kg_traverse as an optional cheaper-alternative. NOT a model
+weakness; the KG is a built-but-dormant feature for this query type. To
+demo the KG you'd need a query that requires graph traversal ("more like
+this anchor", "similar to X").
+
+## Cleanup
+Temp investigation/evidence scripts (scripts/conv_*.py) removed — they were
+throwaway tracers, not shipped. The reusable oracle
+scripts/w10_convergence_check.py is kept (already tracked from W10).

--- a/implementation_plan/james/convergence_investigation_log.md
+++ b/implementation_plan/james/convergence_investigation_log.md
@@ -1,0 +1,211 @@
+# Convergence Investigation — Autonomous Session Log (2026-05-18, overnight)
+
+User went to bed; demo tomorrow. Granted full autonomy: investigate whether
+the convergence problem is tooling / LLM critic-judge / prompting / KV-cache /
+anything, apply the best fix without waiting for approval, do it for BOTH
+DeepSeek and Kimi (Kimi should perform like DeepSeek but is at 1/6), record
+everything here for review on waking.
+
+## Established before this session (reproducible, current merged main)
+
+6-run convergence + latency matrix, standard 3-stop Mission query:
+
+| model | converge | latency/run | per-call | failure mode |
+|---|---|---|---|---|
+| deepseek-v4-pro | 4/6 | ~100-124s | ~18-35s | 2 fails = correctly asks clarifying Qs (not a defect) |
+| gpt-4o-mini | 1/6 | 15-51s | ~5s | loops, ignores clarify instruction; trips open_at tz validator |
+| kimi-k2.6 | 1/6 | 24-50s | ~5s | loops all 8 steps, never commits |
+| gemini-3.1-pro-preview | unviable | >15min/run | very slow | killed |
+
+**Premise inverted:** smart model (DeepSeek) is the BEST converger; old
+"smart models fail" was stale pre-W10 data. Latency = (#LLM calls) × ~18s,
+90% LLM / 10% tool I/O — latency lever == convergence lever (fewer
+round-trips). DeepSeek's 2 "failures" = it follows SYSTEM_PROMPT Rule 3
+(ask when ambiguous) — ideal product behavior, mis-scored by single-shot
+oracle.
+
+## This session's mandate
+1. Full root-cause: tooling vs critic-judge vs prompt vs kv-cache vs other.
+2. Why is Kimi 1/6 when it should match DeepSeek? (key open question)
+3. Apply the best fix (auto-approved), verify via oracle, for DeepSeek + Kimi.
+4. Record every step + decision below.
+
+## Timeline / actions taken
+
+(appended chronologically as work proceeds)
+
+---
+## ROOT CAUSE FOUND (high confidence, direct evidence)
+
+**The `low_similarity` critique fires bogusly on `nearby`/`get_details`/
+`kg_traverse` results, which return `similarity=0.0` BY DESIGN.**
+
+Evidence:
+- Direct tool calls: `semantic_search` returns correct sims (0.60-0.71);
+  `nearby` returns `similarity=0.0` for every result (SQL: `0.0 AS similarity`
+  — it's a geographic radius query, no vector sim).
+- `app/agent/revision.py:_diagnose_one` (lines ~110-118) checks
+  `top.similarity < LOW_SIMILARITY_THRESHOLD (0.55)` on ANY list result,
+  not just `semantic_search`. So every `nearby` call → bogus
+  `[critique:step] low_similarity: Top similarity 0.00 below threshold 0.55,
+  broaden_query`.
+- Kimi deep-trace: did a good `semantic_search`, then followed
+  SYSTEM_PROMPT Rule 4 ("Stop K = nearby(stop_{K-1})") → `nearby` →
+  bogus low_similarity critique → told to "broaden query" (nonsensical for
+  geographic search) → confused, re-searched, looped all 8 steps, 0 stops.
+- DeepSeek converges more because its winning pattern is 3 parallel
+  `semantic_search` upfront (real sims) then get_details then commit — it
+  largely sidesteps the nearby→critique trap. Kimi follows the prescribed
+  anchored nearby pattern more literally → punished by the harness for
+  obeying the harness.
+
+**Classification: TOOLING / CRITIC-JUDGE bug** (user's suspicion correct).
+NOT prompt-quality, NOT model capability, NOT kv-cache.
+
+**Fix:** `_diagnose_one` low_similarity (and the empty/all_closed checks
+that also assume vector semantics) must only apply to `semantic_search`
+results. `nearby`/`kg_traverse`/`get_details` return similarity=0.0
+legitimately and must be exempt from low_similarity diagnosis.
+
+---
+## FIX APPLIED (auto-approved per user instruction)
+
+Commit `f25fda5`: `fix: low_similarity critique only applies to semantic_search`
+- `app/agent/revision.py` `_diagnose_one`: gated the low_similarity block to
+  `tool_name == "semantic_search"`. nearby/kg_traverse/get_details (sim=0.0
+  by design) no longer trigger bogus "broaden_query" critiques.
+- empty_results / all_closed / tool_error checks UNCHANGED (still valid for
+  all tools — an empty nearby is a real signal).
+- TDD: added `test_nearby_zero_similarity_does_not_emit_low_similarity`
+  (RED→GREEN verified; also guards the opposite direction — semantic_search
+  low-sim still flags).
+- Full suite: 468 passed, 39 skipped, 0 failed. mypy + ruff clean.
+
+## DeepSeek converging trace (corroborating evidence)
+stops=3 steps=4, ZERO critiques fired the whole run: 3 parallel
+semantic_search → 3 get_details → 1 get_details → commit. It converges
+*because* it never used nearby, so it never hit the bug. Confirms the
+diagnosis: the difference between converging and looping smart models was
+purely whether they tripped the nearby→low_similarity trap.
+
+## Verification in progress (oracle, 6 runs each, WITH fix)
+- Kimi 6x  -> /tmp/fix_kimi6.log
+- DeepSeek 6x -> /tmp/fix_ds6.log
+Expectation: Kimi should jump from 1/6 toward DeepSeek-class convergence
+(it was looping ONLY because of this bug). Results appended when complete.
+
+---
+## VERIFICATION RESULT — fix #1 (low_similarity gating)
+
+**Kimi 6x WITH fix: 2/6** (was 1/6). Real improvement (run 6 = clean 3-stop
+in 5 steps) but NOT the jump to DeepSeek-class (4/6) hypothesized. The
+bogus-critique bug was real + contributory but is NOT the whole story for
+Kimi. Kimi still 4/6 fail, all steps=8 loops. → there is a SECOND
+Kimi-specific factor (DeepSeek 4/6 on same code). Investigating a post-fix
+Kimi failure trajectory next. (DeepSeek 6x with fix still running — will
+confirm no regression / its number.)
+
+Also fixed in parallel (separate bug, user asked "tooling or anything"):
+naive open_at hard-reject → now coerces to SF tz (commit pending; was
+derailing gpt-4o-mini turn 0). Full suite 468 green for it.
+
+---
+## KV-cache hypothesis (user asked) — RULED OUT as convergence cause
+
+`_prune_for_llm` (graph.py:51) rewrites message history EVERY turn past
+2 tool-calls: drops old ToolMessages, rebuilds old tool-call AIMessages as
+content-only copies. The prompt PREFIX changes every turn → defeats
+provider prefix/KV caching for the back half of every run.
+- Convergence impact: NONE (W10 already proved bypassing _prune_for_llm
+  doesn't change outcomes; pruning changes context seen, not decide-ability).
+- Latency impact: REAL but secondary — every turn is cache-cold, compounding
+  the "latency = #LLM_calls × per_call" cost. A genuine future latency
+  optimization (stabilize the prefix) but NOT the convergence root cause and
+  too big/risky for the demo timeframe.
+Verdict: KV-cache is not the bug. The convergence bug was the
+low_similarity-on-nearby critique (fix #1, partial for Kimi — 2nd factor
+under investigation).
+
+---
+## FULL ROOT-CAUSE + ALL FIXES (autonomous, auto-approved)
+
+The convergence problem was THREE layered harness bugs (NOT model
+capability, NOT kv-cache). User's suspicion (tooling / critic-judge /
+prompt) was correct on all counts.
+
+### Bug 1 — bogus low_similarity critique on non-vector tools
+`_diagnose_one` flagged nearby/kg_traverse/get_details (similarity=0.0 BY
+DESIGN) as "Top similarity 0.00, broaden_query". Derailed any model using
+the prompt's anchored-nearby pattern. **Fix: commit f25fda5** (gate
+low_similarity to semantic_search only). Effect: Kimi 1/6 → 2/6.
+
+### Bug 2 — naive open_at hard-reject
+A naive `open_at` raised a ValidationError, hard-failing the tool call and
+derailing gpt-4o-mini on turn 0 (it omits the tz offset). **Fix: commit
+b0f2c27** (SF-only app → coerce naive to America/Los_Angeles, same
+correctness, no derailment).
+
+### Bug 3 — no decisive-commit contract (the residual Kimi looping)
+Post-Bug-1, Kimi STILL looped 4/6: post-fix trajectory showed a COMPLETE
+viable itinerary by step ~4 (La Taqueria + Grand Coffee "Perfect" +
+Casements "looks great") but it kept re-searching to perfect walkability
+("let me try a different structure") and never called commit_itinerary.
+Prompt Rule 8 framed stopping as a last-resort at the step ceiling; every
+other rule pushed more optimization. A maximally-compliant model optimizes
+forever; DeepSeek converged only by being more decisive. **Fix: commit
+1650473** (rewrote Rule 8: commit the moment you have one viable option
+per stop; don't keep optimizing geometry; max_steps is only a backstop).
+
+### KV-cache: ruled out (see section above) — not a convergence cause.
+
+Full suite after all 3 fixes: **469 passed, 39 skipped, 0 failed.**
+mypy + ruff clean. All committed on branch
+feature/agent-convergence-investigation.
+
+## Final verification IN PROGRESS (oracle 6x, ALL fixes)
+- Kimi  -> /tmp/all_kimi6.log   (was 1/6 → 2/6 after bug1; expect higher)
+- gpt-4o-mini -> /tmp/all_oai6.log (was 1/6; expect higher w/ bug2+3)
+- DeepSeek -> /tmp/all_ds6.log  (was 4/6; expect ≥4/6, regression guard)
+Results + final recommendation appended on completion.
+
+---
+## VERIFICATION RESULTS (all 3 fixes)
+
+**Kimi 6x ALL fixes: 2/6** — SAME as fix#1 alone. The decisive-commit
+prompt fix did NOT move Kimi. Key new evidence: Kimi's 2 PASS runs are
+BOTH steps=8 (commits only after exhausting the loop, not decisively).
+So Kimi isn't obeying the new Rule 8 commit-now instruction the way
+DeepSeek does — this is a model instruction-following gap, not another
+patchable harness bug. systematic-debugging: 2 Kimi fixes, neither
+resolved its residual looping → stop guessing, this may be Kimi-specific.
+(gpt-4o-mini + DeepSeek all-fix results pending — they'll show if the
+fixes help models that DO follow instructions.)
+
+---
+## DECISIVE RESULT — fixes validated
+
+**gpt-4o-mini 6x ALL fixes: 6/6 PERFECT** (was 1/6). Every run committed a
+full 3-stop itinerary, 31-59s each (also demo-fast). The 3 harness fixes
+are CORRECT and highly effective for a model that follows instructions.
+
+**Kimi remains 2/6 — isolated as a Kimi-specific instruction-following
+defect, NOT a harness bug.** Post-all-fix trace: Kimi pathologically
+repeats the SAME coffee search (semantic_search→nearby→semantic_search
+'specialty coffee...'→nearby→...) ignoring both the explicit
+decisive-commit instruction and its own prior tool results. kimi-k2.6 is
+poor at this agentic loop; that is a model property, not patchable in the
+harness. Kimi is the WRONG demo model.
+
+DeepSeek all-fix number pending (regression guard; expect ≥4/6).
+
+## CONCLUSION (for the morning)
+- Root cause fully found + fixed: 3 layered harness bugs (tooling +
+  critic-judge + prompt). User's suspicion correct. Not capability, not
+  kv-cache.
+- **gpt-4o-mini is now the clear demo model: 6/6, fast (31-59s/run),
+  reliable.** Recommend demoing with gpt-4o-mini.
+- Smarter models: DeepSeek was already strong (4/6 pre-fix) and the fixes
+  should hold/help (pending). Kimi is a poor fit regardless of harness.
+- The "smart models can't do this" premise was always a harness artifact;
+  with the harness fixed, even gpt-4o-mini does it 6/6 — proving the task
+  is simple and the harness was the problem all along (as user argued).

--- a/implementation_plan/james/convergence_investigation_log.md
+++ b/implementation_plan/james/convergence_investigation_log.md
@@ -230,3 +230,27 @@ itinerary is acceptable and you want the "smart model" story. Avoid Kimi.
 
 Branch feature/agent-convergence-investigation: 4 commits (3 fixes + log),
 suite 469/0/39, mypy/ruff clean. Ready for PR/merge decision on waking.
+
+---
+## deepseek-v4-flash tested (user request) — NOT a winner
+
+deepseek-v4-flash 6x, all fixes: **2/6**, 28-50s/run.
+- Single-call latency 0.9s (vs v4-pro ~18-35s) suggested a speed win, but
+  the AGENT-LOOP wall time is ~40s/run (failing runs go full 8 steps —
+  latency ≈ steps×per-call, weak convergence ⇒ more steps ⇒ still slow).
+- Convergence 2/6: WORSE than gpt-4o-mini (6/6) and v4-pro (5/6). The
+  smaller/faster DeepSeek is a notably weaker instruction-follower for
+  this loop. Worst of the trade-off: ~gpt-4o-mini speed, far worse
+  convergence. Does NOT solve the demo-latency problem.
+
+## UPDATED FINAL MATRIX (all fixes, 6 runs each)
+| model | convergence | latency/run | demo verdict |
+|---|---|---|---|
+| gpt-4o-mini | **6/6** | 31-59s | ✅ BEST — reliable + fast |
+| deepseek-v4-pro | 5/6 | 57-164s | ✅ quality pick, slow |
+| deepseek-v4-flash | 2/6 | 28-50s | ❌ weak converger, no speed gain |
+| kimi-k2.6 | 2/6 | 25-48s | ❌ instruction-following defect |
+
+**Recommendation stands: demo with gpt-4o-mini.** It is, empirically, both
+the most reliable AND among the fastest. v4-pro is the only viable
+"smart model" alt (5/6) but ~2-3x slower. v4-flash and kimi are out.

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -72,6 +72,26 @@ def test_system_prompt_requires_rich_semantic_query() -> None:
     assert "neighborhood" in s and "place type" in s
 
 
+def test_system_prompt_has_decisive_commit_contract() -> None:
+    """SYSTEM_PROMPT must give an explicit EARLY-commit criterion: once you
+    have one viable option per requested stop, call commit_itinerary — do
+    NOT keep optimizing geometry/walkability.
+
+    Root cause (convergence investigation): with the bogus low_similarity
+    critique fixed, Kimi still looped 4/6 — its trajectories contained a
+    complete viable itinerary by step ~4 but it kept re-searching to perfect
+    the route ('Casements is north of my lunch... let me try a different
+    structure') and never committed. DeepSeek converged only because it was
+    more decisive. Rule 8 framed stopping as a last resort at the step
+    ceiling, with no positive 'you have enough, commit' signal. Add one.
+    """
+    s = SYSTEM_PROMPT.lower()
+    assert "commit_itinerary" in s
+    # An explicit good-enough / don't-keep-optimizing stopping criterion.
+    assert "one viable option" in s or "good enough" in s
+    assert "do not keep" in s or "don't keep" in s or "stop optimizing" in s
+
+
 def test_clarifying_stops_template_is_a_static_string() -> None:
     assert isinstance(CLARIFYING_STOPS_COUNT_TEMPLATE, str)
     assert "stops" in CLARIFYING_STOPS_COUNT_TEMPLATE

--- a/tests/unit/test_agent_self_correct.py
+++ b/tests/unit/test_agent_self_correct.py
@@ -521,6 +521,34 @@ async def test_critique_message_is_visible_to_plan(monkeypatch) -> None:
     assert "empty_results" in critique_msgs[0].content
 
 
+def test_nearby_zero_similarity_does_not_emit_low_similarity() -> None:
+    """ROOT-CAUSE REGRESSION: `nearby`/`kg_traverse`/`get_details` return
+    similarity=0.0 BY DESIGN (geographic/graph, not vector). The
+    low_similarity check must NOT fire for them — doing so injected a bogus
+    'broaden_query' critique that derailed models following the prompt's
+    anchored-nearby pattern (Kimi looped 0/8; DeepSeek only converged because
+    it happened to avoid `nearby`). low_similarity applies to semantic_search
+    only."""
+    from app.agent.revision import _diagnose_one
+
+    zero_sim_result = [make_hit(place_id="n1", similarity=0.0)]
+
+    # nearby with all-zero similarity (its normal output) → NO low_similarity
+    hint = _diagnose_one("nearby", {"args": {"place_id": "p1"}, "result": zero_sim_result})
+    assert hint is None, f"nearby must not emit low_similarity, got {hint!r}"
+
+    # get_details / kg_traverse likewise exempt
+    assert _diagnose_one("kg_traverse", {"args": {}, "result": zero_sim_result}) is None
+
+    # semantic_search with genuinely low similarity STILL flags (regression
+    # guard the opposite direction — we didn't disable the real check).
+    ss_hint = _diagnose_one(
+        "semantic_search",
+        {"args": {"query": "obscure"}, "result": [make_hit(similarity=0.10)]},
+    )
+    assert ss_hint is not None and ss_hint.reason == "low_similarity"
+
+
 async def test_diagnose_handles_no_scratch_entry() -> None:
     """If somehow critique fires without any scratch entry (defensive),
     don't crash and don't emit a hint."""

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-import pytest
-
 from app.tools.filters import SearchFilters, compile_filters
 
 
@@ -113,9 +111,17 @@ def test_unset_boolean_filters_emit_no_clause() -> None:
         assert f"{col} =" not in where
 
 
-def test_open_at_rejects_naive_datetime() -> None:
-    with pytest.raises(ValueError, match="timezone-aware"):
-        SearchFilters(open_at=datetime(2026, 4, 26, 19, 30))
+def test_open_at_coerces_naive_datetime_to_sf_tz() -> None:
+    """A naive open_at must NOT hard-reject (it derailed gpt-4o-mini on its
+    first tool call — models frequently omit the offset). The app is SF-only,
+    so a naive time unambiguously means SF local; coerce it to
+    America/Los_Angeles. Still satisfies the original correctness goal (no
+    ambiguous Postgres-session-tz interpretation across DST)."""
+    f = SearchFilters(open_at=datetime(2026, 4, 26, 19, 30))
+    assert f.open_at is not None
+    assert f.open_at.tzinfo == ZoneInfo("America/Los_Angeles")
+    # wall-clock preserved (interpreted AS SF local, not converted)
+    assert (f.open_at.hour, f.open_at.minute) == (19, 30)
 
 
 def test_open_at_accepts_tz_aware_datetime() -> None:


### PR DESCRIPTION
## Summary

Investigated why "smarter models can't do the simple agentic task." Root cause was **3 layered harness bugs** — NOT model capability, NOT kv-cache. With them fixed, **gpt-4o-mini went 1/6 -> 6/6** and DeepSeek-v4-pro 4/6 -> 5/6.

## The 3 fixes

1. **`f25fda5`** — `low_similarity` critique fired bogusly on `nearby`/`get_details`/`kg_traverse` (they return `similarity=0.0` by design); it injected a "broaden_query" critique that derailed any model following the prompt's anchored-`nearby` pattern. Now gated to `semantic_search` only.
2. **`b0f2c27`** — a naive `open_at` datetime hard-rejected the tool call (derailed models on turn 0). App is SF-only, so coerce naive -> `America/Los_Angeles` instead of raising. Same correctness, no derailment.
3. **`1650473`** — no "commit when good enough" signal: models found a complete plan then optimized walkability forever. Rewrote SYSTEM_PROMPT Rule 8 with an explicit decisive-commit contract.

## Verified results (oracle, 6 runs each, all fixes)

| Model | Before | After | Latency/run |
|---|---|---|---|
| gpt-4o-mini | 1/6 | **6/6** | 31-59s |
| deepseek-v4-pro | 4/6 | **5/6** | 57-164s |
| deepseek-v4-flash | — | 2/6 | 28-50s |
| kimi-k2.6 | 1/6 | 2/6 | 25-48s |

The fixes improved every instruction-following model. Kimi's residual 2/6 is a Kimi-specific instruction-following defect, not a harness bug.

## Notes

- Full investigation narrative: `implementation_plan/james/convergence_investigation_log.md`.
- Tool coverage: both viable models exercise the core 4-tool flow (search/nearby/details/commit); neither calls `kg_traverse` for the standard query (built-but-dormant feature).
- MLflow `production` alias already = v1 gpt-4o-mini temp=0.0 (the best model per this investigation — no change needed).
- Full suite: **469 passed, 39 skipped, 0 failed**; mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)