### PR TITLE
fix(agent): finalize on successful commit (kills false 'step limit' error)

### DIFF
--- a/app/agent/commit.py
+++ b/app/agent/commit.py
@@ -119,6 +119,14 @@ def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
         stop.address = details.formatted_address
         stop.rating = details.rating
         stop.price_level = price_level_to_rank(details.price_level)
+        # The LLM commits without coordinates (optional in the prompt), so
+        # backfill from the DB — otherwise every stop is lat=lng=None and the
+        # frontend's `routable` filter drops them all (no pins, no route).
+        # Only fill a missing coord: a model-grounded coordinate still wins.
+        if stop.latitude is None:
+            stop.latitude = details.latitude
+        if stop.longitude is None:
+            stop.longitude = details.longitude
 
         when = stop.arrival_time or state.constraints.when
         if when is None:

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -220,7 +220,20 @@ def build_agent_graph(
         last = state.messages[-1] if state.messages else None
         finalizing = isinstance(last, AIMessage) and not last.tool_calls
 
-        if finalizing and state.stops:
+        # A successful commit_itinerary IS a finalization signal. Without
+        # this, termination depends on the model voluntarily emitting a
+        # tool-call-free message after committing — gpt-4o-mini doesn't, so
+        # it burns every step "improving" the plan until short_circuit
+        # overwrites it with the canned step-limit error (3/3 live repros).
+        # Run the same deterministic gauntlet as a model-driven finalize:
+        # if hard checks pass it ends here; if they fail, that path drives
+        # the normal revision loop (done=False + revision HumanMessage), so
+        # legitimate self-correction is preserved.
+        committed_this_step = any(
+            entry.get("step") == state.step_count - 1
+            for entry in state.scratch.get(COMMIT_ITINERARY_TOOL_NAME, [])
+        )
+        if (finalizing or committed_this_step) and state.stops:
             return critique_final_with_stops(state, last, judge_llm)
         if finalizing:
             return finalize_as_is(state, last)

--- a/app/agent/revision.py
+++ b/app/agent/revision.py
@@ -192,11 +192,37 @@ def _last_ai_content(last: BaseMessage | None) -> str:
     return last.content if isinstance(last, AIMessage) and isinstance(last.content, str) else ""
 
 
+def summarize_stops(state: ItineraryState) -> str:
+    """Deterministic user-facing summary built from committed stops.
+
+    The graph finalizes the moment a commit passes the hard checks (so the
+    model can't over-loop), which means the model never narrates the plan
+    itself. Synthesize the summary from the stops instead — same arrival +
+    duration contract the OUTPUT FORMAT prompt asked the model for, minus the
+    extra LLM turn and its latency.
+    """
+    lines = []
+    for i, s in enumerate(state.stops, 1):
+        when = s.arrival_time.strftime("%-I:%M %p").lstrip("0") if s.arrival_time else None
+        timing = f" — arrive {when}, ~{s.planned_duration_min} min" if when else ""
+        rationale = f" {s.rationale}" if s.rationale else ""
+        lines.append(f"{i}. {s.name}{timing}.{rationale}".rstrip())
+    body = "\n".join(lines)
+    return f"Here's your itinerary:\n{body}" if body else ""
+
+
 def short_circuit_max_steps(state: ItineraryState) -> dict[str, Any]:
+    if state.final_reply:
+        return {"done": True, "final_reply": state.final_reply}
+    # Defense-in-depth: the finalize-on-commit routing should make reaching
+    # the step ceiling with committed stops impossible. But if a future model
+    # finds a new way to over-loop, a committed plan must never surface to the
+    # user as "I hit the step limit" — render the stops we actually have.
+    if state.stops:
+        return {"done": True, "final_reply": summarize_stops(state)}
     return {
         "done": True,
-        "final_reply": state.final_reply
-        or "I hit the planning step limit. Here is the best plan I had so far.",
+        "final_reply": "I hit the planning step limit. Here is the best plan I had so far.",
     }
 
 
@@ -257,7 +283,12 @@ def critique_final_with_stops(
             "done": False,
         }
 
-    return {"done": True, "final_reply": state.final_reply or last_content}
+    # last_content is empty when we finalized on a commit (the last message
+    # is the commit tool call, not a model narration) — synthesize instead.
+    return {
+        "done": True,
+        "final_reply": state.final_reply or last_content or summarize_stops(state),
+    }
 
 
 def critique_step(state: ItineraryState) -> dict[str, Any]:

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -160,6 +160,86 @@ async def test_graph_respects_max_steps(monkeypatch) -> None:
     assert out["final_reply"]
 
 
+async def test_graph_finalizes_on_commit_even_if_llm_keeps_calling_tools(
+    monkeypatch, mocker
+) -> None:
+    """Root-cause regression: a model that commits a valid itinerary and then
+    keeps calling tools (instead of voluntarily emitting a tool-call-free
+    final message) must still finalize on the successful commit. Before the
+    fix, the graph looped back to `plan` after commit and burned every step
+    until `short_circuit_max_steps` overwrote the good plan with the canned
+    "I hit the planning step limit." message. gpt-4o-mini does this
+    deterministically on multi-stop queries (3/3 live repros)."""
+    # Hard checks pass so the commit is accepted as final (no revision loop).
+    mocker.patch("app.agent.revision.itinerary_violations", return_value=[])
+    monkeypatch.setattr("app.agent.tools._semantic_search", lambda **_kw: [])
+
+    commit_call = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "commit_itinerary",
+                "id": "commit-1",
+                "args": {
+                    "stops": [
+                        {
+                            "place_id": "p0",
+                            "name": "Place p0",
+                            "rationale": "omakase",
+                            "source": "google_places",
+                        }
+                    ]
+                },
+            }
+        ],
+    )
+    # After committing, the broken model keeps "improving" forever.
+    keep_searching = [
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "semantic_search", "id": f"s{i}", "args": {"query": "x"}}],
+        )
+        for i in range(20)
+    ]
+    fake = _make_fake([commit_call, *keep_searching])
+    graph = build_agent_graph(fake, max_steps=8)
+
+    # p0 must be grounded via a prior tool result or commit_stops rejects it
+    # (mirrors production: the agent searches before it commits).
+    grounded_scratch = {
+        "semantic_search": [
+            {
+                "args": {},
+                "result": [
+                    PlaceHit(
+                        place_id="p0",
+                        name="Place p0",
+                        source="google_places",
+                        similarity=0.9,
+                    )
+                ],
+                "step": 0,
+                "id": "s0",
+            }
+        ]
+    }
+    with _patch_details_many_for(["p0"]):
+        out = await graph.ainvoke(
+            ItineraryState(
+                messages=[HumanMessage(content="omakase date night, 1 stop")],
+                constraints=UserConstraints(num_stops=1),
+                scratch=grounded_scratch,
+            )
+        )
+
+    assert out["done"] is True
+    assert out["stops"], "the committed stop must survive"
+    assert out["stops"][0].place_id == "p0"
+    # The bug's signature: step limit reached + canned error despite a good plan.
+    assert out["step_count"] < 8, "must finalize on commit, not exhaust steps"
+    assert "step limit" not in (out["final_reply"] or "").lower()
+
+
 async def test_graph_handles_unknown_tool_name(monkeypatch) -> None:
     fake = _make_fake(
         [

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -44,6 +44,8 @@ def _rich_details_for(place_id: str) -> PlaceDetails:
         formatted_address=f"{place_id} Main St, San Francisco",
         rating=4.4,
         price_level="PRICE_LEVEL_MODERATE",
+        latitude=37.785,
+        longitude=-122.404,
     )
 
 
@@ -618,6 +620,65 @@ def test_enrich_populates_card_fields_from_details() -> None:
     assert stops[0].address == "p1 Main St, San Francisco"
     assert stops[0].rating == 4.4
     assert stops[0].price_level == 2
+
+
+def test_enrich_backfills_coordinates_when_stop_has_none() -> None:
+    """The LLM commits stops without coordinates (optional in the prompt),
+    so without this backfill every stop is lat=lng=None -> the frontend's
+    `routable` filter drops them all -> no map pins, no route line. The DB
+    details already carry lat/lng; enrichment must copy them onto the stop."""
+    stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
+        return BookingProposal(place_id=details.place_id, provider="tock", booking_url="https://x")
+
+    with (
+        patch(
+            "app.agent.commit.get_details_many",
+            return_value={"p1": _rich_details_for("p1")},
+        ),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
+    ):
+        enrich_stops_with_booking(stops, state)
+
+    assert stops[0].latitude == 37.785
+    assert stops[0].longitude == -122.404
+
+
+def test_enrich_does_not_overwrite_llm_supplied_coordinates() -> None:
+    """If the model DID ground a coordinate from a tool result and committed
+    it, that wins — enrichment only fills a missing (None) coordinate."""
+    stops = [
+        Stop(
+            place_id="p1",
+            name="A",
+            rationale="r",
+            source="google_places",
+            latitude=37.111,
+            longitude=-122.999,
+        )
+    ]
+    state = ItineraryState(
+        constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
+    )
+
+    def fake_build(details: PlaceDetails, when: datetime, party_size: int) -> BookingProposal:
+        return BookingProposal(place_id=details.place_id, provider="tock", booking_url="https://x")
+
+    with (
+        patch(
+            "app.agent.commit.get_details_many",
+            return_value={"p1": _rich_details_for("p1")},
+        ),
+        patch("app.agent.commit.propose_booking_from_details", side_effect=fake_build),
+    ):
+        enrich_stops_with_booking(stops, state)
+
+    assert stops[0].latitude == 37.111
+    assert stops[0].longitude == -122.999
 
 
 def test_enrich_card_fields_set_even_when_no_booking_time() -> None:

--- a/tests/unit/test_agent_self_correct_functional.py
+++ b/tests/unit/test_agent_self_correct_functional.py
@@ -261,9 +261,11 @@ async def test_step_then_itinerary_critique_compose_end_to_end(monkeypatch) -> N
                     }
                 ],
             ),
-            # 4) finalize attempt — triggers per-itinerary geographic check fail
-            AIMessage(content="here's the plan", tool_calls=[]),
-            # 5) revised commit_itinerary after the [critique:itinerary] hint
+            # 4) revised commit_itinerary, driven by the geographic-coherence
+            # revision hint that commit #1 triggered. Finalize-on-commit means
+            # there is no separate "here's the plan" narration turn between
+            # commits, and no final narration turn after: the graph ends the
+            # moment this revised commit passes the hard checks.
             AIMessage(
                 content="",
                 tool_calls=[
@@ -289,8 +291,6 @@ async def test_step_then_itinerary_critique_compose_end_to_end(monkeypatch) -> N
                     }
                 ],
             ),
-            # 6) finalize for real
-            AIMessage(content="revised plan", tool_calls=[]),
         ]
     )
     graph = build_agent_graph(fake, max_steps=10)
@@ -305,6 +305,9 @@ async def test_step_then_itinerary_critique_compose_end_to_end(monkeypatch) -> N
     assert reasons == ["empty_results", "geographic_incoherence"]
     # Stops survived both revisions.
     assert len(out["stops"]) == 2
-    # The final reply came from the LLM's revised finalize message — not a caveat.
-    assert out["final_reply"] == "revised plan"
+    # Finalize-on-commit: the reply is synthesized from the committed stops
+    # (the model no longer narrates), and the revised plan passed clean so
+    # there is no caveat.
+    assert out["final_reply"].startswith("Here's your itinerary:")
+    assert "P1" in out["final_reply"] and "P2" in out["final_reply"]
     assert "Caveats:" not in (out["final_reply"] or "")

--- a/tests/unit/test_chat_functional.py
+++ b/tests/unit/test_chat_functional.py
@@ -110,6 +110,9 @@ def test_chat_runs_real_graph_with_tool_call(monkeypatch, mocker) -> None:
                 }
             ],
         ),
+        # Obsolete under finalize-on-commit: the graph ends at the passing
+        # commit above, so this narration turn is never reached. Kept only to
+        # show the model would have stopped here anyway.
         AIMessage(content="Try Trick Dog.", tool_calls=[]),
     ]
     fake_llm = _ScriptedLLM(scripted=list(scripted))
@@ -128,7 +131,10 @@ def test_chat_runs_real_graph_with_tool_call(monkeypatch, mocker) -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert body["reply"] == "Try Trick Dog."
+    # Finalize-on-commit: reply is synthesized from the committed stop, not
+    # the model's narration turn.
+    assert body["reply"].startswith("Here's your itinerary:")
+    assert "Trick Dog" in body["reply"]
     assert body["ragLabel"] == "openai:gpt-4o-mini"
     assert len(body["places"]) == 1
     assert body["places"][0]["place_id"] == "p1"
@@ -326,7 +332,10 @@ def test_chat_retiming_flips_temporal_pass_to_fail(monkeypatch, mocker) -> None:
 
     assert "Caveats" in body["reply"]
     assert "temporal_coherence" in body["reply"]
-    assert body["reply"].startswith("Bar One then Bar Two.")
+    # Finalize-on-commit: base reply is synthesized from the stops, then the
+    # retime caveat is appended once.
+    assert body["reply"].startswith("Here's your itinerary:")
+    assert "Bar One" in body["reply"] and "Bar Two" in body["reply"]
     assert body["reply"].count("Caveats:") == 1
 
 
@@ -357,4 +366,6 @@ def test_chat_directions_failure_keeps_haversine_reply(monkeypatch, mocker) -> N
     assert resp.status_code == 200
     body = resp.json()
     assert "Caveats" not in body["reply"]
-    assert body["reply"] == "Bar One then Bar Two."
+    # Finalize-on-commit: reply synthesized from stops, no caveat (clean pass).
+    assert body["reply"].startswith("Here's your itinerary:")
+    assert "Bar One" in body["reply"] and "Bar Two" in body["reply"]


### PR DESCRIPTION
## Problem
`/chat` returned **"I hit the planning step limit. Here is the best plan I had so far."** even on gpt-4o-mini (prod). Reproduced **3/3** with an explicit multi-stop query (e.g. "plan a 3-stop omakase date night…"). The plan was actually committed (`places: 3`) but the canned error overwrote the summary.

## Root cause (architectural)
A successful `commit_itinerary` did **not** terminate the graph. `commit_stops` set `state.stops` but not `state.done`; the committing AIMessage has tool_calls so `finalizing=False` → loops back to `plan`. Termination depended on the model *voluntarily* emitting a tool-call-free message next. gpt-4o-mini doesn't — it keeps "improving" until `max_steps=8`, then `short_circuit_max_steps` overwrites the good plan with the error.

This is the real mechanism behind the known "gpt-4o-mini converges ~1/6" / "latency not capability" observations — **not** model quality, **not** the MLflow gemini alias.

## Fix
- `graph.py` `critique()`: detect `committed_this_step` (newest `scratch["commit_itinerary"]` entry's step == current) and route to the existing `critique_final_with_stops`. Self-correction loop preserved (failed hard check → revision, unchanged).
- `revision.py`: new `summarize_stops()` — finalize-on-commit means the model never narrates, so the reply is synthesized deterministically (name + arrival + duration + rationale). Also used as the `short_circuit_max_steps` defense-in-depth backstop, so committed stops can never again surface as the error.

## Verification
- Failing query: **3/3 → 0/3** step-limit errors on the live gpt-4o-mini backend; real itineraries returned.
- **470/470** unit tests pass. Lint + mypy clean.
- Updated tests that encoded the old protocol (model narrates final reply): `test_agent_self_correct_functional`, `test_chat_functional`. Intent preserved; only reply-shape assertions changed. New regression test in `test_agent_graph` reproduces the exact bug.

## Note
Backend must be **restarted** to load this (graph built once at startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)