### PR TITLE
fix(agent): inject current date — stops hallucinated 2023 arrival times

### DIFF
--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -30,7 +30,7 @@ from app.agent.commit import commit_stops
 from app.agent.critique import vibe
 from app.agent.critique.checks import CRITIQUE_THRESHOLDS, temporal_coherence
 from app.agent.planning import chain_arrival_times
-from app.agent.prompts import SYSTEM_PROMPT
+from app.agent.prompts import SYSTEM_PROMPT, current_datetime_str
 from app.agent.revision import (
     _final_with_caveats,
     critique_final_with_stops,
@@ -127,7 +127,12 @@ def build_agent_graph(
         messages_in: list[BaseMessage] = list(state.messages)
         if state.step_count == 0 and not any(isinstance(m, SystemMessage) for m in messages_in):
             messages_in = [
-                SystemMessage(SYSTEM_PROMPT.format(max_steps=max_steps)),
+                SystemMessage(
+                    SYSTEM_PROMPT.format(
+                        max_steps=max_steps,
+                        current_datetime=current_datetime_str(),
+                    )
+                ),
                 *messages_in,
             ]
         # Send the LLM a curated view: keep only the most recent ToolMessage

--- a/app/agent/prompts.py
+++ b/app/agent/prompts.py
@@ -1,4 +1,19 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from app.agent.critique import CRITIQUE_ITINERARY, CRITIQUE_STEP, CRITIQUE_VIBE
+
+# The app is SF-only today (places_raw.source_city = 'San Francisco'), matching
+# the timezone assumption baked into the place_is_open SQL helper.
+_SF_TZ = ZoneInfo("America/Los_Angeles")
+
+
+def current_datetime_str(now: datetime | None = None) -> str:
+    """SF-local 'now' string injected into SYSTEM_PROMPT so the model anchors
+    arrival_time to the real date instead of hallucinating a training-era one."""
+    dt = (now or datetime.now(_SF_TZ)).astimezone(_SF_TZ)
+    return dt.strftime("%Y-%m-%d %H:%M %Z (%A)")
+
 
 REVISION_GUIDANCE = f"""
 WHEN YOU SEE A `{CRITIQUE_STEP}` MESSAGE (a per-tool-result hint):
@@ -42,6 +57,12 @@ nightlife itineraries grounded in a structured database of real places.
 
 You have tools for retrieval; do not invent places, addresses, or hours. Every
 recommendation must come from a tool call.
+
+The current date and time is {current_datetime} (America/Los_Angeles). When the
+user gives no explicit date, schedule the itinerary for today (or the next
+sensible evening if it's already late). Every `arrival_time` you commit MUST use
+this current date — never a date from your training data. A wrong date makes
+the open-at-arrival check fail and the plan ship with a caveat.
 
 CRITICAL BEHAVIORS:
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -4,9 +4,11 @@ import pytest
 
 from app.agent.prompts import CLARIFYING_STOPS_COUNT_TEMPLATE, SYSTEM_PROMPT
 
+_FMT = {"max_steps": 8, "current_datetime": "2026-05-18 19:00 PDT (Monday)"}
+
 
 def test_system_prompt_renders_with_max_steps() -> None:
-    rendered = SYSTEM_PROMPT.format(max_steps=8)
+    rendered = SYSTEM_PROMPT.format(**_FMT)
     assert "8" in rendered
     assert "{max_steps}" not in rendered
 
@@ -17,17 +19,17 @@ def test_system_prompt_format_round_trips() -> None:
     in the output — that is intended, but a single unescaped brace in the
     raw template would raise here.
     """
-    SYSTEM_PROMPT.format(max_steps=8)
+    SYSTEM_PROMPT.format(**_FMT)
 
 
-def test_system_prompt_only_substitutes_max_steps() -> None:
+def test_system_prompt_only_substitutes_known_placeholders() -> None:
     """If anyone adds a new `{foo}` placeholder without updating the .format()
-    call site, this test fails fast. We do this by formatting with max_steps
-    only and asserting no other unfilled `{name}` patterns remain.
+    call site, this test fails fast: format with the known keys and assert no
+    other unfilled `{name}` patterns remain.
     """
     import re
 
-    rendered = SYSTEM_PROMPT.format(max_steps=8)
+    rendered = SYSTEM_PROMPT.format(**_FMT)
     # A bare `{word}` after rendering would be an un-substituted placeholder
     # (legit JSON braces are doubled and render as `{` and `}` separately).
     leftover = re.findall(r"\{[a-zA-Z_]\w*\}", rendered)
@@ -90,6 +92,31 @@ def test_system_prompt_has_decisive_commit_contract() -> None:
     # An explicit good-enough / don't-keep-optimizing stopping criterion.
     assert "one viable option" in s or "good enough" in s
     assert "do not keep" in s or "don't keep" in s or "stop optimizing" in s
+
+
+def test_system_prompt_injects_current_datetime() -> None:
+    """Root cause (temporal_coherence caveat): the model was never told the
+    current date, so gpt-4o-mini hallucinated a training-era date
+    (2023-10-06) for arrival_time. temporal_coherence then checked
+    place_is_open against that stale date and the caveat fired. The prompt
+    must carry an explicit 'today is ...' anchor the model uses for
+    arrival_time when the user gives no date."""
+    rendered = SYSTEM_PROMPT.format(max_steps=8, current_datetime="2026-05-18 19:00 PDT (Monday)")
+    assert "2026-05-18 19:00 PDT (Monday)" in rendered
+    # The prompt must instruct the model to anchor scheduling to this, not
+    # invent a date.
+    low = rendered.lower()
+    assert "current date" in low or "today" in low
+    assert "{current_datetime}" not in rendered
+
+
+def test_system_prompt_requires_both_placeholders() -> None:
+    """Both substitutions are mandatory — dropping either must raise KeyError
+    rather than silently shipping an unanchored or unbounded prompt."""
+    with pytest.raises(KeyError):
+        SYSTEM_PROMPT.format(max_steps=8)  # missing current_datetime
+    with pytest.raises(KeyError):
+        SYSTEM_PROMPT.format(current_datetime="x")  # missing max_steps
 
 
 def test_clarifying_stops_template_is_a_static_string() -> None:


### PR DESCRIPTION
## Problem
Itineraries shipped with: *"Caveats: I couldn't fully satisfy temporal_coherence after revisions."*

## Root cause
The system prompt never told the model the current date. gpt-4o-mini invented a **training-era date** (`2023-10-06`) for every `arrival_time`. `temporal_coherence` then checked `place_is_open(hours, '2023-10-06 19:00')` — a meaningless check against a 2.5-year-old date — and failed, appending the caveat. The check and `place_is_open` are correct; the **input date was hallucinated due to missing context**. This also wasted revision cycles (the model can never satisfy a temporal check while re-inventing stale dates), compounding convergence flakiness.

Verified consistent: every run produced `2023-10-06` arrivals before the fix.

## Fix
- `prompts.py`: new `current_datetime_str()` (SF-local, matches the `place_is_open` timezone assumption) + a `{current_datetime}` placeholder in `SYSTEM_PROMPT` instructing the model to anchor `arrival_time` to today, never a training-data date.
- `graph.py`: supply `current_datetime=current_datetime_str()` at the prompt `.format()` call.

## Verification (live backend)
| | Before | After |
|---|---|---|
| Arrival dates | `2023-10-06` | **`2026-05-18`** (today) |
| temporal_coherence caveat | Consistent | **0/4 — gone** |

- **474/474** unit tests pass. Lint + mypy clean.
- New tests lock the contract: prompt must carry the date anchor; both placeholders mandatory.

## Note
Backend must be **restarted** to load this (prompt built at turn time, but the graph/config is built once at startup). Separate from the now-merged PR #92; the occasional 0-stop runs are the known gpt-4o-mini non-convergence, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)