### PR TITLE
Frontend: accessibility + polish pass, honest placeholder copy

### DIFF
--- a/frontend/src/components/ChatMessage.jsx
+++ b/frontend/src/components/ChatMessage.jsx
@@ -50,6 +50,7 @@ const s = {
   time: {
     fontSize: '10px', color: 'var(--warm-gray)',
     marginTop: '4px', padding: '0 4px',
+    fontVariantNumeric: 'tabular-nums',
   },
   timeUser: { textAlign: 'right' },
   // Pill styles (for place references inside bot messages)
@@ -58,7 +59,7 @@ const s = {
     border: '1px solid var(--border)', borderRadius: '4px',
     padding: '2px 8px', fontSize: '12px', margin: '2px',
     cursor: 'pointer', color: 'var(--charcoal)',
-    transition: 'all .15s',
+    transition: 'background .15s, color .15s, border-color .15s',
   },
   pillNum: { color: 'var(--rust)', fontWeight: 600, marginRight: '4px' },
   typing: {
@@ -161,6 +162,7 @@ function PlacePill({ label, num, onClick }) {
       role="button"
       tabIndex={0}
       aria-label={`Show ${label} on map`}
+      className="press"
       style={{
         ...s.pill,
         ...(hovered ? { background: 'var(--moss)', color: 'var(--white)', borderColor: 'var(--moss)' } : {}),

--- a/frontend/src/components/ChatMessage.jsx
+++ b/frontend/src/components/ChatMessage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { clickableProps } from './a11y'
 
 const s = {
   row: {
@@ -159,20 +160,10 @@ function PlacePill({ label, num, onClick }) {
   const [hovered, setHovered] = React.useState(false)
   return (
     <span
-      role="button"
-      tabIndex={0}
-      aria-label={`Show ${label} on map`}
-      className="press"
+      {...clickableProps(onClick, `Show ${label} on map`)}
       style={{
         ...s.pill,
         ...(hovered ? { background: 'var(--moss)', color: 'var(--white)', borderColor: 'var(--moss)' } : {}),
-      }}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onClick?.()
-        }
       }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}

--- a/frontend/src/components/ChatMessage.jsx
+++ b/frontend/src/components/ChatMessage.jsx
@@ -158,11 +158,20 @@ function PlacePill({ label, num, onClick }) {
   const [hovered, setHovered] = React.useState(false)
   return (
     <span
+      role="button"
+      tabIndex={0}
+      aria-label={`Show ${label} on map`}
       style={{
         ...s.pill,
         ...(hovered ? { background: 'var(--moss)', color: 'var(--white)', borderColor: 'var(--moss)' } : {}),
       }}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick?.()
+        }
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -34,10 +34,9 @@ const s = {
   clearBtn: {
     fontSize: '11px', color: 'var(--warm-gray)',
     background: 'none', border: '1px solid var(--border)',
-    padding: '4px 12px', borderRadius: '4px', minHeight: '36px',
+    padding: '4px 12px', borderRadius: '4px',
     cursor: 'pointer', transition: 'background .2s, color .2s',
     fontFamily: 'var(--font-body)',
-    display: 'inline-flex', alignItems: 'center',
   },
   chips: {
     display: 'flex', gap: '6px', flexWrap: 'wrap', marginTop: '12px',
@@ -47,8 +46,7 @@ const s = {
     border: '1px solid var(--border)', background: 'var(--cream)',
     cursor: 'pointer', color: 'var(--warm-gray)',
     transition: 'background .2s, color .2s, border-color .2s', whiteSpace: 'nowrap',
-    fontFamily: 'var(--font-body)', minHeight: '36px',
-    display: 'inline-flex', alignItems: 'center',
+    fontFamily: 'var(--font-body)',
   },
   messages: {
     flex: 1, overflowY: 'auto',
@@ -142,7 +140,7 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
             <div style={s.subtitle}>Powered by live Google Places data</div>
           </div>
           <button
-            className="press"
+            className="press tap-target"
             style={s.clearBtn}
             onClick={onClear}
             onMouseEnter={e => Object.assign(e.target.style, { background: 'var(--cream-dark)', color: 'var(--charcoal)' })}
@@ -155,7 +153,7 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
           {SUGGESTION_CHIPS.map(chip => (
             <button
               key={chip}
-              className="press"
+              className="press tap-target"
               style={s.chip}
               onClick={() => handleChipClick(chip)}
               onMouseEnter={e => Object.assign(e.target.style, { background: 'var(--moss)', color: 'var(--white)', borderColor: 'var(--moss)' })}

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -34,19 +34,21 @@ const s = {
   clearBtn: {
     fontSize: '11px', color: 'var(--warm-gray)',
     background: 'none', border: '1px solid var(--border)',
-    padding: '4px 10px', borderRadius: '4px',
+    padding: '4px 12px', borderRadius: '4px', minHeight: '36px',
     cursor: 'pointer', transition: 'all .2s',
     fontFamily: 'var(--font-body)',
+    display: 'inline-flex', alignItems: 'center',
   },
   chips: {
     display: 'flex', gap: '6px', flexWrap: 'wrap', marginTop: '12px',
   },
   chip: {
-    fontSize: '11px', padding: '5px 11px', borderRadius: '20px',
+    fontSize: '11px', padding: '5px 13px', borderRadius: '20px',
     border: '1px solid var(--border)', background: 'var(--cream)',
     cursor: 'pointer', color: 'var(--warm-gray)',
     transition: 'all .2s', whiteSpace: 'nowrap',
-    fontFamily: 'var(--font-body)',
+    fontFamily: 'var(--font-body)', minHeight: '36px',
+    display: 'inline-flex', alignItems: 'center',
   },
   messages: {
     flex: 1, overflowY: 'auto',
@@ -182,6 +184,7 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
           <textarea
             ref={textareaRef}
             style={s.textarea}
+            aria-label="Ask the SF concierge"
             placeholder="Ask anything about SF — neighborhoods, food, events…"
             value={input}
             onChange={handleInput}
@@ -191,6 +194,8 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
             onBlur={e => e.target.style.borderColor = 'var(--border)'}
           />
           <button
+            type="button"
+            aria-label="Send message"
             style={{ ...s.sendBtn, background: sendHovered ? 'var(--charcoal)' : 'var(--moss)' }}
             onClick={handleSend}
             disabled={isLoading}

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -35,7 +35,7 @@ const s = {
     fontSize: '11px', color: 'var(--warm-gray)',
     background: 'none', border: '1px solid var(--border)',
     padding: '4px 12px', borderRadius: '4px', minHeight: '36px',
-    cursor: 'pointer', transition: 'all .2s',
+    cursor: 'pointer', transition: 'background .2s, color .2s',
     fontFamily: 'var(--font-body)',
     display: 'inline-flex', alignItems: 'center',
   },
@@ -46,7 +46,7 @@ const s = {
     fontSize: '11px', padding: '5px 13px', borderRadius: '20px',
     border: '1px solid var(--border)', background: 'var(--cream)',
     cursor: 'pointer', color: 'var(--warm-gray)',
-    transition: 'all .2s', whiteSpace: 'nowrap',
+    transition: 'background .2s, color .2s, border-color .2s', whiteSpace: 'nowrap',
     fontFamily: 'var(--font-body)', minHeight: '36px',
     display: 'inline-flex', alignItems: 'center',
   },
@@ -142,6 +142,7 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
             <div style={s.subtitle}>Powered by live Google Places data</div>
           </div>
           <button
+            className="press"
             style={s.clearBtn}
             onClick={onClear}
             onMouseEnter={e => Object.assign(e.target.style, { background: 'var(--cream-dark)', color: 'var(--charcoal)' })}
@@ -154,6 +155,7 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
           {SUGGESTION_CHIPS.map(chip => (
             <button
               key={chip}
+              className="press"
               style={s.chip}
               onClick={() => handleChipClick(chip)}
               onMouseEnter={e => Object.assign(e.target.style, { background: 'var(--moss)', color: 'var(--white)', borderColor: 'var(--moss)' })}
@@ -196,6 +198,7 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
           <button
             type="button"
             aria-label="Send message"
+            className="press"
             style={{ ...s.sendBtn, background: sendHovered ? 'var(--charcoal)' : 'var(--moss)' }}
             onClick={handleSend}
             disabled={isLoading}

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -172,7 +172,7 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
         ))}
         {isLoading && (
           <ChatMessage
-            message={{ role: 'typing', ragLabel: 'Searching nearby · Mission District' }}
+            message={{ role: 'typing', ragLabel: 'Searching SF places…' }}
           />
         )}
         <div ref={messagesEndRef} />
@@ -209,7 +209,7 @@ export default function ChatPanel({ messages, onSend, onClear, onPlacePillClick,
         <div style={s.inputMeta}>
           <div style={s.ragIndicator}>
             <div style={s.ragDot} />
-            RAG pipeline active · Places updated 4 min ago
+            RAG pipeline active
           </div>
           <span>↵ to send · ⇧↵ for newline</span>
         </div>

--- a/frontend/src/components/PlaceCard.jsx
+++ b/frontend/src/components/PlaceCard.jsx
@@ -73,8 +73,17 @@ export default function PlaceCard({ place, featured = false, onClick }) {
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label={`${place.name} — ${place.type}`}
       style={{ ...s.card, ...(isHighlighted ? s.cardActive : {}) }}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick?.()
+        }
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/frontend/src/components/PlaceCard.jsx
+++ b/frontend/src/components/PlaceCard.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { clickableProps } from './a11y'
 
 const s = {
   card: {
@@ -74,18 +75,8 @@ export default function PlaceCard({ place, featured = false, onClick }) {
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      aria-label={`${place.name} — ${place.type}`}
-      className="press"
+      {...clickableProps(onClick, `${place.name} — ${place.type}`)}
       style={{ ...s.card, ...(isHighlighted ? s.cardActive : {}) }}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onClick?.()
-        }
-      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/frontend/src/components/PlaceCard.jsx
+++ b/frontend/src/components/PlaceCard.jsx
@@ -6,7 +6,8 @@ const s = {
     border: '1px solid var(--border)',
     padding: '16px 18px',
     display: 'flex', gap: '16px', alignItems: 'flex-start',
-    cursor: 'pointer', transition: 'all .2s',
+    cursor: 'pointer',
+    transition: 'border-color .2s, box-shadow .2s, transform .2s',
     position: 'relative', overflow: 'hidden',
   },
   cardActive: {
@@ -76,6 +77,7 @@ export default function PlaceCard({ place, featured = false, onClick }) {
       role="button"
       tabIndex={0}
       aria-label={`${place.name} — ${place.type}`}
+      className="press"
       style={{ ...s.card, ...(isHighlighted ? s.cardActive : {}) }}
       onClick={onClick}
       onKeyDown={(e) => {

--- a/frontend/src/components/RightPanel.jsx
+++ b/frontend/src/components/RightPanel.jsx
@@ -28,7 +28,7 @@ const s = {
     display: 'flex', alignItems: 'center', gap: '6px',
     padding: '6px 14px', borderRadius: '6px', border: 'none',
     fontFamily: 'var(--font-body)', fontSize: '12px', fontWeight: 500,
-    cursor: 'pointer', transition: 'all .2s', minHeight: '36px',
+    cursor: 'pointer', transition: 'background .2s, color .2s, box-shadow .2s', minHeight: '36px',
     color: 'var(--warm-gray)', background: 'transparent',
   },
   toggleBtnActive: {
@@ -39,13 +39,13 @@ const s = {
     fontSize: '12px', color: 'var(--warm-gray)',
     display: 'flex', alignItems: 'center', gap: '16px',
   },
-  metaCount: { fontWeight: 500, color: 'var(--charcoal)' },
+  metaCount: { fontWeight: 500, color: 'var(--charcoal)', fontVariantNumeric: 'tabular-nums' },
   filters: { display: 'flex', gap: '6px', alignItems: 'center' },
   filterPill: {
     fontSize: '11px', padding: '4px 12px', borderRadius: '20px',
     border: '1px solid var(--border)', background: 'var(--white)',
     cursor: 'pointer', color: 'var(--warm-gray)',
-    transition: 'all .2s', fontFamily: 'var(--font-body)',
+    transition: 'background .2s, color .2s, border-color .2s', fontFamily: 'var(--font-body)',
     minHeight: '36px', display: 'inline-flex', alignItems: 'center',
   },
   filterPillActive: {
@@ -129,6 +129,7 @@ export default function RightPanel({
             ].map(({ id, label, Icon }) => (
               <button
                 key={id}
+                className="press"
                 style={{ ...s.toggleBtn, ...(view === id ? s.toggleBtnActive : {}) }}
                 onClick={() => setView(id)}
               >
@@ -195,6 +196,7 @@ function FilterPill({ label, active, onClick }) {
 
   return (
     <button
+      className="press"
       style={{
         ...s.filterPill,
         ...(isActive ? s.filterPillActive : {}),

--- a/frontend/src/components/RightPanel.jsx
+++ b/frontend/src/components/RightPanel.jsx
@@ -28,7 +28,7 @@ const s = {
     display: 'flex', alignItems: 'center', gap: '6px',
     padding: '6px 14px', borderRadius: '6px', border: 'none',
     fontFamily: 'var(--font-body)', fontSize: '12px', fontWeight: 500,
-    cursor: 'pointer', transition: 'all .2s',
+    cursor: 'pointer', transition: 'all .2s', minHeight: '36px',
     color: 'var(--warm-gray)', background: 'transparent',
   },
   toggleBtnActive: {
@@ -42,10 +42,11 @@ const s = {
   metaCount: { fontWeight: 500, color: 'var(--charcoal)' },
   filters: { display: 'flex', gap: '6px', alignItems: 'center' },
   filterPill: {
-    fontSize: '11px', padding: '4px 10px', borderRadius: '20px',
+    fontSize: '11px', padding: '4px 12px', borderRadius: '20px',
     border: '1px solid var(--border)', background: 'var(--white)',
     cursor: 'pointer', color: 'var(--warm-gray)',
     transition: 'all .2s', fontFamily: 'var(--font-body)',
+    minHeight: '36px', display: 'inline-flex', alignItems: 'center',
   },
   filterPillActive: {
     background: 'var(--charcoal)', color: 'var(--white)',

--- a/frontend/src/components/RightPanel.jsx
+++ b/frontend/src/components/RightPanel.jsx
@@ -25,10 +25,10 @@ const s = {
     borderRadius: '8px', padding: '3px',
   },
   toggleBtn: {
-    display: 'flex', alignItems: 'center', gap: '6px',
+    gap: '6px',
     padding: '6px 14px', borderRadius: '6px', border: 'none',
     fontFamily: 'var(--font-body)', fontSize: '12px', fontWeight: 500,
-    cursor: 'pointer', transition: 'background .2s, color .2s, box-shadow .2s', minHeight: '36px',
+    cursor: 'pointer', transition: 'background .2s, color .2s, box-shadow .2s',
     color: 'var(--warm-gray)', background: 'transparent',
   },
   toggleBtnActive: {
@@ -46,7 +46,6 @@ const s = {
     border: '1px solid var(--border)', background: 'var(--white)',
     cursor: 'pointer', color: 'var(--warm-gray)',
     transition: 'background .2s, color .2s, border-color .2s', fontFamily: 'var(--font-body)',
-    minHeight: '36px', display: 'inline-flex', alignItems: 'center',
   },
   filterPillActive: {
     background: 'var(--charcoal)', color: 'var(--white)',
@@ -129,7 +128,7 @@ export default function RightPanel({
             ].map(({ id, label, Icon }) => (
               <button
                 key={id}
-                className="press"
+                className="press tap-target"
                 style={{ ...s.toggleBtn, ...(view === id ? s.toggleBtnActive : {}) }}
                 onClick={() => setView(id)}
               >
@@ -196,7 +195,7 @@ function FilterPill({ label, active, onClick }) {
 
   return (
     <button
-      className="press"
+      className="press tap-target"
       style={{
         ...s.filterPill,
         ...(isActive ? s.filterPillActive : {}),

--- a/frontend/src/components/RightPanel.jsx
+++ b/frontend/src/components/RightPanel.jsx
@@ -101,7 +101,7 @@ export default function RightPanel({
   onPlaceClick,
   planFinalized = false,
   focusId = null,
-  lastRefreshed = '4 min ago',
+  lastRefreshed = 'just now',
 }) {
   const [view, setView] = useState('map')       // 'map' | 'list'
   const [activeFilter, setActiveFilter] = useState('All')
@@ -138,10 +138,9 @@ export default function RightPanel({
             ))}
           </div>
 
-          {/* Result count + context */}
+          {/* Result count */}
           <div style={s.meta}>
             <span style={s.metaCount}>{filteredPlaces.length} places</span>
-            <span>Mission District · Tonight</span>
           </div>
         </div>
 

--- a/frontend/src/components/RouteOverlay.jsx
+++ b/frontend/src/components/RouteOverlay.jsx
@@ -37,8 +37,9 @@ const s = {
   toggle: { display: 'flex', gap: '2px', background: 'var(--cream-dark)', borderRadius: '7px', padding: '3px' },
   btn: {
     border: 'none', background: 'transparent', cursor: 'pointer',
-    padding: '5px 10px', borderRadius: '5px', fontSize: '12px',
+    padding: '5px 12px', borderRadius: '5px', fontSize: '12px',
     fontFamily: 'var(--font-body)', color: 'var(--warm-gray)',
+    minHeight: '36px', display: 'inline-flex', alignItems: 'center', gap: '4px',
   },
   btnActive: { background: 'var(--white)', color: 'var(--charcoal)', boxShadow: '0 1px 3px rgba(0,0,0,.1)' },
   total: { fontWeight: 600, color: 'var(--charcoal)', whiteSpace: 'nowrap' },

--- a/frontend/src/components/RouteOverlay.jsx
+++ b/frontend/src/components/RouteOverlay.jsx
@@ -42,7 +42,7 @@ const s = {
     minHeight: '36px', display: 'inline-flex', alignItems: 'center', gap: '4px',
   },
   btnActive: { background: 'var(--white)', color: 'var(--charcoal)', boxShadow: '0 1px 3px rgba(0,0,0,.1)' },
-  total: { fontWeight: 600, color: 'var(--charcoal)', whiteSpace: 'nowrap' },
+  total: { fontWeight: 600, color: 'var(--charcoal)', whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' },
   err: { color: 'var(--rust)', whiteSpace: 'nowrap' },
 }
 
@@ -177,6 +177,7 @@ export default function RouteOverlay({ stops }) {
         {MODES.map((m) => (
           <button
             key={m.id}
+            className="press"
             style={{ ...s.btn, ...(mode === m.id ? s.btnActive : {}) }}
             onClick={() => setMode(m.id)}
             aria-pressed={mode === m.id}

--- a/frontend/src/components/RouteOverlay.jsx
+++ b/frontend/src/components/RouteOverlay.jsx
@@ -38,8 +38,7 @@ const s = {
   btn: {
     border: 'none', background: 'transparent', cursor: 'pointer',
     padding: '5px 12px', borderRadius: '5px', fontSize: '12px',
-    fontFamily: 'var(--font-body)', color: 'var(--warm-gray)',
-    minHeight: '36px', display: 'inline-flex', alignItems: 'center', gap: '4px',
+    fontFamily: 'var(--font-body)', color: 'var(--warm-gray)', gap: '4px',
   },
   btnActive: { background: 'var(--white)', color: 'var(--charcoal)', boxShadow: '0 1px 3px rgba(0,0,0,.1)' },
   total: { fontWeight: 600, color: 'var(--charcoal)', whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' },
@@ -177,7 +176,7 @@ export default function RouteOverlay({ stops }) {
         {MODES.map((m) => (
           <button
             key={m.id}
-            className="press"
+            className="press tap-target"
             style={{ ...s.btn, ...(mode === m.id ? s.btnActive : {}) }}
             onClick={() => setMode(m.id)}
             aria-pressed={mode === m.id}

--- a/frontend/src/components/TopNav.jsx
+++ b/frontend/src/components/TopNav.jsx
@@ -36,6 +36,7 @@ const styles = {
     display: 'flex', alignItems: 'center', gap: '6px',
     fontSize: '12px', color: 'var(--moss-light)',
   },
+  statusCount: { fontVariantNumeric: 'tabular-nums' },
   statusDot: {
     width: '6px', height: '6px', borderRadius: '50%',
     background: '#6CBF6C',
@@ -65,7 +66,7 @@ export default function TopNav({ indexedCount = 847 }) {
 
       <div style={styles.status}>
         <div style={styles.statusDot} />
-        Live · <span style={{ fontVariantNumeric: 'tabular-nums' }}>{indexedCount.toLocaleString()}</span> places indexed
+        Live · <span style={styles.statusCount}>{indexedCount.toLocaleString()}</span> places indexed
       </div>
     </nav>
   )

--- a/frontend/src/components/TopNav.jsx
+++ b/frontend/src/components/TopNav.jsx
@@ -65,7 +65,7 @@ export default function TopNav({ indexedCount = 847 }) {
 
       <div style={styles.status}>
         <div style={styles.statusDot} />
-        Live · {indexedCount.toLocaleString()} places indexed
+        Live · <span style={{ fontVariantNumeric: 'tabular-nums' }}>{indexedCount.toLocaleString()}</span> places indexed
       </div>
     </nav>
   )

--- a/frontend/src/components/a11y.js
+++ b/frontend/src/components/a11y.js
@@ -1,0 +1,20 @@
+/**
+ * Props that make a non-<button> element behave like a button: clickable,
+ * keyboard-operable (Enter/Space), focusable, labeled, with press feedback.
+ * Single source of truth for the "div/span acting as a button" a11y contract.
+ */
+export function clickableProps(onClick, label) {
+  return {
+    role: 'button',
+    tabIndex: 0,
+    'aria-label': label,
+    className: 'press',
+    onClick,
+    onKeyDown: (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        onClick?.()
+      }
+    },
+  }
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -5,8 +5,13 @@
   --sage: #C8D4BB; --rust: #C4703A; --white: #FDFCF9; --border: #D8D0C4;
   --font-display: 'Playfair Display', serif; --font-body: 'DM Sans', sans-serif;
 }
+html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 html, body, #root { height: 100%; overflow: hidden; font-family: var(--font-body); background: var(--cream); color: var(--charcoal); }
+h1, h2, h3 { text-wrap: balance; }
+p, li, figcaption { text-wrap: pretty; }
 :focus-visible { outline: 2px solid var(--moss); outline-offset: 2px; border-radius: 3px; }
+.press { transition-property: scale; transition-duration: 150ms; transition-timing-function: ease-out; }
+.press:active:not(:disabled) { scale: .96; }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -6,6 +6,10 @@
   --font-display: 'Playfair Display', serif; --font-body: 'DM Sans', sans-serif;
 }
 html, body, #root { height: 100%; overflow: hidden; font-family: var(--font-body); background: var(--cream); color: var(--charcoal); }
+:focus-visible { outline: 2px solid var(--moss); outline-offset: 2px; border-radius: 3px; }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+}
 ::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -12,6 +12,7 @@ p, li, figcaption { text-wrap: pretty; }
 :focus-visible { outline: 2px solid var(--moss); outline-offset: 2px; border-radius: 3px; }
 .press { transition-property: scale; transition-duration: 150ms; transition-timing-function: ease-out; }
 .press:active:not(:disabled) { scale: .96; }
+.tap-target { min-height: 36px; display: inline-flex; align-items: center; }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
 }


### PR DESCRIPTION
Three-pass frontend improvement on `frontend/src` plus a copy honesty fix.

## Changes

**Accessibility (`cf6189f`)**
- Global `:focus-visible` ring + `prefers-reduced-motion` reset (4 unguarded animations existed)
- `PlaceCard` / `PlacePill` made keyboard-operable (were click-only `<div>`/`<span>`)
- Accessible names on send button + chat textarea
- Sub-44px controls raised to ~36px tap targets (pragmatic; preserves compact design)

**Polish (`42e745f`)**
- `tabular-nums` on all dynamic numbers
- Removed every `transition: all` (6) → explicit property lists
- `scale(0.96)` press feedback via `.press` class (CSS — no motion lib in deps)
- macOS font smoothing + `text-wrap: balance`/`pretty`

**Refactor / dedupe (`be418aa`)**
- Extracted `clickableProps()` (`components/a11y.js`) — removed duplicated keyboard handler
- Extracted `.tap-target` utility — removed 4× copy-pasted inline fragment
- Hoisted TopNav inline style into its `styles` const

**Honest copy (`71ba516`)**
- Replaced hardcoded mockup strings that ignored the query: "Searching nearby · Mission District" → "Searching SF places…"; dropped fabricated "Places updated 4 min ago" and "Mission District · Tonight"

## Verification
- 27/27 frontend tests pass (Vitest)
- `vite build` clean
- Scope: 8 files, +65/−22, all under `frontend/`

## Not in scope
Unrelated to the stale-`gemini` runtime label some local backends show — that's an MLflow-alias/restart issue, not a code change. The prod alias is correctly on `gpt-4o-mini`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)