### PR TITLE
Closure-aware itinerary swap + agent reliability fixes

### DIFF
--- a/app/agent/commit.py
+++ b/app/agent/commit.py
@@ -116,6 +116,8 @@ def enrich_stops_with_booking(stops: list[Stop], state: ItineraryState) -> None:
 
         # Card fields do NOT depend on a booking time — stamp them before the
         # `when is None` skip so a timeless stop still renders a full card.
+        stop.name = details.name
+        stop.primary_type = details.primary_type
         stop.address = details.formatted_address
         stop.rating = details.rating
         stop.price_level = price_level_to_rank(details.price_level)

--- a/app/agent/critique/checks.py
+++ b/app/agent/critique/checks.py
@@ -22,6 +22,7 @@ _log = logging.getLogger(__name__)
 CRITIQUE_THRESHOLDS: dict[str, float] = {
     "constraints_satisfied": 0.8,
     "geographic_coherence": 1.0,
+    "stop_count_satisfied": 1.0,
     "temporal_coherence": 1.0,
     "walking_budget_respected": 1.0,
     "no_hallucinated_place_ids": 1.0,
@@ -40,6 +41,14 @@ def no_hallucinated_place_ids(state: ItineraryState) -> float:
         )
         found = {row[0] for row in cur.fetchall()}
     return 1.0 if all(p in found for p in pids) else 0.0
+
+
+def stop_count_satisfied(state: ItineraryState) -> float:
+    """1.0 iff an explicit requested stop count matches committed stops."""
+    requested = state.constraints.num_stops
+    if requested is None:
+        return 1.0
+    return 1.0 if len(state.stops) == requested else 0.0
 
 
 def temporal_coherence(state: ItineraryState) -> float:
@@ -198,8 +207,11 @@ def itinerary_violations(state: ItineraryState) -> list[str]:
             failed.append(name)
 
     # Order matters: hallucinated_place_ids comes first because every other
-    # check assumes the place_ids are real.
+    # check assumes the place_ids are real. Stop count comes next because a
+    # partially rejected commit is not a complete itinerary even if every
+    # committed place is individually valid.
     _try("no_hallucinated_place_ids", no_hallucinated_place_ids)
+    _try("stop_count_satisfied", stop_count_satisfied)
     _try("temporal_coherence", temporal_coherence)
     _try("geographic_coherence", geographic_coherence)
     _try("walking_budget_respected", walking_budget_respected)

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -22,7 +22,7 @@ import logging
 from typing import Any, Literal
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, StateGraph
 from pydantic import BaseModel
 
@@ -46,6 +46,51 @@ logger = logging.getLogger(__name__)
 
 
 _RECENT_TOOL_EXCHANGES_KEPT = 2
+_EXPLICIT_STOP_COUNT_RETRY_KEY = "explicit_num_stops_clarification"
+
+
+def _constraints_context(state: ItineraryState) -> str:
+    """Human-readable deterministic constraints appended to the system prompt."""
+    if state.constraints.num_stops is None:
+        return ""
+    return (
+        "\n\nDETERMINISTIC REQUEST CONTEXT:\n"
+        f"- The user explicitly requested {state.constraints.num_stops} stops. "
+        "Do not ask how many stops they want; plan exactly that many stops."
+    )
+
+
+def _retry_unnecessary_stop_count_clarification(
+    state: ItineraryState,
+) -> dict[str, Any] | None:
+    """One-shot nudge when the user gave an explicit count but the model
+    finalized without any stops. The trigger is structural — no stops
+    committed plus no tool calls (the call site is the `finalizing` branch
+    of critique) — not lexical. An earlier string-match version missed
+    non-stereotyped clarifying phrasings like "what vibe are you going for?"
+    while still gating retries to one per turn via revision_counts."""
+    num_stops = state.constraints.num_stops
+    if num_stops is None:
+        return None
+    if state.stops:
+        return None
+    if state.revision_counts.get(_EXPLICIT_STOP_COUNT_RETRY_KEY, 0) > 0:
+        return None
+    counts = dict(state.revision_counts)
+    counts[_EXPLICIT_STOP_COUNT_RETRY_KEY] = 1
+    return {
+        "revision_counts": counts,
+        "messages": [
+            HumanMessage(
+                content=(
+                    f"The user already specified {num_stops} stops. "
+                    "Do not ask how many stops; use retrieval tools and plan exactly "
+                    f"{num_stops} stops now."
+                )
+            )
+        ],
+        "done": False,
+    }
 
 
 def _prune_for_llm(messages: list[BaseMessage]) -> list[BaseMessage]:
@@ -132,6 +177,7 @@ def build_agent_graph(
                         max_steps=max_steps,
                         current_datetime=current_datetime_str(),
                     )
+                    + _constraints_context(state)
                 ),
                 *messages_in,
             ]
@@ -241,6 +287,9 @@ def build_agent_graph(
         if (finalizing or committed_this_step) and state.stops:
             return critique_final_with_stops(state, last, judge_llm)
         if finalizing:
+            retry = _retry_unnecessary_stop_count_clarification(state)
+            if retry is not None:
+                return retry
             return finalize_as_is(state, last)
         return critique_step(state)
 

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -28,17 +28,16 @@ from pydantic import BaseModel
 
 from app.agent.commit import commit_stops
 from app.agent.critique import vibe
-from app.agent.critique.checks import CRITIQUE_THRESHOLDS, temporal_coherence
 from app.agent.planning import chain_arrival_times
 from app.agent.prompts import SYSTEM_PROMPT, current_datetime_str
 from app.agent.revision import (
-    _final_with_caveats,
     critique_final_with_stops,
     critique_step,
     finalize_as_is,
     short_circuit_max_steps,
 )
 from app.agent.state import ItineraryState, Stop
+from app.agent.swap import _inject_closure_exclusions, swap_closed_stops
 from app.agent.tools import COMMIT_ITINERARY_TOOL_NAME, all_tools
 from app.tools.directions import route_legs
 
@@ -50,14 +49,31 @@ _EXPLICIT_STOP_COUNT_RETRY_KEY = "explicit_num_stops_clarification"
 
 
 def _constraints_context(state: ItineraryState) -> str:
-    """Human-readable deterministic constraints appended to the system prompt."""
-    if state.constraints.num_stops is None:
+    """Human-readable deterministic constraints appended to the system prompt.
+
+    Two sources contribute:
+    1. An explicit user-stated stop count (preserved across multi-turn /chat).
+    2. closure_context — every outcome contributes, so refinement turns never
+       re-suggest a place we've already learned is closed. Even after the
+       user accepts a drive alternative, the original closed source must
+       stay excluded.
+    """
+    parts: list[str] = []
+    if state.constraints.num_stops is not None:
+        parts.append(
+            f"- The user explicitly requested {state.constraints.num_stops} stops. "
+            "Do not ask how many stops they want; plan exactly that many stops."
+        )
+    if state.closure_context:
+        names = ", ".join(c.place_name for c in state.closure_context)
+        parts.append(
+            f"- Earlier in this conversation, these places were closed at the planned "
+            f"arrival time and should NOT be re-suggested: {names}. "
+            f"Their place_ids are also excluded from your search-result candidates."
+        )
+    if not parts:
         return ""
-    return (
-        "\n\nDETERMINISTIC REQUEST CONTEXT:\n"
-        f"- The user explicitly requested {state.constraints.num_stops} stops. "
-        "Do not ask how many stops they want; plan exactly that many stops."
-    )
+    return "\n\nDETERMINISTIC REQUEST CONTEXT:\n" + "\n".join(parts)
 
 
 def _retry_unnecessary_stop_count_clarification(
@@ -227,6 +243,13 @@ def build_agent_graph(
                     )
                 )
                 continue
+            # Belt-and-suspenders: merge closure-context exclusions into the
+            # tool args at the SQL layer. The prompt guidance in
+            # _constraints_context is an optimization; this is enforcement.
+            if tc["name"] in ("semantic_search", "nearby", "kg_traverse"):
+                tc["args"] = _inject_closure_exclusions(
+                    tc["name"], tc["args"], state.closure_context
+                )
             try:
                 # psycopg2 + OpenAI are sync; offload to a worker thread so the
                 # event loop stays responsive while the tool blocks on I/O.
@@ -322,30 +345,11 @@ def build_agent_graph(
             # Can't retime — leave the existing stops/reply untouched.
             return {}
 
-        update: dict[str, Any] = {"stops": retimed}
-
-        # Re-run ONLY the open-at-arrival check on the real times. Other
-        # checks (geographic/walking/hallucination) are coord/id-based and
-        # unaffected by re-timing, so re-running them would be wasted work.
-        # temporal_coherence is sync psycopg2 I/O — offload to a thread so
-        # the event loop stays responsive (same pattern as act()).
-        probe = state.model_copy(update={"stops": retimed})
-        try:
-            score = await asyncio.to_thread(temporal_coherence, probe)
-        except Exception:  # noqa: BLE001
-            # Fails open exactly like itinerary_violations(): a DB blip must
-            # not block /chat. Ship the re-timed plan without the re-check.
-            return update
-
-        # Only append a caveat if the revision loop hasn't already shipped
-        # one (the END->retime rewire routes the caveats-exhausted path
-        # through here too; _final_with_caveats is not idempotent, so a
-        # second call would duplicate the identical "Caveats:" paragraph).
-        if score < CRITIQUE_THRESHOLDS["temporal_coherence"]:
-            existing = state.final_reply or ""
-            if "Caveats:" not in existing:
-                update["final_reply"] = _final_with_caveats(existing, ["temporal_coherence"])
-        return update
+        # Closure detection on the real-time arrivals is now the responsibility
+        # of the swap_closed_stops node (next in the graph), which silently
+        # swaps walking-distance alternatives and asks the user about anything
+        # else. retime just supplies the retimed stops.
+        return {"stops": retimed}
 
     def route_after_plan(state: ItineraryState) -> Literal["act", "critique"]:
         last = state.messages[-1]
@@ -361,9 +365,11 @@ def build_agent_graph(
     g.add_node("act", act)
     g.add_node("critique", critique)
     g.add_node("retime", retime)
+    g.add_node("swap_closed_stops", swap_closed_stops)
     g.set_entry_point("plan")
     g.add_conditional_edges("plan", route_after_plan, {"act": "act", "critique": "critique"})
     g.add_edge("act", "critique")
     g.add_conditional_edges("critique", route_after_critique, {"plan": "plan", "retime": "retime"})
-    g.add_edge("retime", END)
+    g.add_edge("retime", "swap_closed_stops")
+    g.add_edge("swap_closed_stops", END)
     return g.compile()

--- a/app/agent/graph.py
+++ b/app/agent/graph.py
@@ -246,14 +246,25 @@ def build_agent_graph(
             # Belt-and-suspenders: merge closure-context exclusions into the
             # tool args at the SQL layer. The prompt guidance in
             # _constraints_context is an optimization; this is enforcement.
+            #
+            # CRITICAL: never reassign `tc["args"]`. `tc` references a dict
+            # INSIDE the AIMessage stored on state.messages — the next plan()
+            # step re-serializes that AIMessage for OpenAI's API via
+            # `json.dumps`, and a Pydantic SearchFilters instance there
+            # crashes with "Object of type SearchFilters is not JSON
+            # serializable". Compute `effective_args` locally instead so the
+            # injected args drive `tool.invoke` and the scratch record while
+            # the AIMessage stays untouched.
             if tc["name"] in ("semantic_search", "nearby", "kg_traverse"):
-                tc["args"] = _inject_closure_exclusions(
+                effective_args = _inject_closure_exclusions(
                     tc["name"], tc["args"], state.closure_context
                 )
+            else:
+                effective_args = tc["args"]
             try:
                 # psycopg2 + OpenAI are sync; offload to a worker thread so the
                 # event loop stays responsive while the tool blocks on I/O.
-                result: Any = await asyncio.to_thread(tool.invoke, tc["args"])
+                result: Any = await asyncio.to_thread(tool.invoke, effective_args)
             except Exception as e:  # noqa: BLE001
                 result = {"error": str(e)}
             new_messages.append(
@@ -261,7 +272,7 @@ def build_agent_graph(
             )
             scratch_updates.setdefault(tc["name"], []).append(
                 {
-                    "args": tc["args"],
+                    "args": effective_args,
                     "result": result,
                     "step": state.step_count,
                     "id": tc["id"],

--- a/app/agent/input_parsing.py
+++ b/app/agent/input_parsing.py
@@ -8,6 +8,8 @@ guardrails when the model tries to ask a question the user already answered.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
+from typing import Protocol
 
 _MAX_EXPLICIT_STOPS = 10
 _STOP_NOUN = r"(?:stop|stops|spot|spots|place|places)"
@@ -28,6 +30,33 @@ _WORD_STOP_RE = re.compile(
     rf"\b({'|'.join(_WORD_TO_INT)})\s*[- ]?\s*{_STOP_NOUN}\b",
     re.IGNORECASE,
 )
+
+
+class _HasRoleContent(Protocol):
+    role: str
+    content: str
+
+
+def explicit_num_stops_from_conversation(
+    history: Iterable[_HasRoleContent], current_message: str
+) -> int | None:
+    """The latest explicit user-stated stop count across the whole turn.
+
+    /chat is stateless — each POST rebuilds ItineraryState — so parsing only
+    `current_message` loses the count on every follow-up turn. Walks history's
+    user messages in order, then the current message; the LAST hit wins so a
+    mid-conversation revision ("actually make it 4") overrides an earlier "3".
+    """
+    latest: int | None = None
+    for m in history:
+        if getattr(m, "role", None) == "user":
+            found = explicit_num_stops_from_text(getattr(m, "content", "") or "")
+            if found is not None:
+                latest = found
+    found = explicit_num_stops_from_text(current_message)
+    if found is not None:
+        latest = found
+    return latest
 
 
 def explicit_num_stops_from_text(text: str) -> int | None:

--- a/app/agent/input_parsing.py
+++ b/app/agent/input_parsing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
-from typing import Protocol
+from typing import Literal, Protocol
 
 _MAX_EXPLICIT_STOPS = 10
 _STOP_NOUN = r"(?:stop|stops|spot|spots|place|places)"
@@ -80,3 +80,33 @@ def explicit_num_stops_from_text(text: str) -> int | None:
         return _WORD_TO_INT[word_match.group(1).lower()]
 
     return None
+
+
+# First-token sets for `parse_closure_decision`. The rule is intentionally
+# conservative: only act when the user's first word reads as a yes/no token,
+# so "yes, make it 4 stops" routes to accept (the count update is handled
+# separately by `explicit_num_stops_from_conversation`) while
+# "find something cheaper" — a question disguised as a hint — routes to
+# alternative for the LLM to interpret in context.
+_ACCEPT_TOKENS: frozenset[str] = frozenset({"yes", "yeah", "yep", "sure", "ok", "okay", "y", "👍"})
+_DECLINE_TOKENS: frozenset[str] = frozenset({"no", "nope", "n", "nah"})
+
+
+def parse_closure_decision(text: str) -> Literal["accept", "decline", "alternative"]:
+    """Conservative parser for a user's reply to a closure question.
+
+    First-token rule resolves "yes + revision" (e.g. "yes! make it 4 stops")
+    unambiguously as accept; the existing `explicit_num_stops_from_conversation`
+    separately handles the count update. Empty / whitespace / questions / free
+    text all bucket to "alternative" (no auto-accept on silence).
+    """
+    if not text or not text.strip():
+        return "alternative"
+    first = text.strip().split()[0].lower()
+    # Strip surrounding punctuation so "Yes!" / "yes," / "ok." also match.
+    stripped = first.strip(".,!?;:\"'()[]{}")
+    if stripped in _ACCEPT_TOKENS or first in _ACCEPT_TOKENS:
+        return "accept"
+    if stripped in _DECLINE_TOKENS or first in _DECLINE_TOKENS:
+        return "decline"
+    return "alternative"

--- a/app/agent/input_parsing.py
+++ b/app/agent/input_parsing.py
@@ -31,6 +31,23 @@ _WORD_STOP_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Detects "the assistant just asked a how-many-stops question."
+# Conservative — requires both an interrogative phrase ("how many") and a
+# stop-noun nearby, so a stray "how many drinks?" or a comment like
+# "I'd want 3 stops" doesn't activate the bare-number capture below.
+_ASSISTANT_STOPS_QUESTION_RE = re.compile(
+    rf"how\s+many\s+\w*\s*{_STOP_NOUN}\b",
+    re.IGNORECASE,
+)
+
+# Bare-integer or bare-word-integer in [1, _MAX_EXPLICIT_STOPS]. Used only
+# when the prior assistant turn was a stops-count question.
+_BARE_NUMBER_RE = re.compile(r"^\s*([1-9]|10)\s*[.!]?\s*$")
+_BARE_WORD_NUMBER_RE = re.compile(
+    rf"^\s*({'|'.join(_WORD_TO_INT)})\s*[.!]?\s*$",
+    re.IGNORECASE,
+)
+
 
 class _HasRoleContent(Protocol):
     # Read-only attribute protocol so concrete classes with narrower types
@@ -50,17 +67,59 @@ def explicit_num_stops_from_conversation(
     `current_message` loses the count on every follow-up turn. Walks history's
     user messages in order, then the current message; the LAST hit wins so a
     mid-conversation revision ("actually make it 4") overrides an earlier "3".
+
+    Bare-number fallback (current_message only): if the prior assistant turn
+    was clearly a how-many-stops question (e.g. "How many stops would you
+    like?") and the current message is a bare integer or bare word-integer
+    (e.g. "3", "three", "3.", "Three!"), treat it as the count. This
+    closes the gap where gpt-4o-mini asked the count question and the user
+    replied with just a number — without it, no count guardrail kicks in
+    and the model can over-loop into the step-limit short-circuit. The
+    bare-number rule applies ONLY to the current message, not to history,
+    because old assistant turns are no longer the prompt at the front of
+    the model's attention.
     """
+    history_list = list(history)
     latest: int | None = None
-    for m in history:
+    for m in history_list:
         if getattr(m, "role", None) == "user":
             found = explicit_num_stops_from_text(getattr(m, "content", "") or "")
             if found is not None:
                 latest = found
     found = explicit_num_stops_from_text(current_message)
     if found is not None:
-        latest = found
+        return found
+    # Bare-number fallback: only activate if the LAST assistant turn (the
+    # one the user is replying to) was a how-many-stops question.
+    last_assistant = next(
+        (
+            getattr(m, "content", "") or ""
+            for m in reversed(history_list)
+            if getattr(m, "role", None) == "assistant"
+        ),
+        None,
+    )
+    if last_assistant and _ASSISTANT_STOPS_QUESTION_RE.search(last_assistant):
+        bare = _parse_bare_count(current_message)
+        if bare is not None:
+            return bare
     return latest
+
+
+def _parse_bare_count(text: str) -> int | None:
+    """Bare digit / word number in [1, 10], or None.
+
+    Anchored match (`^...$`): "3 places" doesn't qualify (the noun-based
+    parser handles that); only standalone numbers or word-numbers.
+    """
+    m = _BARE_NUMBER_RE.match(text)
+    if m:
+        value = int(m.group(1))
+        return value if 1 <= value <= _MAX_EXPLICIT_STOPS else None
+    m = _BARE_WORD_NUMBER_RE.match(text)
+    if m:
+        return _WORD_TO_INT[m.group(1).lower()]
+    return None
 
 
 def explicit_num_stops_from_text(text: str) -> int | None:

--- a/app/agent/input_parsing.py
+++ b/app/agent/input_parsing.py
@@ -33,8 +33,12 @@ _WORD_STOP_RE = re.compile(
 
 
 class _HasRoleContent(Protocol):
-    role: str
-    content: str
+    # Read-only attribute protocol so concrete classes with narrower types
+    # (e.g. ChatMessage with role: Literal["user", "assistant"]) still match.
+    @property
+    def role(self) -> str: ...
+    @property
+    def content(self) -> str: ...
 
 
 def explicit_num_stops_from_conversation(

--- a/app/agent/input_parsing.py
+++ b/app/agent/input_parsing.py
@@ -1,0 +1,49 @@
+"""Lightweight deterministic parsing for user constraints.
+
+This is deliberately conservative. The LLM still owns nuanced interpretation;
+these helpers only extract constraints that are explicit enough to use as
+guardrails when the model tries to ask a question the user already answered.
+"""
+
+from __future__ import annotations
+
+import re
+
+_MAX_EXPLICIT_STOPS = 10
+_STOP_NOUN = r"(?:stop|stops|spot|spots|place|places)"
+_DIGIT_STOP_RE = re.compile(rf"\b([1-9]|10)\s*[- ]?\s*{_STOP_NOUN}\b", re.IGNORECASE)
+_WORD_TO_INT: dict[str, int] = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+}
+_WORD_STOP_RE = re.compile(
+    rf"\b({'|'.join(_WORD_TO_INT)})\s*[- ]?\s*{_STOP_NOUN}\b",
+    re.IGNORECASE,
+)
+
+
+def explicit_num_stops_from_text(text: str) -> int | None:
+    """Return an explicit stop count from user text, if one is stated.
+
+    Examples matched: "3-stop", "3 stops", "three spots". Counts above 10
+    are intentionally ignored because the current itinerary agent is optimized
+    for small walking plans, not all-day route generation.
+    """
+    digit_match = _DIGIT_STOP_RE.search(text)
+    if digit_match:
+        value = int(digit_match.group(1))
+        return value if 1 <= value <= _MAX_EXPLICIT_STOPS else None
+
+    word_match = _WORD_STOP_RE.search(text)
+    if word_match:
+        return _WORD_TO_INT[word_match.group(1).lower()]
+
+    return None

--- a/app/agent/prompts.py
+++ b/app/agent/prompts.py
@@ -37,6 +37,10 @@ WHEN YOU SEE A `{CRITIQUE_ITINERARY}` MESSAGE (a post-commit_itinerary hint):
   start time, then re-call commit_itinerary.
 - "constraint_unmet_in_final": a stop violates the user's shared constraints
   (price, rating, neighborhood). Swap the offending stop and re-commit.
+- "stop_count_mismatch": the committed itinerary has the wrong number of
+  stops. Suggested action `add_missing_stops` means search for more places
+  and re-call commit_itinerary with the full set; `remove_extra_stops` means
+  re-call commit_itinerary with exactly the requested number.
 - "hallucinated_place_id": one or more committed place_ids don't exist in
   the DB. Only commit place_ids you've seen in a tool result.
 

--- a/app/agent/revision.py
+++ b/app/agent/revision.py
@@ -16,7 +16,7 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMe
 
 from app.agent.critique import CRITIQUE_ITINERARY, CRITIQUE_STEP, CRITIQUE_VIBE, vibe
 from app.agent.critique.checks import itinerary_violations
-from app.agent.state import ItineraryState, RevisionHint
+from app.agent.state import ItineraryState, RevisionAction, RevisionHint
 
 LOW_SIMILARITY_THRESHOLD = 0.55
 MAX_REVISIONS_PER_REASON = 2
@@ -161,6 +161,29 @@ def _hint_for_violation(reason: str, state: ItineraryState) -> RevisionHint:
             detail="Total walking exceeds the user's budget.",
             suggested_action="rebalance_walking_budget",
             target={},
+        )
+    if reason == "stop_count_satisfied":
+        # stop_count_satisfied only fails when num_stops is set (the check
+        # returns 1.0 unconditionally otherwise), so requested is guaranteed
+        # non-None whenever this branch executes. Narrow it explicitly so the
+        # type checker can prove the < below is safe.
+        requested = state.constraints.num_stops
+        if requested is None:
+            raise RuntimeError("stop_count_satisfied invariant: num_stops must be set")
+        actual = len(state.stops)
+        detail = (
+            f"The committed itinerary has {actual} stops, but the user requested {requested} stops."
+        )
+        # Direction is load-bearing — telling the model to "add" when it needs
+        # to "remove" is actively misleading. The reason is also distinct from
+        # the generic constraint_unmet_in_final so debugging and revision-hint
+        # logs can tell a count mismatch apart from a per-stop constraint fail.
+        action: RevisionAction = "add_missing_stops" if actual < requested else "remove_extra_stops"
+        return RevisionHint(
+            reason="stop_count_mismatch",
+            detail=detail,
+            suggested_action=action,
+            target={"requested_stops": requested, "actual_stops": actual},
         )
     if reason == "no_hallucinated_place_ids":
         return RevisionHint(

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -151,6 +151,43 @@ class Stop(BaseModel):
     booking_provider: BookingProvider | None = None
 
 
+ClosureOutcome = Literal[
+    "auto_swapped",
+    "user_accepted_drive",
+    "user_declined_dropped",
+    "pending_user_decision",
+    "queued_user_decision",
+]
+
+
+class ClosureContext(BaseModel):
+    """One closure event recorded during a /chat conversation.
+
+    Persisted across turns via the opaque `conversation_state` round-trip on
+    /chat. Placement anchors (`insert_after_place_id` / `insert_before_place_id`)
+    are durable against neighbor drops/inserts because they reference
+    neighboring stops' place_ids rather than indices; `stop_index_hint` is the
+    last-resort fallback used only when both anchors are absent from current
+    stops. Resolution order is documented in
+    `app.agent.swap._resolve_insert_position`.
+    """
+
+    schema_version: int = 1
+    place_id: str
+    place_name: str
+    family: str
+    attempted_arrival: datetime
+    outcome: ClosureOutcome
+    insert_after_place_id: str | None = None
+    insert_before_place_id: str | None = None
+    stop_index_hint: int
+    proposed_alternative: Stop | None = None
+    proposed_distance_m: float | None = None
+
+
+MAX_CLOSURE_CONTEXT_ENTRIES = 10
+
+
 class ItineraryState(BaseModel):
     """The single piece of state passed through every graph node."""
 
@@ -172,6 +209,7 @@ class ItineraryState(BaseModel):
     walked_meters_so_far: float = 0.0
     revision_hints: list[RevisionHint] = Field(default_factory=list)
     revision_counts: dict[str, int] = Field(default_factory=dict)
+    closure_context: list[ClosureContext] = Field(default_factory=list)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/app/agent/state.py
+++ b/app/agent/state.py
@@ -26,6 +26,7 @@ RevisionReason = Literal[
     "temporal_incoherence",
     "walking_budget_exceeded",
     "constraint_unmet_in_final",
+    "stop_count_mismatch",
     "hallucinated_place_id",
     "vibe_mismatch",
 ]
@@ -40,6 +41,8 @@ RevisionAction = Literal[
     "tighten_radius",
     "shift_arrival_time",
     "rebalance_walking_budget",
+    "add_missing_stops",
+    "remove_extra_stops",
 ]
 
 

--- a/app/agent/swap.py
+++ b/app/agent/swap.py
@@ -453,6 +453,57 @@ def _formulate_closure_question(pending: ClosureContext) -> str:
     )
 
 
+def _inject_closure_exclusions(
+    tool_name: str,
+    args: dict[str, Any],
+    closure_context: list[ClosureContext],
+) -> dict[str, Any]:
+    """Merge closure_context place_ids into a tool call's exclusion argument.
+
+    Server-side belt-and-suspenders enforcement so the prompt guidance is an
+    optimization, not the only line of defense. Routes by tool name because
+    the exclusion argument lives in different places per tool:
+
+      - semantic_search / nearby -> args["filters"].excluded_place_ids
+      - kg_traverse              -> args["excluded_place_ids"]  (top-level)
+      - anything else            -> no-op
+
+    Returns a NEW args dict; never mutates the input (the graph.act node
+    records the original args verbatim in scratch for tracing).
+
+    Every closure_context outcome contributes — auto_swapped through
+    pending_user_decision all exclude the source closed place_id. The
+    proposed_alternative.place_id is NOT in this set unless that place was
+    itself later recorded as a closure.
+    """
+    if not closure_context:
+        return dict(args)
+    excluded = {c.place_id for c in closure_context}
+    new_args = dict(args)
+    if tool_name in ("semantic_search", "nearby"):
+        existing_filters = new_args.get("filters")
+        if existing_filters is None:
+            filters = SearchFilters(excluded_place_ids=sorted(excluded))
+        elif isinstance(existing_filters, SearchFilters):
+            llm_excluded = set(existing_filters.excluded_place_ids or [])
+            filters = existing_filters.model_copy(
+                update={"excluded_place_ids": sorted(llm_excluded | excluded)}
+            )
+        else:
+            # LangChain may deliver `filters` as a plain dict; validate it
+            # through SearchFilters so the merged value is type-correct.
+            llm = SearchFilters.model_validate(existing_filters)
+            llm_excluded = set(llm.excluded_place_ids or [])
+            filters = llm.model_copy(update={"excluded_place_ids": sorted(llm_excluded | excluded)})
+        new_args["filters"] = filters
+        return new_args
+    if tool_name == "kg_traverse":
+        llm_excluded = set(new_args.get("excluded_place_ids") or [])
+        new_args["excluded_place_ids"] = sorted(llm_excluded | excluded)
+        return new_args
+    return new_args
+
+
 def _cap_closure_context(entries: list[ClosureContext]) -> list[ClosureContext]:
     """Append-and-drop-oldest to `MAX_CLOSURE_CONTEXT_ENTRIES`."""
     if len(entries) <= MAX_CLOSURE_CONTEXT_ENTRIES:
@@ -629,6 +680,7 @@ __all__ = [
     "_build_closure_context_entry",
     "_execute_closure_query",
     "_formulate_closure_question",
+    "_inject_closure_exclusions",
     "_per_stop_closure_status",
     "_promote_pending",
     "_resolve_anchor",

--- a/app/agent/swap.py
+++ b/app/agent/swap.py
@@ -16,8 +16,10 @@ import logging
 from typing import Any
 
 from psycopg2.extras import RealDictCursor
+from pydantic import BaseModel
 
-from app.agent.state import Stop
+from app.agent.planning import haversine_m
+from app.agent.state import ClosureContext, Stop
 from app.db import get_conn
 
 logger = logging.getLogger(__name__)
@@ -75,7 +77,102 @@ def _per_stop_closure_status(stops: list[Stop]) -> list[bool]:
     return out
 
 
+class CandidateMatch(BaseModel):
+    """Internal record returned by candidate-search helpers."""
+
+    stop: Stop
+    distance_m: float
+    family_match_score: float
+    route_impact_score: float
+    total_score: float
+
+
+# Per-leg walking budget (meters) used as the cutoff for the silent-swap
+# path. ~500m at 80 m/min ≈ a 6-minute walk — close enough that swapping
+# doesn't change the user's experience materially. Anything beyond this
+# escalates to a user question.
+_WALKING_DISTANCE_BUDGET_M: int = 500
+
+# Citywide radius used by the fallback search. SF fits comfortably inside
+# 30 km from any anchor in the city; `nearby()` requires an explicit
+# `radius_m: int` so we pass a large constant rather than introducing a
+# separate citywide function.
+_CITYWIDE_RADIUS_M: int = 30_000
+
+
+def _resolve_insert_position(
+    closure: ClosureContext,
+    stops: list[Stop],
+) -> int:
+    """Where in `stops` should we insert the proposed alternative?
+
+    Priority rules (matches the ClosureContext docstring in state.py):
+      1) insert_after_place_id present in stops -> that index + 1
+      2) else insert_before_place_id present in stops -> that index
+      3) else stop_index_hint, clamped to [0, len(stops)]
+    """
+    by_id = {s.place_id: i for i, s in enumerate(stops)}
+    if closure.insert_after_place_id and closure.insert_after_place_id in by_id:
+        return by_id[closure.insert_after_place_id] + 1
+    if closure.insert_before_place_id and closure.insert_before_place_id in by_id:
+        return by_id[closure.insert_before_place_id]
+    return max(0, min(closure.stop_index_hint, len(stops)))
+
+
+def _score_candidate(
+    candidate: Stop,
+    closed_stop: Stop,
+    prev_stop: Stop | None,
+    next_stop: Stop | None,
+    *,
+    family_match: bool,
+) -> float:
+    """Combined score: higher is better.
+
+    Two components, summed equally weighted:
+      - family_match_score: 1.0 if the candidate is in the same family as
+        the closed stop, else 0.0
+      - route_impact_score: 1 - (haversine prev->candidate + candidate->next)
+        / 2000, clamped to [0, 1]. Inside the walking radius the family
+        bonus dominates any plausible route delta.
+    `closed_stop` is currently informational (the prev/next pair carries the
+    geometry); it's threaded through so future scoring tweaks (e.g.
+    rating/category similarity) have access to it without a signature change.
+    """
+    _ = closed_stop  # reserved for future heuristics (rating/category)
+    fam = 1.0 if family_match else 0.0
+    total_dist_m = 0.0
+    if (
+        prev_stop is not None
+        and prev_stop.latitude is not None
+        and prev_stop.longitude is not None
+        and candidate.latitude is not None
+        and candidate.longitude is not None
+    ):
+        total_dist_m += haversine_m(
+            (prev_stop.latitude, prev_stop.longitude),
+            (candidate.latitude, candidate.longitude),
+        )
+    if (
+        next_stop is not None
+        and next_stop.latitude is not None
+        and next_stop.longitude is not None
+        and candidate.latitude is not None
+        and candidate.longitude is not None
+    ):
+        total_dist_m += haversine_m(
+            (candidate.latitude, candidate.longitude),
+            (next_stop.latitude, next_stop.longitude),
+        )
+    # Linear penalty: 0m -> 1.0, 1000m -> 0.5, 2000m+ -> 0
+    route = max(0.0, 1.0 - total_dist_m / 2000.0)
+    return fam + route
+
+
 __all__ = [
+    "CandidateMatch",
     "_execute_closure_query",
     "_per_stop_closure_status",
+    "_resolve_insert_position",
+    "_score_candidate",
 ]

--- a/app/agent/swap.py
+++ b/app/agent/swap.py
@@ -19,8 +19,11 @@ from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel
 
 from app.agent.planning import haversine_m
-from app.agent.state import ClosureContext, Stop
+from app.agent.state import ClosureContext, ItineraryState, Stop
 from app.db import get_conn
+from app.tools.filters import SearchFilters, family_of
+from app.tools.retrieval import PlaceHit
+from app.tools.retrieval import nearby as _nearby_search  # aliased for test patching
 
 logger = logging.getLogger(__name__)
 
@@ -169,10 +172,190 @@ def _score_candidate(
     return fam + route
 
 
+_VALID_FAMILIES = frozenset({"dessert", "bar", "restaurant", "cafe"})
+
+
+def _resolve_anchor(state: ItineraryState, closed_stop: Stop) -> str | None:
+    """Pick a stable anchor place_id to search around when looking for an
+    alternative to the closed stop.
+
+    Prefer the previous stop; if closed_stop is at index 0, fall back to the
+    next stop; if neither exists, fall back to the closed stop itself (Google
+    returns same-coords neighbors). Returns None only when state.stops is
+    empty (defensive — caller guards against this).
+    """
+    try:
+        idx = state.stops.index(closed_stop)
+    except ValueError:
+        return closed_stop.place_id or None
+    if idx > 0:
+        return state.stops[idx - 1].place_id
+    if idx + 1 < len(state.stops):
+        return state.stops[idx + 1].place_id
+    return closed_stop.place_id or None
+
+
+def _candidates_to_matches(
+    candidates: list[PlaceHit],
+    closed_stop: Stop,
+    state: ItineraryState,
+) -> list[CandidateMatch]:
+    """Score each candidate and sort descending. Family match is computed
+    against the closed stop's primary_type. Each candidate becomes a Stop
+    inheriting the closed stop's arrival_time + planned_duration_min so the
+    chain math stays consistent post-swap.
+    """
+    closed_family = family_of(closed_stop.primary_type)
+    try:
+        idx = state.stops.index(closed_stop)
+    except ValueError:
+        idx = len(state.stops)
+    prev_stop = state.stops[idx - 1] if idx > 0 else None
+    next_stop = state.stops[idx + 1] if idx + 1 < len(state.stops) else None
+
+    matches: list[CandidateMatch] = []
+    for c in candidates:
+        candidate_stop = Stop(
+            place_id=c.place_id,
+            name=c.name,
+            address=c.formatted_address,
+            rating=c.rating,
+            primary_type=c.primary_type,
+            latitude=c.latitude,
+            longitude=c.longitude,
+            arrival_time=closed_stop.arrival_time,
+            planned_duration_min=closed_stop.planned_duration_min,
+            rationale=f"Walking-distance alternative for {closed_stop.name}",
+            source=c.source,
+        )
+        candidate_family = family_of(c.primary_type)
+        family_match = candidate_family is not None and candidate_family == closed_family
+        score = _score_candidate(
+            candidate_stop, closed_stop, prev_stop, next_stop, family_match=family_match
+        )
+        matches.append(
+            CandidateMatch(
+                stop=candidate_stop,
+                distance_m=c.dist_m if c.dist_m is not None else 0.0,
+                family_match_score=1.0 if family_match else 0.0,
+                route_impact_score=score - (1.0 if family_match else 0.0),
+                total_score=score,
+            )
+        )
+    matches.sort(key=lambda m: m.total_score, reverse=True)
+    return matches
+
+
+def _excluded_place_ids_from_state(
+    state: ItineraryState,
+    extra: list[str] | None = None,
+) -> list[str]:
+    """All place_ids the swap node must not re-propose: current stops + every
+    closure_context entry's source place_id + extras.
+
+    Every outcome contributes per spec — once recorded, never re-suggested.
+    Sorted for deterministic SQL params (helps test assertions and pg log
+    correlation).
+    """
+    excluded = {s.place_id for s in state.stops}
+    excluded.update(entry.place_id for entry in state.closure_context)
+    if extra:
+        excluded.update(extra)
+    return sorted(excluded)
+
+
+def _try_walking_distance_swap(
+    state: ItineraryState,
+    closure: ClosureContext,
+    *,
+    anchor_place_id: str,
+) -> CandidateMatch | None:
+    """Search within `_WALKING_DISTANCE_BUDGET_M` for an alternative of the
+    same family that's open at the closed stop's attempted_arrival.
+
+    Returns the highest-scoring match or None if no candidates fit. DB errors
+    return None and log a warning (fail-open: a DB blip won't block the
+    response, it just causes escalation to the user-question path).
+    """
+    closed_stop = next((s for s in state.stops if s.place_id == closure.place_id), None)
+    if closed_stop is None:
+        return None
+    if closure.family not in _VALID_FAMILIES:
+        # Without a resolved family we can't do a category-matched search;
+        # caller escalates to the user-question path.
+        return None
+    excluded = _excluded_place_ids_from_state(state)
+    filters = SearchFilters(
+        primary_type_family=closure.family,  # type: ignore[arg-type]
+        excluded_place_ids=excluded,
+        open_at=closure.attempted_arrival,
+    )
+    try:
+        candidates = _nearby_search(
+            place_id=anchor_place_id,
+            radius_m=_WALKING_DISTANCE_BUDGET_M,
+            filters=filters,
+            k=8,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("closure_swap.db_error during walking-distance search: %s", e)
+        return None
+    if not candidates:
+        return None
+    matches = _candidates_to_matches(candidates, closed_stop, state)
+    if not matches:
+        return None
+    return matches[0]
+
+
+def _try_any_distance_search(
+    state: ItineraryState,
+    closure: ClosureContext,
+    *,
+    anchor_place_id: str,
+) -> CandidateMatch | None:
+    """Citywide fallback — used only to populate the user-facing question's
+    proposed_alternative when the walking-distance pass failed.
+
+    Uses `_CITYWIDE_RADIUS_M` (30 km, covers all of SF). Same family +
+    exclusion rules as walking-distance.
+    """
+    closed_stop = next((s for s in state.stops if s.place_id == closure.place_id), None)
+    if closed_stop is None:
+        return None
+    if closure.family not in _VALID_FAMILIES:
+        return None
+    excluded = _excluded_place_ids_from_state(state)
+    filters = SearchFilters(
+        primary_type_family=closure.family,  # type: ignore[arg-type]
+        excluded_place_ids=excluded,
+        open_at=closure.attempted_arrival,
+    )
+    try:
+        candidates = _nearby_search(
+            place_id=anchor_place_id,
+            radius_m=_CITYWIDE_RADIUS_M,
+            filters=filters,
+            k=5,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("closure_swap.db_error during any-distance search: %s", e)
+        return None
+    if not candidates:
+        return None
+    matches = _candidates_to_matches(candidates, closed_stop, state)
+    if not matches:
+        return None
+    return matches[0]
+
+
 __all__ = [
     "CandidateMatch",
     "_execute_closure_query",
     "_per_stop_closure_status",
+    "_resolve_anchor",
     "_resolve_insert_position",
     "_score_candidate",
+    "_try_any_distance_search",
+    "_try_walking_distance_swap",
 ]

--- a/app/agent/swap.py
+++ b/app/agent/swap.py
@@ -13,14 +13,22 @@ for the architecture rationale and contract details.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel
 
 from app.agent.commit import enrich_stops_with_booking
 from app.agent.planning import chain_arrival_times, haversine_m
-from app.agent.state import ClosureContext, ItineraryState, Stop
+from app.agent.revision import summarize_stops
+from app.agent.state import (
+    MAX_CLOSURE_CONTEXT_ENTRIES,
+    ClosureContext,
+    ItineraryState,
+    Stop,
+)
 from app.db import get_conn
 from app.tools.directions import route_legs
 from app.tools.filters import SearchFilters, family_of
@@ -445,17 +453,189 @@ def _formulate_closure_question(pending: ClosureContext) -> str:
     )
 
 
+def _cap_closure_context(entries: list[ClosureContext]) -> list[ClosureContext]:
+    """Append-and-drop-oldest to `MAX_CLOSURE_CONTEXT_ENTRIES`."""
+    if len(entries) <= MAX_CLOSURE_CONTEXT_ENTRIES:
+        return entries
+    dropped = len(entries) - MAX_CLOSURE_CONTEXT_ENTRIES
+    logger.warning("closure_context.cap_exceeded: dropped %d oldest entries", dropped)
+    return entries[dropped:]
+
+
+def _resolve_family_for_stop(stop: Stop) -> str:
+    """family from primary_type. Returns "" when nothing resolves so the
+    caller can still record the closure (without searching for a swap)."""
+    fam = family_of(stop.primary_type) if stop.primary_type else None
+    return fam or ""
+
+
+def _build_closure_context_entry(
+    stops: list[Stop],
+    closed_index: int,
+    proposed: CandidateMatch | None,
+    outcome: str,
+) -> ClosureContext:
+    """Build a ClosureContext entry for a closed stop at `closed_index`,
+    with stable anchors derived from neighboring stops."""
+    closed = stops[closed_index]
+    insert_after = stops[closed_index - 1].place_id if closed_index > 0 else None
+    insert_before = stops[closed_index + 1].place_id if closed_index + 1 < len(stops) else None
+    return ClosureContext(
+        place_id=closed.place_id,
+        place_name=closed.name,
+        family=_resolve_family_for_stop(closed),
+        attempted_arrival=closed.arrival_time
+        or datetime.fromtimestamp(0, tz=ZoneInfo("America/Los_Angeles")),
+        outcome=outcome,  # type: ignore[arg-type]
+        insert_after_place_id=insert_after,
+        insert_before_place_id=insert_before,
+        stop_index_hint=closed_index,
+        proposed_alternative=proposed.stop if proposed else None,
+        proposed_distance_m=proposed.distance_m if proposed else None,
+    )
+
+
+async def swap_closed_stops(state: ItineraryState) -> dict[str, Any]:
+    """LangGraph node — closure-aware swap pass.
+
+    1. Per-stop closure check on real arrival times.
+    2. For each closed stop, try a walking-distance swap of the same family.
+    3. Auto-swaps batched; one bounded retime + re-check covers all of them.
+    4. Any remaining closures: first becomes pending_user_decision, the rest
+       queued_user_decision. Citywide fallback search populates the pending
+       entry's proposed_alternative when possible.
+    5. Final reply = the question text if anything is pending, else the
+       regenerated summary.
+
+    Returns the LangGraph update dict (subset of ItineraryState fields).
+    No-op (empty update) when no closures are detected.
+    """
+    if not state.stops:
+        return {}
+
+    closed = _per_stop_closure_status(state.stops)
+    if not any(closed):
+        return {}
+
+    # Phase 1: try a walking-distance swap for each closed stop.
+    working_stops = list(state.stops)
+    auto_swapped_entries: list[tuple[int, CandidateMatch]] = []
+    pending_indices: list[int] = []
+
+    for idx, is_closed in enumerate(closed):
+        if not is_closed:
+            continue
+        closed_stop = working_stops[idx]
+        family = _resolve_family_for_stop(closed_stop)
+        if not family:
+            pending_indices.append(idx)
+            continue
+        anchor = _resolve_anchor(state, closed_stop)
+        if anchor is None:
+            pending_indices.append(idx)
+            continue
+        probe_ctx = ClosureContext(
+            place_id=closed_stop.place_id,
+            place_name=closed_stop.name,
+            family=family,
+            attempted_arrival=closed_stop.arrival_time or datetime.now(),
+            outcome="pending_user_decision",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=idx,
+        )
+        match = _try_walking_distance_swap(state, probe_ctx, anchor_place_id=anchor)
+        if match is None:
+            pending_indices.append(idx)
+            continue
+        auto_swapped_entries.append((idx, match))
+
+    # Apply auto-swaps in one pass.
+    new_closure_entries: list[ClosureContext] = []
+    if auto_swapped_entries:
+        for idx, match in auto_swapped_entries:
+            working_stops[idx] = match.stop
+            new_closure_entries.append(
+                _build_closure_context_entry(
+                    state.stops, idx, proposed=match, outcome="auto_swapped"
+                )
+            )
+        # Phase 2: one bounded retime + re-check.
+        retimed = await _bounded_retime_after_swap(working_stops)
+        # Re-check on the retimed plan to catch a swap that's open at the
+        # OLD projected arrival but not the NEW one after re-routing.
+        re_closed = _per_stop_closure_status(retimed)
+        # Pull DB enrichment in once on the retimed set so cards stay fresh.
+        enrich_stops_with_booking(retimed, state)
+        working_stops = retimed
+        for idx, is_closed in enumerate(re_closed):
+            if is_closed and idx not in pending_indices:
+                pending_indices.append(idx)
+
+    # Phase 3: escalate unresolved closures.
+    pending_indices.sort()
+    for n, idx in enumerate(pending_indices):
+        closed_stop = working_stops[idx]
+        family = _resolve_family_for_stop(closed_stop)
+        outcome = "pending_user_decision" if n == 0 else "queued_user_decision"
+
+        proposal: CandidateMatch | None = None
+        if family:
+            anchor = _resolve_anchor(state, closed_stop)
+            if anchor:
+                probe_ctx = ClosureContext(
+                    place_id=closed_stop.place_id,
+                    place_name=closed_stop.name,
+                    family=family,
+                    attempted_arrival=closed_stop.arrival_time or datetime.now(),
+                    outcome="pending_user_decision",
+                    insert_after_place_id=None,
+                    insert_before_place_id=None,
+                    stop_index_hint=idx,
+                )
+                proposal = _try_any_distance_search(state, probe_ctx, anchor_place_id=anchor)
+        new_closure_entries.append(
+            _build_closure_context_entry(state.stops, idx, proposed=proposal, outcome=outcome)
+        )
+
+    # Drop the closed (unswapped) stops from working_stops so the summary
+    # doesn't show a place we're asking about.
+    pending_set = set(pending_indices)
+    final_stops = [s for i, s in enumerate(working_stops) if i not in pending_set]
+
+    merged_context = _cap_closure_context([*state.closure_context, *new_closure_entries])
+
+    pending_entry = next(
+        (c for c in new_closure_entries if c.outcome == "pending_user_decision"),
+        None,
+    )
+    if pending_entry is not None:
+        final_reply = _formulate_closure_question(pending_entry)
+    else:
+        probe_state = state.model_copy(update={"stops": final_stops})
+        final_reply = summarize_stops(probe_state)
+
+    return {
+        "stops": final_stops,
+        "closure_context": merged_context,
+        "final_reply": final_reply,
+    }
+
+
 __all__ = [
     "CandidateMatch",
     "_apply_swap",
     "_bounded_retime_after_swap",
+    "_build_closure_context_entry",
     "_execute_closure_query",
     "_formulate_closure_question",
     "_per_stop_closure_status",
     "_promote_pending",
     "_resolve_anchor",
+    "_resolve_family_for_stop",
     "_resolve_insert_position",
     "_score_candidate",
     "_try_any_distance_search",
     "_try_walking_distance_swap",
+    "swap_closed_stops",
 ]

--- a/app/agent/swap.py
+++ b/app/agent/swap.py
@@ -18,9 +18,11 @@ from typing import Any
 from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel
 
-from app.agent.planning import haversine_m
+from app.agent.commit import enrich_stops_with_booking
+from app.agent.planning import chain_arrival_times, haversine_m
 from app.agent.state import ClosureContext, ItineraryState, Stop
 from app.db import get_conn
+from app.tools.directions import route_legs
 from app.tools.filters import SearchFilters, family_of
 from app.tools.retrieval import PlaceHit
 from app.tools.retrieval import nearby as _nearby_search  # aliased for test patching
@@ -349,10 +351,108 @@ def _try_any_distance_search(
     return matches[0]
 
 
+async def _bounded_retime_after_swap(stops: list[Stop]) -> list[Stop]:
+    """One extra `route_legs` call after a swap -> re-chain arrival_times.
+
+    Strictly bounded: no recursion, no loop. Called at most once per swap
+    node invocation. Falls back to the input stops on any failure (mirrors
+    `retime()` in graph.py:319-323).
+    """
+    coords = [
+        (s.latitude, s.longitude)
+        for s in stops
+        if s.latitude is not None and s.longitude is not None
+    ]
+    if len(coords) < 2 or len(coords) != len(stops):
+        return stops
+    try:
+        result = await route_legs(coords, mode="walk")
+        leg_min = [leg.duration_s / 60 for leg in result.legs]
+        retimed = chain_arrival_times(stops, leg_min)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("closure_swap.retime_failure: %s", e)
+        return stops
+    return retimed
+
+
+def _apply_swap(
+    state: ItineraryState,
+    stop_index: int,
+    replacement: Stop,
+    leg_durations_min: list[float],
+) -> list[Stop]:
+    """Replace stops[stop_index] with `replacement` and re-chain arrivals.
+
+    Returns the new stops list. Caller is responsible for substituting it
+    into state. Booking enrichment is re-run on the new list so the swapped
+    stop's card fields (booking URL, refreshed address) stay accurate.
+    """
+    new_stops = list(state.stops)
+    new_stops[stop_index] = replacement
+    if leg_durations_min and new_stops and new_stops[0].arrival_time is not None:
+        new_stops = chain_arrival_times(new_stops, leg_durations_min)
+    enrich_stops_with_booking(new_stops, state)
+    return new_stops
+
+
+def _promote_pending(
+    closure_context: list[ClosureContext],
+) -> list[ClosureContext]:
+    """If there is no pending entry, promote the first queued one (if any).
+
+    Returns a new list. Caller substitutes it into state.closure_context.
+    No-op when a pending entry is already present (v1 surfaces one at a
+    time, in arrival order).
+    """
+    if any(c.outcome == "pending_user_decision" for c in closure_context):
+        return list(closure_context)
+    promoted = list(closure_context)
+    for i, c in enumerate(promoted):
+        if c.outcome == "queued_user_decision":
+            promoted[i] = c.model_copy(update={"outcome": "pending_user_decision"})
+            break
+    return promoted
+
+
+def _miles_from_meters(m: float) -> int:
+    """Round to nearest mile for user-facing text. 1609m -> 1mi, 4800m -> 3mi."""
+    return round(m / 1609.34)
+
+
+def _formulate_closure_question(pending: ClosureContext) -> str:
+    """User-facing question text for a pending closure decision.
+
+    Two shapes:
+      - With proposed_alternative: 'The closest open <family> is <name>,
+        about <N> mi (drive/transit). Want it, or pick something else?'
+      - Without: 'I couldn't find an open <family> alternative for <name>.
+        Want me to skip that stop, or pick a different category?'
+    """
+    if pending.proposed_alternative is not None:
+        distance = pending.proposed_distance_m or 0.0
+        miles = _miles_from_meters(distance)
+        mode = "drive" if distance > 1500 else "walk/transit"
+        return (
+            f"{pending.place_name} is closed at the planned arrival time. "
+            f"The closest open {pending.family} place is "
+            f"{pending.proposed_alternative.name}, about {miles} mi ({mode}). "
+            f"Want me to add it, or pick something else?"
+        )
+    return (
+        f"{pending.place_name} is closed at the planned arrival time and I "
+        f"couldn't find an open {pending.family} alternative. Want me to "
+        f"skip that stop, or pick a different category?"
+    )
+
+
 __all__ = [
     "CandidateMatch",
+    "_apply_swap",
+    "_bounded_retime_after_swap",
     "_execute_closure_query",
+    "_formulate_closure_question",
     "_per_stop_closure_status",
+    "_promote_pending",
     "_resolve_anchor",
     "_resolve_insert_position",
     "_score_candidate",

--- a/app/agent/swap.py
+++ b/app/agent/swap.py
@@ -464,12 +464,16 @@ def _inject_closure_exclusions(
     optimization, not the only line of defense. Routes by tool name because
     the exclusion argument lives in different places per tool:
 
-      - semantic_search / nearby -> args["filters"].excluded_place_ids
+      - semantic_search / nearby -> args["filters"]["excluded_place_ids"]
       - kg_traverse              -> args["excluded_place_ids"]  (top-level)
       - anything else            -> no-op
 
-    Returns a NEW args dict; never mutates the input (the graph.act node
-    records the original args verbatim in scratch for tracing).
+    Returns a NEW args dict with `filters` as a plain dict — NOT a Pydantic
+    `SearchFilters` instance. The result must be `json.dumps`-safe because
+    the caller stores it (or a copy) inside `AIMessage.tool_calls`, which
+    langchain serializes on every subsequent OpenAI API call. A Pydantic
+    instance there causes `TypeError: Object of type SearchFilters is not
+    JSON serializable` on the next plan() step.
 
     Every closure_context outcome contributes — auto_swapped through
     pending_user_decision all exclude the source closed place_id. The
@@ -483,19 +487,21 @@ def _inject_closure_exclusions(
     if tool_name in ("semantic_search", "nearby"):
         existing_filters = new_args.get("filters")
         if existing_filters is None:
-            filters = SearchFilters(excluded_place_ids=sorted(excluded))
+            llm_excluded: set[str] = set()
+            base: dict[str, Any] = {}
         elif isinstance(existing_filters, SearchFilters):
-            llm_excluded = set(existing_filters.excluded_place_ids or [])
-            filters = existing_filters.model_copy(
-                update={"excluded_place_ids": sorted(llm_excluded | excluded)}
-            )
+            base = existing_filters.model_dump(exclude_none=True)
+            llm_excluded = set(base.get("excluded_place_ids") or [])
         else:
-            # LangChain may deliver `filters` as a plain dict; validate it
-            # through SearchFilters so the merged value is type-correct.
+            # LangChain delivers `filters` as a plain dict in tool_call args.
+            # Validate it through SearchFilters once (defensive — rejects
+            # unknown fields) then re-emit as a dict so the result stays
+            # JSON-serializable.
             llm = SearchFilters.model_validate(existing_filters)
-            llm_excluded = set(llm.excluded_place_ids or [])
-            filters = llm.model_copy(update={"excluded_place_ids": sorted(llm_excluded | excluded)})
-        new_args["filters"] = filters
+            base = llm.model_dump(exclude_none=True)
+            llm_excluded = set(base.get("excluded_place_ids") or [])
+        base["excluded_place_ids"] = sorted(llm_excluded | excluded)
+        new_args["filters"] = base
         return new_args
     if tool_name == "kg_traverse":
         llm_excluded = set(new_args.get("excluded_place_ids") or [])

--- a/app/agent/swap.py
+++ b/app/agent/swap.py
@@ -1,0 +1,81 @@
+"""Closure-aware itinerary swap node.
+
+Sits between `retime` and END in the agent graph. Detects committed stops
+that will be closed at their planned arrival time, deterministically swaps
+in walking-distance alternatives of the same category where possible,
+escalates to a single user question per turn when not, and remembers every
+closure event so refinement turns never re-suggest the same closed place.
+
+See docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
+for the architecture rationale and contract details.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from psycopg2.extras import RealDictCursor
+
+from app.agent.state import Stop
+from app.db import get_conn
+
+logger = logging.getLogger(__name__)
+
+
+def _execute_closure_query(
+    place_ids: list[str],
+    arrivals: list[Any],
+) -> dict[str, bool]:
+    """One SQL round-trip via `place_is_open`. Returns {place_id: is_open}.
+
+    Mirrors `temporal_coherence` at app/agent/critique/checks.py:69-79; that
+    pattern unnests the two arrays in lockstep so an N-stop itinerary is one
+    round-trip, not N. Stops missing from the result default to open (no row =
+    not in places_raw, which the critique pipeline scores separately).
+    """
+    with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT pr.place_id,
+                   place_is_open(pr.regular_opening_hours, t.arrival) AS is_open
+              FROM unnest(%s::text[], %s::timestamptz[]) AS t(place_id, arrival)
+              JOIN places_raw pr ON pr.place_id = t.place_id
+            """,
+            [place_ids, arrivals],
+        )
+        return {row["place_id"]: bool(row["is_open"]) for row in cur.fetchall()}
+
+
+def _per_stop_closure_status(stops: list[Stop]) -> list[bool]:
+    """Return [is_closed_at_arrival] per stop, in the same order as `stops`.
+
+    True means "we know this stop is closed at its planned arrival time."
+    Stops without an arrival_time, stops missing from places_raw, and full
+    DB failures all return False (fail-open — matches checks.py:200-205
+    precedent so a DB blip doesn't block the /chat response).
+    """
+    if not stops:
+        return []
+    checkable = [(i, s) for i, s in enumerate(stops) if s.arrival_time is not None]
+    if not checkable:
+        return [False] * len(stops)
+    place_ids = [s.place_id for _, s in checkable]
+    arrivals = [s.arrival_time for _, s in checkable]
+    try:
+        is_open_by_id = _execute_closure_query(place_ids, arrivals)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("closure_swap.db_error: %s", e)
+        return [False] * len(stops)
+    out = [False] * len(stops)
+    for i, stop in checkable:
+        # No row -> default to open (matches temporal_coherence semantics).
+        is_open = is_open_by_id.get(stop.place_id, True)
+        out[i] = not is_open
+    return out
+
+
+__all__ = [
+    "_execute_closure_query",
+    "_per_stop_closure_status",
+]

--- a/app/agent/tools.py
+++ b/app/agent/tools.py
@@ -78,6 +78,7 @@ def kg_traverse(
     place_id: str,
     relation_type: str = "SIMILAR_VECTOR",
     k: int = 5,
+    excluded_place_ids: list[str] | None = None,
 ) -> list[RelatedPlace]:
     """Traverse the knowledge graph from `place_id` along a relation_type.
 
@@ -93,7 +94,12 @@ def kg_traverse(
     """
     from app.tools.graph import kg_traverse as _kg_traverse
 
-    return _kg_traverse(place_id=place_id, relation_type=relation_type, k=k)
+    return _kg_traverse(
+        place_id=place_id,
+        relation_type=relation_type,
+        k=k,
+        excluded_place_ids=excluded_place_ids,
+    )
 
 
 def _args_schema_for(fn: Any):

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Literal
 
 import mlflow
+import psycopg2
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from langchain_core.language_models import BaseChatModel
@@ -13,15 +16,29 @@ from langchain_core.messages import HumanMessage
 from psycopg2.extensions import connection
 from pydantic import BaseModel, Field, ValidationError
 
+from .agent.commit import enrich_stops_with_booking
 from .agent.graph import build_agent_graph
-from .agent.input_parsing import explicit_num_stops_from_conversation
+from .agent.input_parsing import explicit_num_stops_from_conversation, parse_closure_decision
 from .agent.io import messages_from_history, state_to_cards
+from .agent.revision import summarize_stops
 from .agent.state import ClosureContext, ItineraryState, Stop, UserConstraints
+from .agent.swap import (
+    _bounded_retime_after_swap,
+    _build_closure_context_entry,
+    _formulate_closure_question,
+    _per_stop_closure_status,
+    _promote_pending,
+    _resolve_anchor,
+    _resolve_family_for_stop,
+    _resolve_insert_position,
+    _try_walking_distance_swap,
+)
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
-from .db import get_db
+from .db import get_conn, get_db
 from .db_pool import close_db_pool, init_db_pool
 from .observability import langgraph_callbacks, trace_request
+from .tools.retrieval import get_details
 
 logger = logging.getLogger(__name__)
 
@@ -304,6 +321,187 @@ def health_db(conn: connection = db_connection_dependency) -> dict[str, str]:
     return {"status": "ok"}
 
 
+def _place_is_open_now(hours: dict | None, when: datetime) -> bool:
+    """One-shot SQL call mirroring closure_swap's check, used on the accept
+    path to re-validate a proposed alternative right before applying it.
+
+    Fails OPEN — a DB blip must not block the swap, matching the codebase's
+    "fail-open on DB error" precedent (see app/agent/critique/checks.py:200).
+    """
+    if not hours:
+        return True
+    try:
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT place_is_open(%s::jsonb, %s)",
+                [json.dumps(hours), when],
+            )
+            row = cur.fetchone()
+            return bool(row[0]) if row else True
+    except psycopg2.Error:
+        logger.warning("_place_is_open_now DB error; treating as open", exc_info=True)
+        return True
+
+
+def _build_outbound_state(
+    closure_context: list[ClosureContext],
+    stops: list[Stop],
+) -> ConversationState:
+    return ConversationState(
+        schema_version=1,
+        closure_context=closure_context,
+        prior_stops=stops,
+    )
+
+
+async def _try_accept_path(
+    pending: ClosureContext,
+    incoming: ConversationState,
+    rag_label: str,
+) -> ChatResponse | None:
+    """User accepted the proposed drive alternative.
+
+    Returns a built ChatResponse for the early-return path, or None if
+    re-validation fails (caller falls through to the graph).
+    """
+    if pending.proposed_alternative is None:
+        return None
+    # Defense in depth: re-fetch the proposal in case the index changed
+    # between the question and the answer.
+    details = get_details(pending.proposed_alternative.place_id)
+    if details is None:
+        logger.warning(
+            "closure_swap.proposed_alternative_invalidated: place_id=%s missing",
+            pending.proposed_alternative.place_id,
+        )
+        return None
+    if not _place_is_open_now(details.regular_opening_hours, pending.attempted_arrival):
+        logger.warning("closure_swap.proposed_alternative_invalidated: now closed")
+        return None
+
+    # Insert at the resolved position and re-chain arrivals on the new plan.
+    insert_at = _resolve_insert_position(pending, incoming.prior_stops)
+    replacement = pending.proposed_alternative.model_copy()
+    new_stops = list(incoming.prior_stops)
+    new_stops.insert(insert_at, replacement)
+
+    retimed = await _bounded_retime_after_swap(new_stops)
+    re_closed = _per_stop_closure_status(retimed)
+
+    # Mark the pending entry as accepted up front so subsequent escalations
+    # see the right outcome shape.
+    updated_context: list[ClosureContext] = [
+        c.model_copy(update={"outcome": "user_accepted_drive"})
+        if c.place_id == pending.place_id and c.outcome == "pending_user_decision"
+        else c
+        for c in incoming.closure_context
+    ]
+
+    probe_state = ItineraryState(stops=retimed, closure_context=updated_context)
+
+    # If the retime exposed a NEW closure on a different stop, try a single
+    # walking-distance swap; escalate anything still closed.
+    new_pending_entries: list[ClosureContext] = []
+    if any(re_closed):
+        still_closed_indices = [i for i, flag in enumerate(re_closed) if flag]
+        for idx in still_closed_indices:
+            closed_stop = retimed[idx]
+            family = _resolve_family_for_stop(closed_stop)
+            anchor = _resolve_anchor(probe_state, closed_stop)
+            match = None
+            if family and anchor:
+                probe_ctx = ClosureContext(
+                    place_id=closed_stop.place_id,
+                    place_name=closed_stop.name,
+                    family=family,
+                    attempted_arrival=closed_stop.arrival_time or datetime.now(),
+                    outcome="pending_user_decision",
+                    insert_after_place_id=None,
+                    insert_before_place_id=None,
+                    stop_index_hint=idx,
+                )
+                match = _try_walking_distance_swap(probe_state, probe_ctx, anchor_place_id=anchor)
+            if match is not None:
+                retimed[idx] = match.stop
+                updated_context.append(
+                    _build_closure_context_entry(retimed, idx, match, "auto_swapped")
+                )
+            else:
+                outcome = (
+                    "pending_user_decision" if not new_pending_entries else "queued_user_decision"
+                )
+                new_pending_entries.append(
+                    _build_closure_context_entry(retimed, idx, None, outcome)
+                )
+
+    if new_pending_entries:
+        updated_context.extend(new_pending_entries)
+
+    # Promote a queued entry if pending was cleared.
+    updated_context = _promote_pending(updated_context)
+
+    # Surface either the next question or the summary.
+    next_pending = next(
+        (c for c in updated_context if c.outcome == "pending_user_decision"),
+        None,
+    )
+    surfaced_stops = list(retimed)
+    if next_pending is not None:
+        final_reply = _formulate_closure_question(next_pending)
+        surfaced_stops = [s for s in surfaced_stops if s.place_id != next_pending.place_id]
+    else:
+        enrich_stops_with_booking(surfaced_stops, probe_state)
+        final_reply = summarize_stops(probe_state.model_copy(update={"stops": surfaced_stops}))
+
+    final_state = ItineraryState(stops=surfaced_stops, closure_context=updated_context)
+    return ChatResponse(
+        reply=final_reply,
+        places=state_to_cards(final_state),
+        ragLabel=rag_label,
+        conversation_state=_build_outbound_state(updated_context, surfaced_stops),
+    )
+
+
+def _decline_path(
+    pending: ClosureContext,
+    incoming: ConversationState,
+    rag_label: str,
+) -> ChatResponse:
+    """User declined the drive option. The closed stop wasn't on prior_stops
+    (it was demoted to pending before the user saw the plan), so we just flip
+    the outcome and promote any queued entry.
+    """
+    updated_context: list[ClosureContext] = [
+        c.model_copy(update={"outcome": "user_declined_dropped"})
+        if c.place_id == pending.place_id and c.outcome == "pending_user_decision"
+        else c
+        for c in incoming.closure_context
+    ]
+    updated_context = _promote_pending(updated_context)
+    next_pending = next(
+        (c for c in updated_context if c.outcome == "pending_user_decision"),
+        None,
+    )
+    probe_state = ItineraryState(
+        stops=incoming.prior_stops,
+        closure_context=updated_context,
+    )
+    if next_pending is not None:
+        final_reply = _formulate_closure_question(next_pending)
+        surfaced_stops = [s for s in incoming.prior_stops if s.place_id != next_pending.place_id]
+    else:
+        final_reply = summarize_stops(probe_state)
+        surfaced_stops = list(incoming.prior_stops)
+
+    final_state = ItineraryState(stops=surfaced_stops, closure_context=updated_context)
+    return ChatResponse(
+        reply=final_reply,
+        places=state_to_cards(final_state),
+        ragLabel=rag_label,
+        conversation_state=_build_outbound_state(updated_context, surfaced_stops),
+    )
+
+
 @app.post("/chat", response_model=ChatResponse)
 async def chat(req: ChatRequest, request: Request) -> ChatResponse:
     graph = getattr(request.app.state, "agent_graph", None)
@@ -312,9 +510,6 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
 
     rag_label = getattr(request.app.state, "rag_label", _rag_label_for(None))
 
-    # Hydrate inbound conversation_state. Manual validation so we degrade
-    # rather than 422 on schema mismatch (same warning-log pattern other
-    # "untrusted opaque state" decoders use in the codebase).
     incoming: ConversationState
     if req.conversation_state is None:
         incoming = ConversationState()
@@ -325,10 +520,43 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
             logger.warning("conversation_state.decode_failed", exc_info=True)
             incoming = ConversationState()
 
+    pending = next(
+        (c for c in incoming.closure_context if c.outcome == "pending_user_decision"),
+        None,
+    )
+
+    decision: str | None = None
+    if pending is not None and req.message.strip():
+        decision = parse_closure_decision(req.message)
+        if decision == "accept":
+            early = await _try_accept_path(pending, incoming, rag_label)
+            if early is not None:
+                return early
+            # Re-validation failed — fall through to the graph with the bad
+            # pending entry preserved; the model will plan around it.
+        elif decision == "decline":
+            return _decline_path(pending, incoming, rag_label)
+        # "alternative" falls through to the graph (handled below).
+
     with trace_request("chat", message=req.message[:200]) as trace_id:
+        # If we just routed "alternative", give the model a HumanMessage hint
+        # so it knows the user declined the drive option and what they asked
+        # for instead.
+        hint_messages: list[HumanMessage] = []
+        if pending is not None and decision == "alternative":
+            hint_messages.append(
+                HumanMessage(
+                    content=(
+                        f"User declined the drive option for {pending.place_name}. "
+                        f"They want: '{req.message}'. Plan again with this guidance."
+                    )
+                )
+            )
+
         state = ItineraryState(
             messages=[
                 *messages_from_history(req.history),
+                *hint_messages,
                 HumanMessage(content=req.message),
             ],
             constraints=UserConstraints(
@@ -345,20 +573,11 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
         )
     final_state = raw if isinstance(raw, ItineraryState) else ItineraryState(**raw)
 
-    # Build outbound conversation_state. prior_stops carries the stops the
-    # user just saw so a follow-up turn's early-return path can act on them
-    # without /chat round-tripping the full places list.
-    outbound = ConversationState(
-        schema_version=1,
-        closure_context=final_state.closure_context,
-        prior_stops=final_state.stops,
-    )
-
     return ChatResponse(
         reply=final_state.final_reply or "",
         places=state_to_cards(final_state),
         ragLabel=rag_label,
-        conversation_state=outbound,
+        conversation_state=_build_outbound_state(final_state.closure_context, final_state.stops),
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -14,8 +14,9 @@ from psycopg2.extensions import connection
 from pydantic import BaseModel, Field
 
 from .agent.graph import build_agent_graph
+from .agent.input_parsing import explicit_num_stops_from_conversation
 from .agent.io import messages_from_history, state_to_cards
-from .agent.state import ItineraryState
+from .agent.state import ItineraryState, UserConstraints
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
 from .db import get_db
@@ -291,7 +292,10 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
             messages=[
                 *messages_from_history(req.history),
                 HumanMessage(content=req.message),
-            ]
+            ],
+            constraints=UserConstraints(
+                num_stops=explicit_num_stops_from_conversation(req.history, req.message),
+            ),
         )
         raw = await graph.ainvoke(
             state,

--- a/app/main.py
+++ b/app/main.py
@@ -11,12 +11,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from psycopg2.extensions import connection
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from .agent.graph import build_agent_graph
 from .agent.input_parsing import explicit_num_stops_from_conversation
 from .agent.io import messages_from_history, state_to_cards
-from .agent.state import ItineraryState, UserConstraints
+from .agent.state import ClosureContext, ItineraryState, Stop, UserConstraints
 from .chain import build_rag_chain
 from .config import get_settings, resolve_llm_api_key
 from .db import get_db
@@ -78,9 +78,31 @@ class ChatMessage(BaseModel):
     content: str
 
 
+class ConversationState(BaseModel):
+    """Opaque-to-frontend state round-tripped via /chat.
+
+    The frontend stores this verbatim from each response and sends it back
+    on the next request; the backend is the source of truth for the schema.
+    `prior_stops` carries the stops the user just saw so an accept/decline
+    early-return path can act on them without /chat round-tripping the full
+    places list.
+    """
+
+    schema_version: int = 1
+    closure_context: list[ClosureContext] = Field(default_factory=list)
+    prior_stops: list[Stop] = Field(default_factory=list)
+
+
 class ChatRequest(BaseModel):
     message: str
     history: list[ChatMessage] = Field(default_factory=list)
+    # Opaque dict so a malformed nested object doesn't 422 before the
+    # handler runs — `/chat` does manual ConversationState.model_validate
+    # and degrades to empty state on ValidationError. `dict | None` still
+    # 422s on non-object payloads (string/list/number), which is the right
+    # answer for those (developer/curl mistakes; the real frontend can't
+    # produce them).
+    conversation_state: dict[str, Any] | None = None
 
 
 class ChatResponse(BaseModel):
@@ -88,6 +110,8 @@ class ChatResponse(BaseModel):
     reply: str
     places: list[dict]
     ragLabel: str  # noqa: N815
+    # Backend always emits a typed, validated shape on the response side.
+    conversation_state: ConversationState | None = None
 
 
 @dataclass
@@ -287,6 +311,20 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
         raise HTTPException(status_code=503, detail=AGENT_UNAVAILABLE_DETAIL)
 
     rag_label = getattr(request.app.state, "rag_label", _rag_label_for(None))
+
+    # Hydrate inbound conversation_state. Manual validation so we degrade
+    # rather than 422 on schema mismatch (same warning-log pattern other
+    # "untrusted opaque state" decoders use in the codebase).
+    incoming: ConversationState
+    if req.conversation_state is None:
+        incoming = ConversationState()
+    else:
+        try:
+            incoming = ConversationState.model_validate(req.conversation_state)
+        except ValidationError:
+            logger.warning("conversation_state.decode_failed", exc_info=True)
+            incoming = ConversationState()
+
     with trace_request("chat", message=req.message[:200]) as trace_id:
         state = ItineraryState(
             messages=[
@@ -296,6 +334,7 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
             constraints=UserConstraints(
                 num_stops=explicit_num_stops_from_conversation(req.history, req.message),
             ),
+            closure_context=incoming.closure_context,
         )
         raw = await graph.ainvoke(
             state,
@@ -305,10 +344,21 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
             },
         )
     final_state = raw if isinstance(raw, ItineraryState) else ItineraryState(**raw)
+
+    # Build outbound conversation_state. prior_stops carries the stops the
+    # user just saw so a follow-up turn's early-return path can act on them
+    # without /chat round-tripping the full places list.
+    outbound = ConversationState(
+        schema_version=1,
+        closure_context=final_state.closure_context,
+        prior_stops=final_state.stops,
+    )
+
     return ChatResponse(
         reply=final_state.final_reply or "",
         places=state_to_cards(final_state),
         ragLabel=rag_label,
+        conversation_state=outbound,
     )
 
 

--- a/app/tools/filters.py
+++ b/app/tools/filters.py
@@ -9,6 +9,7 @@ not need to know about — it just sets `open_at`.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -69,6 +70,24 @@ class SearchFilters(BaseModel):
     types_any: list[str] | None = Field(
         default=None,
         description="Match if any of these strings appears in types[].",
+    )
+    primary_type_family: Literal["dessert", "bar", "restaurant", "cafe"] | None = Field(
+        default=None,
+        description=(
+            "Restrict candidates to a category family (dessert/bar/restaurant/"
+            "cafe). Expands to a `(types && %s OR primary_type = ANY(%s))` "
+            "clause against both column conventions. Distinct from `types_any`, "
+            "which only matches the types[] array."
+        ),
+    )
+    excluded_place_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "place_ids to exclude from results. Used by the closure-aware "
+            "swap path to prevent re-suggesting a place that was previously "
+            "found closed in the same conversation. Empty list (or None) is a "
+            "no-op."
+        ),
     )
     business_status: str | None = Field(
         default="OPERATIONAL",
@@ -336,6 +355,18 @@ def compile_filters(f: SearchFilters) -> tuple[str, list]:
     if f.types_any:
         clauses.append("types && %s")
         params.append(f.types_any)
+
+    if f.primary_type_family is not None:
+        family = _PRIMARY_TYPE_FAMILIES[f.primary_type_family]
+        clauses.append("(types && %s OR primary_type = ANY(%s))")
+        params.append(list(family["types"]))
+        params.append(list(family["primary_types"]))
+
+    if f.excluded_place_ids:
+        # Empty list is intentionally a no-op (caller signals "no exclusions"
+        # without having to pass None).
+        clauses.append("place_id != ALL(%s)")
+        params.append(f.excluded_place_ids)
 
     if f.source:
         clauses.append("source = %s")

--- a/app/tools/filters.py
+++ b/app/tools/filters.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # The concierge is San Francisco-only; a naive open_at unambiguously means
 # SF local time.
@@ -27,6 +27,8 @@ class SearchFilters(BaseModel):
     everything — it matches operational places with at least 50 raters. The
     agent must opt out of the floors deliberately.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     price_level_max: int | None = Field(
         default=None,
@@ -86,6 +88,14 @@ class SearchFilters(BaseModel):
     serves_lunch: bool | None = None
     serves_dinner: bool | None = None
     serves_vegetarian: bool | None = None
+    serves_dessert: bool | None = Field(
+        default=None,
+        description=(
+            "Dessert category helper. True matches dessert-oriented Google "
+            "types such as dessert_shop, bakery, ice_cream_shop, cafe, "
+            "tea_house, and confectionery."
+        ),
+    )
     outdoor_seating: bool | None = None
     reservable: bool | None = None
     allows_dogs: bool | None = None
@@ -127,6 +137,32 @@ _BOOL_COLUMNS: tuple[str, ...] = (
     "good_for_sports",
 )
 
+_DESSERT_TYPES: tuple[str, ...] = (
+    "dessert_shop",
+    "bakery",
+    "ice_cream_shop",
+    "candy_store",
+    "chocolate_shop",
+    "coffee_shop",
+    "cafe",
+    "confectionery",
+    "donut_shop",
+    "tea_house",
+)
+
+_DESSERT_PRIMARY_TYPES: tuple[str, ...] = (
+    "Dessert Shop",
+    "Bakery",
+    "Ice Cream Shop",
+    "Candy Store",
+    "Chocolate Shop",
+    "Coffee Shop",
+    "Cafe",
+    "Confectionery store",
+    "Donut Shop",
+    "Tea House",
+)
+
 
 def compile_filters(f: SearchFilters) -> tuple[str, list]:
     """Return (sql_where_fragment, params_list).
@@ -140,8 +176,12 @@ def compile_filters(f: SearchFilters) -> tuple[str, list]:
     if f.price_level_max is not None:
         # places_raw.price_level is a Google v1 enum string ('PRICE_LEVEL_*');
         # price_level_rank() (alembic c428add573d7) maps it to 0..4 so we can
-        # compare against the integer the agent passes.
-        clauses.append("price_level_rank(price_level) <= %s")
+        # compare against the integer the agent passes. Unknown price passes
+        # rather than disappearing; constraints_satisfied() uses the same
+        # "missing data should not fail" semantics.
+        clauses.append(
+            "(price_level_rank(price_level) IS NULL OR price_level_rank(price_level) <= %s)"
+        )
         params.append(f.price_level_max)
 
     if f.min_rating is not None:
@@ -166,6 +206,15 @@ def compile_filters(f: SearchFilters) -> tuple[str, list]:
         if value is not None:
             clauses.append(f"{column} = %s")
             params.append(value)
+
+    if f.serves_dessert is not None:
+        dessert_clause = "(types && %s OR primary_type = ANY(%s))"
+        if f.serves_dessert:
+            clauses.append(dessert_clause)
+        else:
+            clauses.append(f"NOT {dessert_clause}")
+        params.append(list(_DESSERT_TYPES))
+        params.append(list(_DESSERT_PRIMARY_TYPES))
 
     if f.types_any:
         clauses.append("types && %s")

--- a/app/tools/filters.py
+++ b/app/tools/filters.py
@@ -137,31 +137,147 @@ _BOOL_COLUMNS: tuple[str, ...] = (
     "good_for_sports",
 )
 
-_DESSERT_TYPES: tuple[str, ...] = (
-    "dessert_shop",
-    "bakery",
-    "ice_cream_shop",
-    "candy_store",
-    "chocolate_shop",
-    "coffee_shop",
-    "cafe",
-    "confectionery",
-    "donut_shop",
-    "tea_house",
-)
+# Maps a family name to the column conventions place_documents/places_raw
+# uses for category matching:
+#   - "types":         snake_case strings used in the `types[]` array column
+#   - "primary_types": Title Case strings used in the `primary_type` scalar
+# Both lists are required for each family because Postgres rows can carry
+# either or both. The `serves_dessert` helper and the `primary_type_family`
+# filter both compile to `(types && %s OR primary_type = ANY(%s))` against
+# these two lists so the row matches on either column.
+_PRIMARY_TYPE_FAMILIES: dict[str, dict[str, tuple[str, ...]]] = {
+    "dessert": {
+        "types": (
+            "dessert_shop",
+            "bakery",
+            "ice_cream_shop",
+            "candy_store",
+            "chocolate_shop",
+            "coffee_shop",
+            "cafe",
+            "confectionery",
+            "donut_shop",
+            "tea_house",
+        ),
+        "primary_types": (
+            "Dessert Shop",
+            "Bakery",
+            "Ice Cream Shop",
+            "Candy Store",
+            "Chocolate Shop",
+            "Coffee Shop",
+            "Cafe",
+            "Confectionery store",
+            "Donut Shop",
+            "Tea House",
+        ),
+    },
+    "bar": {
+        "types": (
+            "bar",
+            "cocktail_bar",
+            "wine_bar",
+            "pub",
+            "sports_bar",
+            "night_club",
+        ),
+        "primary_types": (
+            "Bar",
+            "Cocktail Bar",
+            "Wine Bar",
+            "Pub",
+            "Sports Bar",
+            "Night Club",
+        ),
+    },
+    "restaurant": {
+        "types": (
+            "restaurant",
+            "fine_dining_restaurant",
+            "italian_restaurant",
+            "japanese_restaurant",
+            "chinese_restaurant",
+            "mexican_restaurant",
+            "thai_restaurant",
+            "indian_restaurant",
+            "french_restaurant",
+            "vietnamese_restaurant",
+            "korean_restaurant",
+            "mediterranean_restaurant",
+            "seafood_restaurant",
+            "steak_house",
+            "sushi_restaurant",
+            "ramen_restaurant",
+            "pizza_restaurant",
+            "american_restaurant",
+        ),
+        "primary_types": (
+            "Restaurant",
+            "Fine Dining Restaurant",
+            "Italian Restaurant",
+            "Japanese Restaurant",
+            "Chinese Restaurant",
+            "Mexican Restaurant",
+            "Thai Restaurant",
+            "Indian Restaurant",
+            "French Restaurant",
+            "Vietnamese Restaurant",
+            "Korean Restaurant",
+            "Mediterranean Restaurant",
+            "Seafood Restaurant",
+            "Steak House",
+            "Sushi Restaurant",
+            "Ramen Restaurant",
+            "Pizza Restaurant",
+            "American Restaurant",
+        ),
+    },
+    "cafe": {
+        "types": ("cafe", "coffee_shop", "tea_house"),
+        "primary_types": ("Cafe", "Coffee Shop", "Tea House"),
+    },
+}
 
-_DESSERT_PRIMARY_TYPES: tuple[str, ...] = (
-    "Dessert Shop",
-    "Bakery",
-    "Ice Cream Shop",
-    "Candy Store",
-    "Chocolate Shop",
-    "Coffee Shop",
-    "Cafe",
-    "Confectionery store",
-    "Donut Shop",
-    "Tea House",
-)
+
+# Priority order for the reverse-lookup helpers below. The dessert family
+# intentionally overlaps with the cafe family (a cafe serves desserts), but
+# when *identifying* a closed stop's category for the closure-aware swap,
+# we want the more specific family — a closed "Cafe" should swap to another
+# cafe, not arbitrarily into the dessert family. Order: most specific first.
+_FAMILY_LOOKUP_PRIORITY: tuple[str, ...] = ("bar", "restaurant", "cafe", "dessert")
+
+
+def family_of(primary_type: str | None) -> str | None:
+    """Reverse lookup: scalar primary_type column value -> family name.
+
+    Case-preserving comparison — the DB column preserves Title Case verbatim,
+    and `_PRIMARY_TYPE_FAMILIES` stores both casings exactly as the columns do.
+    Returns the first match in `_FAMILY_LOOKUP_PRIORITY` order so overlapping
+    categories (Cafe is in both "cafe" and "dessert") resolve deterministically.
+    Returns None for unknown / empty / None inputs.
+    """
+    if not primary_type:
+        return None
+    for family in _FAMILY_LOOKUP_PRIORITY:
+        if primary_type in _PRIMARY_TYPE_FAMILIES[family]["primary_types"]:
+            return family
+    return None
+
+
+def family_of_types(types: list[str] | None) -> str | None:
+    """Reverse lookup: types[] array values -> family name.
+
+    Returns the first family that overlaps the input list, walking families
+    in `_FAMILY_LOOKUP_PRIORITY` order. Lets the swap node fall back when
+    `primary_type` isn't in the index but `types[]` is populated. Returns
+    None for an empty list.
+    """
+    if not types:
+        return None
+    for family in _FAMILY_LOOKUP_PRIORITY:
+        if any(t in _PRIMARY_TYPE_FAMILIES[family]["types"] for t in types):
+            return family
+    return None
 
 
 def compile_filters(f: SearchFilters) -> tuple[str, list]:
@@ -208,13 +324,14 @@ def compile_filters(f: SearchFilters) -> tuple[str, list]:
             params.append(value)
 
     if f.serves_dessert is not None:
+        dessert = _PRIMARY_TYPE_FAMILIES["dessert"]
         dessert_clause = "(types && %s OR primary_type = ANY(%s))"
         if f.serves_dessert:
             clauses.append(dessert_clause)
         else:
             clauses.append(f"NOT {dessert_clause}")
-        params.append(list(_DESSERT_TYPES))
-        params.append(list(_DESSERT_PRIMARY_TYPES))
+        params.append(list(dessert["types"]))
+        params.append(list(dessert["primary_types"]))
 
     if f.types_any:
         clauses.append("types && %s")

--- a/app/tools/graph.py
+++ b/app/tools/graph.py
@@ -30,12 +30,17 @@ def kg_traverse(
     place_id: str,
     relation_type: str = "SIMILAR_VECTOR",
     k: int = 5,
+    excluded_place_ids: list[str] | None = None,
 ) -> list[RelatedPlace]:
     """Return up to ``k`` places related to ``place_id`` by ``relation_type``.
 
     NEAR is ordered ascending by weight (closest first); SIMILAR_VECTOR is
     ordered descending by weight (most similar first); other relations use a
     stable LIMIT. Unknown relation_type raises ValueError.
+
+    ``excluded_place_ids`` lets callers (the closure-swap node) suppress
+    place_ids known to be closed in the current conversation. Filtered at the
+    SQL layer so behavior matches ``nearby`` and ``semantic_search`` exclusion.
     """
     if relation_type not in VALID_RELATIONS:
         raise ValueError(f"Unknown relation_type: {relation_type}")
@@ -50,7 +55,9 @@ def kg_traverse(
                r.metadata AS relation_metadata
         FROM place_relations r
         JOIN {view} pd ON pd.place_id = r.dst_place_id
-        WHERE r.src_place_id = %s AND r.relation_type = %s
+        WHERE r.src_place_id = %s
+          AND r.relation_type = %s
+          AND (%s::text[] IS NULL OR pd.place_id != ALL(%s::text[]))
         ORDER BY
           CASE r.relation_type
             WHEN 'NEAR'           THEN  r.weight
@@ -59,7 +66,10 @@ def kg_traverse(
           END
         LIMIT %s
     """  # noqa: S608
-    rows = _execute(sql, [place_id, relation_type, k])
+    # Pass excluded twice: once for the NULL guard, once for the comparison
+    # — keeps the no-exclusion call site backward-compatible.
+    exclude = excluded_place_ids or None
+    rows = _execute(sql, [place_id, relation_type, exclude, exclude, k])
     return [RelatedPlace(**row) for row in rows]
 
 

--- a/app/tools/retrieval.py
+++ b/app/tools/retrieval.py
@@ -42,6 +42,9 @@ class PlaceHit(BaseModel):
     source: str
     similarity: float
     snippet: str | None = None
+    # `nearby()` projects this; semantic_search and get_details do not. Default
+    # None keeps both call paths compatible without forcing a separate model.
+    dist_m: float | None = None
 
 
 class PlaceDetails(PlaceHit):
@@ -147,7 +150,8 @@ def nearby(
             latitude, longitude, rating, price_level, business_status,
             source,
             0.0 AS similarity,
-            snippet
+            snippet,
+            dist_m
         FROM candidates
         WHERE dist_m <= %s
         ORDER BY dist_m ASC

--- a/docs/superpowers/plans/2026-05-19-closure-aware-itinerary-swap.md
+++ b/docs/superpowers/plans/2026-05-19-closure-aware-itinerary-swap.md
@@ -1,0 +1,4226 @@
+# Closure-Aware Itinerary Swap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a committed itinerary contains a stop that will be closed at its planned arrival time, the agent silently swaps in a walking-distance alternative of the same category; if none exists, it asks the user one clear question and remembers the closure across the whole conversation so refinement turns never re-suggest a closed place.
+
+**Architecture:** A new LangGraph node `swap_closed_stops` sits between the existing `retime` node and `END`. Closure history flows through an explicit `conversation_state` field on `/chat` request and response (opaque to the frontend, validated/re-enriched on the backend). Walking-distance candidate search uses an extended `nearby()` (now projecting `dist_m`) and a new `SearchFilters.primary_type_family` / `excluded_place_ids` pair; `kg_traverse` gets the same exclusion as a top-level argument. The existing `temporal_coherence` caveat in `retime` is deleted — closures are now resolved or asked about, never warned about.
+
+**Tech Stack:** FastAPI, Pydantic v2, LangGraph, psycopg2 (sync DB tools), httpx (async Routes API), pytest+pytest-mock, Vitest + React 18, ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md`
+**Branch:** `fix/agent-reliability-review` (5 existing commits already on it)
+
+---
+
+## File Structure
+
+**Create:**
+- `app/agent/swap.py` — the new node + helpers (`swap_closed_stops`, `_per_stop_closure_status`, `_try_walking_distance_swap`, `_try_any_distance_search`, `_score_candidate`, `_bounded_retime_after_swap`, `_promote_pending`, `_resolve_insert_position`, `_formulate_closure_question`, `_apply_swap`, `_inject_closure_exclusions`, `CandidateMatch`)
+- `tests/unit/test_swap.py` — unit + mock tests for swap helpers
+- `tests/unit/test_swap_node.py` — smoke tests for the graph node with DB mocked
+- `tests/integration/test_swap_real_db.py` — gated `APP_ENV=integration` integration tests
+
+**Modify:**
+- `app/agent/state.py` — add `ClosureContext`, extend `Stop` is unchanged, add `ItineraryState.closure_context`
+- `app/agent/input_parsing.py` — add `parse_closure_decision`
+- `app/agent/graph.py` — register `swap_closed_stops` node, delete temporal caveat in `retime` (lines 327-348), extend `_constraints_context` for closure exclusion, wire `_inject_closure_exclusions` into `act()`
+- `app/tools/filters.py` — refactor dessert mapping into `_PRIMARY_TYPE_FAMILIES`, add `family_of`/`family_of_types`, add `SearchFilters.primary_type_family` + `excluded_place_ids`, compile both
+- `app/tools/retrieval.py` — project `dist_m` from `nearby()`, add `dist_m` to `PlaceHit`
+- `app/tools/graph.py` — add `excluded_place_ids` parameter to `kg_traverse`
+- `app/agent/tools.py` — re-expose `kg_traverse` with new arg in the LLM tool surface
+- `app/main.py` — extend `ChatRequest`/`ChatResponse`, add `ConversationState`, implement decode + accept/decline/alternative early-return branches, attach response state
+- `frontend/src/api/chat.js` — read/write `conversation_state` (opaque)
+- `frontend/src/App.jsx` — store last `conversation_state` in a `useRef`
+- `tests/unit/test_chat_endpoint.py` — extend with closure-flow tests
+- `tests/unit/test_filters.py` — extend with new fields
+- `tests/unit/test_agent_input_parsing.py` — extend with `parse_closure_decision`
+- `frontend/src/api/chat.test.js` — extend if the existing file tests round-trip; otherwise leave
+
+**Why this decomposition:** State models and tool primitives ship first because everything else imports them. The swap module is the only file that owns closure orchestration. Graph wiring is a separate task so a failed wiring doesn't block independently-testable helpers. `/chat` and frontend changes come last because they're the user-visible glue.
+
+---
+
+## Pre-flight (do this exactly once, before Task 1)
+
+- [ ] **Step 0.1: Confirm clean working tree**
+
+Run: `git status --short`
+Expected output: empty (no modifications, no untracked).
+If anything appears, STOP and ask the user — do not proceed.
+
+- [ ] **Step 0.2: Confirm branch + commits already on it**
+
+Run: `git log main..HEAD --oneline`
+Expected: the five existing commits ending with `48d1a6e` plus five docs(spec) commits ending with `15b9a6e`. If something else is present, STOP and ask the user.
+
+- [ ] **Step 0.3: Run the full test suite once as a clean baseline**
+
+Run: `make test`
+Expected: PASS. Note the test count — additions in this plan should bring it to ~535 (current + ~36).
+
+If anything fails on `main`-derived behavior before any code is touched, STOP and surface it. We don't want to inherit a pre-existing failure into this branch.
+
+---
+
+## Task 1: Add `ClosureContext` and `closure_context` field to state
+
+**Files:**
+- Modify: `app/agent/state.py`
+- Test: `tests/unit/test_agent_state.py` (extend)
+
+**Why first:** Every downstream module imports `ClosureContext` and `ItineraryState.closure_context`. Establish the contract before touching anything that uses it.
+
+- [ ] **Step 1.1: Write the failing test**
+
+Append to `tests/unit/test_agent_state.py` (create the file's import line for `ClosureContext` if missing):
+
+```python
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.agent.state import ClosureContext, ItineraryState, Stop
+
+
+def test_closure_context_minimal_fields_validate() -> None:
+    """Pending entry with no proposal — used when nearby() returns no candidate."""
+    ctx = ClosureContext(
+        place_id="ChIJ_closed",
+        place_name="Mochill Mochidonut",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 2, tzinfo=ZoneInfo("America/Los_Angeles")),
+        outcome="pending_user_decision",
+        insert_after_place_id="ChIJ_stop1",
+        insert_before_place_id=None,
+        stop_index_hint=2,
+        proposed_alternative=None,
+        proposed_distance_m=None,
+    )
+    assert ctx.schema_version == 1
+    assert ctx.outcome == "pending_user_decision"
+    assert ctx.proposed_alternative is None
+
+
+def test_closure_context_with_proposal_validates() -> None:
+    sophies = Stop(
+        place_id="ChIJ_sophies",
+        name="Sophie's Crepes",
+        rationale="closest open dessert",
+        source="google_places",
+        latitude=37.7849,
+        longitude=-122.4093,
+        primary_type="Dessert Shop",
+        planned_duration_min=30,
+    )
+    ctx = ClosureContext(
+        place_id="ChIJ_closed",
+        place_name="Mochill Mochidonut",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 2, tzinfo=ZoneInfo("America/Los_Angeles")),
+        outcome="pending_user_decision",
+        insert_after_place_id="ChIJ_stop1",
+        insert_before_place_id=None,
+        stop_index_hint=2,
+        proposed_alternative=sophies,
+        proposed_distance_m=4800.0,
+    )
+    assert ctx.proposed_alternative is not None
+    assert ctx.proposed_alternative.place_id == "ChIJ_sophies"
+    assert ctx.proposed_distance_m == 4800.0
+
+
+def test_itinerary_state_default_closure_context_empty() -> None:
+    state = ItineraryState()
+    assert state.closure_context == []
+
+
+def test_itinerary_state_accepts_closure_context_list() -> None:
+    state = ItineraryState(
+        closure_context=[
+            ClosureContext(
+                place_id="p",
+                place_name="X",
+                family="bar",
+                attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+                outcome="auto_swapped",
+                insert_after_place_id=None,
+                insert_before_place_id=None,
+                stop_index_hint=0,
+                proposed_alternative=None,
+                proposed_distance_m=None,
+            )
+        ]
+    )
+    assert len(state.closure_context) == 1
+    assert state.closure_context[0].outcome == "auto_swapped"
+```
+
+- [ ] **Step 1.2: Run the failing test**
+
+Run: `poetry run pytest tests/unit/test_agent_state.py -v -k closure`
+Expected: ImportError for `ClosureContext`.
+
+- [ ] **Step 1.3: Add `ClosureContext` and `closure_context` to `state.py`**
+
+In `app/agent/state.py`, after the `Stop` class (around line 152, before `class ItineraryState`), insert:
+
+```python
+ClosureOutcome = Literal[
+    "auto_swapped",
+    "user_accepted_drive",
+    "user_declined_dropped",
+    "pending_user_decision",
+    "queued_user_decision",
+]
+
+
+class ClosureContext(BaseModel):
+    """One closure event recorded during a /chat conversation.
+
+    Persisted across turns via the opaque `conversation_state` round-trip
+    on /chat. Stable across neighbor drops/inserts because placement is
+    anchored to the neighboring stops' place_ids, with stop_index_hint as
+    a last-resort fallback.
+    """
+
+    schema_version: int = 1
+    place_id: str
+    place_name: str
+    family: str
+    attempted_arrival: datetime
+    outcome: ClosureOutcome
+    # Stable placement anchors — resolution priority order:
+    #   1) insert_after_place_id in current stops -> insert at that index + 1
+    #   2) else insert_before_place_id in current stops -> insert at that index
+    #   3) else stop_index_hint, clamped to len(stops)
+    insert_after_place_id: str | None = None
+    insert_before_place_id: str | None = None
+    stop_index_hint: int
+    proposed_alternative: Stop | None = None
+    proposed_distance_m: float | None = None
+
+
+MAX_CLOSURE_CONTEXT_ENTRIES = 10
+```
+
+Then extend `ItineraryState` to add the new field. Find the existing class definition (line 154) and add this field after `revision_counts`:
+
+```python
+    closure_context: list[ClosureContext] = Field(default_factory=list)
+```
+
+- [ ] **Step 1.4: Run the test to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_agent_state.py -v -k closure`
+Expected: 4 passed.
+
+- [ ] **Step 1.5: Run the full unit suite to confirm nothing regressed**
+
+Run: `poetry run pytest tests/unit/ -v 2>&1 | tail -5`
+Expected: all pass (count = baseline + 4).
+
+- [ ] **Step 1.6: Lint + typecheck**
+
+Run: `poetry run ruff check app/agent/state.py tests/unit/test_agent_state.py && poetry run mypy app/agent/state.py`
+Expected: clean.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add app/agent/state.py tests/unit/test_agent_state.py
+git commit -m "feat(state): add ClosureContext + closure_context field for closure-aware swap"
+```
+
+---
+
+## Task 2: Add `parse_closure_decision` to input parsing
+
+**Files:**
+- Modify: `app/agent/input_parsing.py`
+- Test: `tests/unit/test_agent_input_parsing.py` (extend)
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Append to `tests/unit/test_agent_input_parsing.py`:
+
+```python
+from app.agent.input_parsing import parse_closure_decision
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # accept — first-token rule, anything starting with a yes-ish token
+        ("yes", "accept"),
+        ("Yes", "accept"),
+        ("yes!", "accept"),
+        ("yes, make it 4 stops", "accept"),
+        ("yeah do it", "accept"),
+        ("yep", "accept"),
+        ("sure thing", "accept"),
+        ("ok let's go", "accept"),
+        ("okay", "accept"),
+        ("y", "accept"),
+        ("👍", "accept"),
+        # decline
+        ("no", "decline"),
+        ("No thanks", "decline"),
+        ("nope", "decline"),
+        ("nah", "decline"),
+        ("n", "decline"),
+        # alternative — anything else
+        ("find something cheaper instead", "alternative"),
+        ("what about ramen?", "alternative"),
+        ("pick a different one", "alternative"),
+        ("", "alternative"),
+        ("   ", "alternative"),
+    ],
+)
+def test_parse_closure_decision(text: str, expected: str) -> None:
+    assert parse_closure_decision(text) == expected
+```
+
+- [ ] **Step 2.2: Run it to confirm it fails**
+
+Run: `poetry run pytest tests/unit/test_agent_input_parsing.py -v -k closure_decision`
+Expected: ImportError.
+
+- [ ] **Step 2.3: Implement `parse_closure_decision`**
+
+Append to `app/agent/input_parsing.py`:
+
+```python
+_ACCEPT_TOKENS: frozenset[str] = frozenset({
+    "yes", "yeah", "yep", "sure", "ok", "okay", "y", "👍",
+})
+_DECLINE_TOKENS: frozenset[str] = frozenset({"no", "nope", "n", "nah"})
+
+
+def parse_closure_decision(text: str) -> Literal["accept", "decline", "alternative"]:
+    """Conservative parser for a user's reply to a closure question.
+
+    First-token rule resolves "yes + revision" (e.g. "yes! make it 4 stops")
+    unambiguously as accept; the existing `explicit_num_stops_from_conversation`
+    separately handles the count update. Empty / whitespace / questions / free
+    text all bucket to "alternative" (no auto-accept on silence).
+    """
+    if not text or not text.strip():
+        return "alternative"
+    # First "word" — split on whitespace then strip surrounding punctuation
+    # so "Yes!" or "yes," still matches. The emoji case is preserved verbatim.
+    first = text.strip().split()[0].lower()
+    stripped = first.strip(".,!?;:\"'()[]{}")
+    if stripped in _ACCEPT_TOKENS or first in _ACCEPT_TOKENS:
+        return "accept"
+    if stripped in _DECLINE_TOKENS or first in _DECLINE_TOKENS:
+        return "decline"
+    return "alternative"
+```
+
+Also add `Literal` to the import block at the top of the file (currently only `Protocol` from `typing` is imported):
+
+```python
+from typing import Literal, Protocol
+```
+
+- [ ] **Step 2.4: Run the test to verify it passes**
+
+Run: `poetry run pytest tests/unit/test_agent_input_parsing.py -v -k closure_decision`
+Expected: all parametrized cases pass.
+
+- [ ] **Step 2.5: Lint**
+
+Run: `poetry run ruff check app/agent/input_parsing.py tests/unit/test_agent_input_parsing.py`
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add app/agent/input_parsing.py tests/unit/test_agent_input_parsing.py
+git commit -m "feat(parsing): add parse_closure_decision for accept/decline/alternative"
+```
+
+---
+
+## Task 3: Refactor dessert mapping into `_PRIMARY_TYPE_FAMILIES` + `family_of`
+
+**Files:**
+- Modify: `app/tools/filters.py`
+- Test: `tests/unit/test_filters.py` (extend)
+
+**Why before SearchFilters changes:** `primary_type_family` resolves family → SQL clauses against this mapping. Land the mapping first so the next task can lean on it.
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Append to `tests/unit/test_filters.py`:
+
+```python
+from app.tools.filters import (
+    _PRIMARY_TYPE_FAMILIES,
+    family_of,
+    family_of_types,
+)
+
+
+def test_primary_type_families_all_have_types_and_primary_types() -> None:
+    for family, members in _PRIMARY_TYPE_FAMILIES.items():
+        assert set(members.keys()) == {"types", "primary_types"}, family
+        assert members["types"], f"{family} types must not be empty"
+        assert members["primary_types"], f"{family} primary_types must not be empty"
+
+
+def test_dessert_family_preserves_existing_dessert_members() -> None:
+    dessert = _PRIMARY_TYPE_FAMILIES["dessert"]
+    assert "dessert_shop" in dessert["types"]
+    assert "Dessert Shop" in dessert["primary_types"]
+    assert "Ice Cream Shop" in dessert["primary_types"]
+
+
+def test_family_of_resolves_primary_type() -> None:
+    assert family_of("Dessert Shop") == "dessert"
+    assert family_of("Bar") == "bar"
+    assert family_of("Cafe") == "cafe"
+    assert family_of("Italian Restaurant") == "restaurant"
+
+
+def test_family_of_returns_none_for_unknown_primary_type() -> None:
+    assert family_of("Spaceship") is None
+    assert family_of(None) is None
+    assert family_of("") is None
+
+
+def test_family_of_types_resolves_via_types_array() -> None:
+    assert family_of_types(["italian_restaurant", "restaurant"]) == "restaurant"
+    assert family_of_types(["dessert_shop"]) == "dessert"
+    assert family_of_types([]) is None
+```
+
+- [ ] **Step 3.2: Run to confirm failure**
+
+Run: `poetry run pytest tests/unit/test_filters.py -v -k "family or PRIMARY_TYPE_FAMILIES"`
+Expected: ImportError.
+
+- [ ] **Step 3.3: Refactor `filters.py`**
+
+Replace the existing `_DESSERT_TYPES` and `_DESSERT_PRIMARY_TYPES` constants (lines 140-164) with:
+
+```python
+# Maps a family name to the column conventions place_documents/places_raw
+# uses for category matching:
+#   - "types":         snake_case strings used in the `types[]` array column
+#   - "primary_types": Title Case strings used in the `primary_type` scalar
+# Both lists are required for each family because Postgres rows can carry
+# either or both. The serves_dessert helper and the primary_type_family
+# filter both compile to `(types && %s OR primary_type = ANY(%s))` against
+# these two lists so the row matches on either column.
+_PRIMARY_TYPE_FAMILIES: dict[str, dict[str, tuple[str, ...]]] = {
+    "dessert": {
+        "types": (
+            "dessert_shop",
+            "bakery",
+            "ice_cream_shop",
+            "candy_store",
+            "chocolate_shop",
+            "coffee_shop",
+            "cafe",
+            "confectionery",
+            "donut_shop",
+            "tea_house",
+        ),
+        "primary_types": (
+            "Dessert Shop",
+            "Bakery",
+            "Ice Cream Shop",
+            "Candy Store",
+            "Chocolate Shop",
+            "Coffee Shop",
+            "Cafe",
+            "Confectionery store",
+            "Donut Shop",
+            "Tea House",
+        ),
+    },
+    "bar": {
+        "types": (
+            "bar",
+            "cocktail_bar",
+            "wine_bar",
+            "pub",
+            "sports_bar",
+            "night_club",
+        ),
+        "primary_types": (
+            "Bar",
+            "Cocktail Bar",
+            "Wine Bar",
+            "Pub",
+            "Sports Bar",
+            "Night Club",
+        ),
+    },
+    "restaurant": {
+        "types": (
+            "restaurant",
+            "fine_dining_restaurant",
+            "italian_restaurant",
+            "japanese_restaurant",
+            "chinese_restaurant",
+            "mexican_restaurant",
+            "thai_restaurant",
+            "indian_restaurant",
+            "french_restaurant",
+            "vietnamese_restaurant",
+            "korean_restaurant",
+            "mediterranean_restaurant",
+            "seafood_restaurant",
+            "steak_house",
+            "sushi_restaurant",
+            "ramen_restaurant",
+            "pizza_restaurant",
+            "american_restaurant",
+        ),
+        "primary_types": (
+            "Restaurant",
+            "Fine Dining Restaurant",
+            "Italian Restaurant",
+            "Japanese Restaurant",
+            "Chinese Restaurant",
+            "Mexican Restaurant",
+            "Thai Restaurant",
+            "Indian Restaurant",
+            "French Restaurant",
+            "Vietnamese Restaurant",
+            "Korean Restaurant",
+            "Mediterranean Restaurant",
+            "Seafood Restaurant",
+            "Steak House",
+            "Sushi Restaurant",
+            "Ramen Restaurant",
+            "Pizza Restaurant",
+            "American Restaurant",
+        ),
+    },
+    "cafe": {
+        "types": ("cafe", "coffee_shop", "tea_house"),
+        "primary_types": ("Cafe", "Coffee Shop", "Tea House"),
+    },
+}
+
+
+def family_of(primary_type: str | None) -> str | None:
+    """Reverse lookup: scalar primary_type column value -> family name.
+
+    Case-preserving comparison — the DB column preserves Title Case verbatim,
+    and _PRIMARY_TYPE_FAMILIES stores both casings exactly as the columns do.
+    """
+    if not primary_type:
+        return None
+    for family, members in _PRIMARY_TYPE_FAMILIES.items():
+        if primary_type in members["primary_types"]:
+            return family
+    return None
+
+
+def family_of_types(types: list[str] | None) -> str | None:
+    """Reverse lookup: types[] array values -> family name.
+
+    Returns the first family that overlaps the input list (by membership).
+    Lets the swap node fall back when primary_type isn't in the index but
+    types[] is populated.
+    """
+    if not types:
+        return None
+    for family, members in _PRIMARY_TYPE_FAMILIES.items():
+        if any(t in members["types"] for t in types):
+            return family
+    return None
+```
+
+Update the `serves_dessert` clause (currently lines 210-217) to use the new mapping:
+
+```python
+    if f.serves_dessert is not None:
+        dessert = _PRIMARY_TYPE_FAMILIES["dessert"]
+        dessert_clause = "(types && %s OR primary_type = ANY(%s))"
+        if f.serves_dessert:
+            clauses.append(dessert_clause)
+        else:
+            clauses.append(f"NOT {dessert_clause}")
+        params.append(list(dessert["types"]))
+        params.append(list(dessert["primary_types"]))
+```
+
+- [ ] **Step 3.4: Run the new tests**
+
+Run: `poetry run pytest tests/unit/test_filters.py -v -k "family or PRIMARY_TYPE_FAMILIES"`
+Expected: all pass.
+
+- [ ] **Step 3.5: Run the full filters test file**
+
+Run: `poetry run pytest tests/unit/test_filters.py -v`
+Expected: all existing dessert tests still pass (the SQL clause shape didn't change).
+
+- [ ] **Step 3.6: Lint + typecheck**
+
+Run: `poetry run ruff check app/tools/filters.py tests/unit/test_filters.py && poetry run mypy app/tools/filters.py`
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add app/tools/filters.py tests/unit/test_filters.py
+git commit -m "refactor(filters): unify primary_type families + add family_of lookups"
+```
+
+---
+
+## Task 4: Add `primary_type_family` and `excluded_place_ids` to `SearchFilters`
+
+**Files:**
+- Modify: `app/tools/filters.py`
+- Test: `tests/unit/test_filters.py` (extend)
+
+- [ ] **Step 4.1: Write the failing tests**
+
+Append to `tests/unit/test_filters.py`:
+
+```python
+def test_primary_type_family_filter_compiles_both_columns() -> None:
+    where, params = compile_filters(
+        SearchFilters(
+            primary_type_family="dessert",
+            business_status=None,
+            min_user_rating_count=0,
+        )
+    )
+    assert "(types && %s OR primary_type = ANY(%s))" in where
+    # types list (snake_case) and primary_types list (Title Case) both as params.
+    assert "dessert_shop" in params[0]
+    assert "Dessert Shop" in params[1]
+
+
+def test_primary_type_family_unknown_family_raises() -> None:
+    with pytest.raises(ValidationError):
+        SearchFilters.model_validate({"primary_type_family": "spaceship"})
+
+
+def test_excluded_place_ids_filter_compiles_to_not_all() -> None:
+    where, params = compile_filters(
+        SearchFilters(
+            excluded_place_ids=["ChIJ_a", "ChIJ_b"],
+            business_status=None,
+            min_user_rating_count=0,
+        )
+    )
+    assert "place_id != ALL(%s)" in where
+    assert ["ChIJ_a", "ChIJ_b"] in params
+
+
+def test_excluded_place_ids_empty_list_emits_no_clause() -> None:
+    where, _ = compile_filters(
+        SearchFilters(
+            excluded_place_ids=[],
+            business_status=None,
+            min_user_rating_count=0,
+        )
+    )
+    assert "place_id != ALL" not in where
+```
+
+- [ ] **Step 4.2: Confirm they fail**
+
+Run: `poetry run pytest tests/unit/test_filters.py -v -k "primary_type_family or excluded_place_ids"`
+Expected: ValidationError on the unknown-field path / no clause emitted for the others.
+
+- [ ] **Step 4.3: Extend `SearchFilters`**
+
+In `app/tools/filters.py`, in the `SearchFilters` class, add the two new fields after `types_any` (around line 72). The `extra="forbid"` config means unknown keys are already rejected, so the validation test above doesn't need its own validator.
+
+```python
+    primary_type_family: Literal["dessert", "bar", "restaurant", "cafe"] | None = Field(
+        default=None,
+        description=(
+            "Restrict candidates to a category family (dessert/bar/restaurant/"
+            "cafe). Expands to a `(types && %s OR primary_type = ANY(%s))` "
+            "clause against both column conventions. Distinct from `types_any`, "
+            "which only matches the types[] array."
+        ),
+    )
+    excluded_place_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "place_ids to exclude from results. Used by the closure-swap path "
+            "to prevent re-suggesting a place that was previously found closed "
+            "in the same conversation. Empty list (or None) is a no-op."
+        ),
+    )
+```
+
+Add `Literal` to the typing import at the top:
+
+```python
+from typing import Literal
+```
+
+Then extend `compile_filters` with two new clauses. After the existing `types_any` block (around line 222):
+
+```python
+    if f.primary_type_family is not None:
+        family = _PRIMARY_TYPE_FAMILIES[f.primary_type_family]
+        clauses.append("(types && %s OR primary_type = ANY(%s))")
+        params.append(list(family["types"]))
+        params.append(list(family["primary_types"]))
+
+    if f.excluded_place_ids:
+        clauses.append("place_id != ALL(%s)")
+        params.append(f.excluded_place_ids)
+```
+
+(Note: `if f.excluded_place_ids:` is intentional — `[]` is falsy here, so an empty list emits no clause per the test.)
+
+- [ ] **Step 4.4: Run the new tests**
+
+Run: `poetry run pytest tests/unit/test_filters.py -v -k "primary_type_family or excluded_place_ids"`
+Expected: all pass.
+
+- [ ] **Step 4.5: Full filters file passes**
+
+Run: `poetry run pytest tests/unit/test_filters.py -v`
+
+- [ ] **Step 4.6: Lint + typecheck**
+
+Run: `poetry run ruff check app/tools/filters.py && poetry run mypy app/tools/filters.py`
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add app/tools/filters.py tests/unit/test_filters.py
+git commit -m "feat(filters): add primary_type_family + excluded_place_ids"
+```
+
+---
+
+## Task 5: Project `dist_m` from `nearby()` and add it to `PlaceHit`
+
+**Files:**
+- Modify: `app/tools/retrieval.py`
+- Test: `tests/unit/test_tools_retrieval.py` (extend)
+
+- [ ] **Step 5.1: Read the existing retrieval tests to mirror their mocking style**
+
+Run: `poetry run python -c "import pathlib; print(pathlib.Path('tests/unit/test_tools_retrieval.py').read_text()[:800])"`
+(Used only as a reference — no change needed if its `mocker.patch` shape already covers `_execute`.)
+
+- [ ] **Step 5.2: Write a failing test**
+
+Append to `tests/unit/test_tools_retrieval.py`:
+
+```python
+def test_place_hit_dist_m_defaults_to_none() -> None:
+    """Backward compatibility: semantic_search rows have no dist_m column,
+    so PlaceHit must accept missing dist_m and default to None."""
+    from app.tools.retrieval import PlaceHit
+
+    hit = PlaceHit(
+        place_id="p1",
+        name="x",
+        source="google_places",
+        similarity=0.7,
+    )
+    assert hit.dist_m is None
+
+
+def test_nearby_projects_dist_m_in_select(mocker) -> None:
+    """nearby() must SELECT dist_m alongside the existing fields so the
+    closure-swap node can score candidates by route impact."""
+    from app.tools.retrieval import nearby
+
+    captured: dict = {}
+
+    def _fake_execute(sql: str, params: list):
+        captured["sql"] = sql
+        captured["params"] = params
+        return [
+            {
+                "place_id": "p2",
+                "name": "near",
+                "primary_type": "Bar",
+                "formatted_address": "...",
+                "latitude": 37.78,
+                "longitude": -122.41,
+                "rating": 4.5,
+                "price_level": None,
+                "business_status": "OPERATIONAL",
+                "source": "google_places",
+                "similarity": 0.0,
+                "snippet": "snippet",
+                "dist_m": 250.0,
+            }
+        ]
+
+    mocker.patch("app.tools.retrieval._execute", side_effect=_fake_execute)
+    hits = nearby(place_id="anchor", radius_m=800)
+    assert "dist_m" in captured["sql"]
+    assert hits[0].dist_m == 250.0
+```
+
+- [ ] **Step 5.3: Confirm failure**
+
+Run: `poetry run pytest tests/unit/test_tools_retrieval.py -v -k "dist_m"`
+Expected: failure — `PlaceHit` rejects unknown field `dist_m` (extra=forbid is NOT set there, but the dict-construction path would just pass it as an unknown kw if the model lacks the field — depending on Pydantic version, the test may fail by AttributeError on `.dist_m`). Either way, FAIL before the change.
+
+- [ ] **Step 5.4: Add `dist_m` to `PlaceHit`**
+
+In `app/tools/retrieval.py`, append a `dist_m: float | None = None` field to `PlaceHit` (after `snippet`, around line 44):
+
+```python
+    dist_m: float | None = None
+```
+
+- [ ] **Step 5.5: Project `dist_m` in `nearby()` SQL**
+
+Change the outer SELECT inside `nearby()` (currently lines 145-150) to include `dist_m`:
+
+```python
+        SELECT
+            place_id, name, primary_type, formatted_address,
+            latitude, longitude, rating, price_level, business_status,
+            source,
+            0.0 AS similarity,
+            snippet,
+            dist_m
+        FROM candidates
+```
+
+- [ ] **Step 5.6: Run the dist_m tests**
+
+Run: `poetry run pytest tests/unit/test_tools_retrieval.py -v -k "dist_m"`
+Expected: pass.
+
+- [ ] **Step 5.7: Confirm `semantic_search` still works (no `dist_m` row coming in)**
+
+Run: `poetry run pytest tests/unit/test_tools_retrieval.py -v`
+Expected: pass — `dist_m: float | None = None` means rows without it default to None.
+
+- [ ] **Step 5.8: Lint + typecheck**
+
+Run: `poetry run ruff check app/tools/retrieval.py && poetry run mypy app/tools/retrieval.py`
+
+- [ ] **Step 5.9: Commit**
+
+```bash
+git add app/tools/retrieval.py tests/unit/test_tools_retrieval.py
+git commit -m "feat(retrieval): project dist_m from nearby() + expose on PlaceHit"
+```
+
+---
+
+## Task 6: Add `excluded_place_ids` to `kg_traverse`
+
+**Files:**
+- Modify: `app/tools/graph.py`
+- Modify: `app/agent/tools.py` (LLM-facing wrapper)
+- Test: `tests/unit/test_kg_traverse.py` (extend)
+
+- [ ] **Step 6.1: Write the failing test**
+
+Append to `tests/unit/test_kg_traverse.py`:
+
+```python
+def test_kg_traverse_excluded_place_ids_filters_at_sql_layer(mocker) -> None:
+    """Closure-swap exclusion path: kg_traverse must drop excluded place_ids
+    from the WHERE clause at the SQL layer, not in Python."""
+    from app.tools.graph import kg_traverse
+
+    captured: dict = {}
+
+    def _fake_execute(sql: str, params: list):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    mocker.patch("app.tools.graph._execute", side_effect=_fake_execute)
+    kg_traverse(place_id="anchor", excluded_place_ids=["ChIJ_a", "ChIJ_b"])
+
+    # The SQL must include a place_id exclusion guarded by the NULL check so
+    # callers that omit excluded_place_ids still match the original behavior.
+    assert "pd.place_id != ALL(%s::text[])" in captured["sql"]
+    # Params pattern: src, relation, excluded (null check), excluded (filter), k
+    assert ["ChIJ_a", "ChIJ_b"] in captured["params"]
+
+
+def test_kg_traverse_no_exclusions_is_no_op(mocker) -> None:
+    """Without excluded_place_ids the SQL must produce the same rows as before
+    — guarded by `IS NULL` so an empty list never filters everything out."""
+    from app.tools.graph import kg_traverse
+
+    captured: dict = {}
+
+    def _fake_execute(sql: str, params: list):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    mocker.patch("app.tools.graph._execute", side_effect=_fake_execute)
+    kg_traverse(place_id="anchor")
+    # The NULL guard is in the SQL; the parameter list includes None for both
+    # exclusion slots.
+    assert "IS NULL OR pd.place_id != ALL" in captured["sql"]
+    # Two None slots for the duplicated parameter.
+    assert captured["params"].count(None) == 2
+```
+
+- [ ] **Step 6.2: Confirm failure**
+
+Run: `poetry run pytest tests/unit/test_kg_traverse.py -v -k "excluded or no_exclusions"`
+Expected: TypeError (`kg_traverse() got unexpected keyword argument 'excluded_place_ids'`).
+
+- [ ] **Step 6.3: Modify `kg_traverse`**
+
+In `app/tools/graph.py`, change the function signature (line 29) and SQL:
+
+```python
+def kg_traverse(
+    place_id: str,
+    relation_type: str = "SIMILAR_VECTOR",
+    k: int = 5,
+    excluded_place_ids: list[str] | None = None,
+) -> list[RelatedPlace]:
+    """Return up to ``k`` places related to ``place_id`` by ``relation_type``.
+
+    NEAR is ordered ascending by weight (closest first); SIMILAR_VECTOR is
+    ordered descending by weight (most similar first); other relations use a
+    stable LIMIT. Unknown relation_type raises ValueError.
+
+    ``excluded_place_ids`` lets callers (the closure-swap node) suppress
+    place_ids known to be closed in the current conversation. Passed at the
+    SQL layer so behavior matches `nearby` and `semantic_search` exclusion.
+    """
+    if relation_type not in VALID_RELATIONS:
+        raise ValueError(f"Unknown relation_type: {relation_type}")
+    view = _view_name()  # allowlist member — interpolated into SQL below
+    sql = f"""
+        SELECT pd.place_id, pd.name, pd.primary_type, pd.formatted_address,
+               pd.latitude, pd.longitude, pd.rating, pd.price_level,
+               pd.business_status, pd.source,
+               0.0 AS similarity,
+               LEFT(pd.embedding_text, 400) AS snippet,
+               r.relation_type, r.weight,
+               r.metadata AS relation_metadata
+        FROM place_relations r
+        JOIN {view} pd ON pd.place_id = r.dst_place_id
+        WHERE r.src_place_id = %s
+          AND r.relation_type = %s
+          AND (%s::text[] IS NULL OR pd.place_id != ALL(%s::text[]))
+        ORDER BY
+          CASE r.relation_type
+            WHEN 'NEAR'           THEN  r.weight
+            WHEN 'SIMILAR_VECTOR' THEN -r.weight
+            ELSE 0
+          END
+        LIMIT %s
+    """  # noqa: S608
+    # Pass excluded twice so the NULL guard short-circuits when the caller
+    # didn't provide a list — keeps the no-op semantics free.
+    exclude = excluded_place_ids or None
+    rows = _execute(sql, [place_id, relation_type, exclude, exclude, k])
+    return [RelatedPlace(**row) for row in rows]
+```
+
+- [ ] **Step 6.4: Update the LLM-facing wrapper**
+
+In `app/agent/tools.py`, change the `kg_traverse` wrapper signature (line 77-96) and forward the new arg:
+
+```python
+def kg_traverse(
+    place_id: str,
+    relation_type: str = "SIMILAR_VECTOR",
+    k: int = 5,
+    excluded_place_ids: list[str] | None = None,
+) -> list[RelatedPlace]:
+    """Traverse the knowledge graph from `place_id` along a relation_type.
+
+    Pick the relation_type by intent:
+    - SIMILAR_VECTOR: "more like this" — same vibe/category as the anchor.
+    - SAME_NEIGHBORHOOD: alternates in the same SF neighborhood.
+    - NEAR_LANDMARK: the anchor is near a known landmark (museum, park).
+    - NEAR: geographic neighbors (~800m) without re-running `nearby`.
+    - CONTAINED_IN: the parent venue (e.g. a stall inside a food hall) — rare.
+
+    Single-hop: for multi-hop reasoning call again with the new anchor. If it
+    returns empty, fall back to `semantic_search` or `nearby`.
+    """
+    from app.tools.graph import kg_traverse as _kg_traverse
+
+    return _kg_traverse(
+        place_id=place_id,
+        relation_type=relation_type,
+        k=k,
+        excluded_place_ids=excluded_place_ids,
+    )
+```
+
+- [ ] **Step 6.5: Run the new tests**
+
+Run: `poetry run pytest tests/unit/test_kg_traverse.py -v -k "excluded or no_exclusions"`
+Expected: pass.
+
+- [ ] **Step 6.6: Run the full kg_traverse test suite**
+
+Run: `poetry run pytest tests/unit/test_kg_traverse.py tests/unit/test_kg_traverse_functional.py tests/unit/test_kg_traverse_smoke.py -v`
+Expected: all pass — the SQL change is backward-compatible because the new clause is a NULL-guarded no-op when excluded is None.
+
+- [ ] **Step 6.7: Lint + typecheck**
+
+Run: `poetry run ruff check app/tools/graph.py app/agent/tools.py && poetry run mypy app/tools/graph.py app/agent/tools.py`
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add app/tools/graph.py app/agent/tools.py tests/unit/test_kg_traverse.py
+git commit -m "feat(tools): add excluded_place_ids to kg_traverse + LLM wrapper"
+```
+
+---
+
+## Task 7: Create `app/agent/swap.py` skeleton with `_per_stop_closure_status`
+
+**Files:**
+- Create: `app/agent/swap.py`
+- Create: `tests/unit/test_swap.py`
+
+**Why split:** the swap module's surface is large. Build it bottom-up — the closure-status helper underpins every other helper, and verifying it independently is cleanest.
+
+- [ ] **Step 7.1: Write the failing test**
+
+Create `tests/unit/test_swap.py`:
+
+```python
+"""Unit tests for app/agent/swap.py.
+
+All DB access (place_is_open SQL function) is mocked via _execute or the
+helper's direct cursor calls. Live-DB behavior is covered separately in
+tests/integration/test_swap_real_db.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.agent.state import Stop
+
+SF = ZoneInfo("America/Los_Angeles")
+
+
+def _stop(
+    place_id: str = "p",
+    name: str = "X",
+    arrival_iso: str = "2026-05-19T19:00:00-07:00",
+    lat: float = 37.78,
+    lng: float = -122.41,
+    primary_type: str = "Bar",
+) -> Stop:
+    return Stop(
+        place_id=place_id,
+        name=name,
+        rationale="r",
+        source="google_places",
+        arrival_time=datetime.fromisoformat(arrival_iso),
+        latitude=lat,
+        longitude=lng,
+        primary_type=primary_type,
+        planned_duration_min=60,
+    )
+
+
+def test_per_stop_closure_status_all_open(mocker) -> None:
+    """Every stop returns is_open=True → list of all True (so "is closed" is
+    all False)."""
+    from app.agent.swap import _per_stop_closure_status
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"p1": True, "p2": True},
+    )
+    stops = [_stop(place_id="p1"), _stop(place_id="p2")]
+    statuses = _per_stop_closure_status(stops)
+    # _per_stop_closure_status returns True for "closed".
+    assert statuses == [False, False]
+
+
+def test_per_stop_closure_status_one_closed(mocker) -> None:
+    from app.agent.swap import _per_stop_closure_status
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"p1": True, "p2": False},
+    )
+    stops = [_stop(place_id="p1"), _stop(place_id="p2")]
+    statuses = _per_stop_closure_status(stops)
+    assert statuses == [False, True]
+
+
+def test_per_stop_closure_status_skips_stops_without_arrival_time(mocker) -> None:
+    """A stop with arrival_time=None can't be checked; treat as open."""
+    from app.agent.swap import _per_stop_closure_status
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"p1": True},
+    )
+    stops = [_stop(place_id="p1")]
+    stops.append(
+        Stop(
+            place_id="p2",
+            name="no time",
+            rationale="r",
+            source="google_places",
+            arrival_time=None,
+            latitude=37.78,
+            longitude=-122.41,
+            primary_type="Bar",
+            planned_duration_min=60,
+        )
+    )
+    statuses = _per_stop_closure_status(stops)
+    assert statuses == [False, False]
+
+
+def test_per_stop_closure_status_db_failure_fails_open(mocker) -> None:
+    """A DB blip must NOT block /chat — the helper returns [False] * n
+    (no closure detected) so the plan ships unchanged. Matches checks.py
+    fail-open precedent at lines 200-205."""
+    from app.agent.swap import _per_stop_closure_status
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        side_effect=Exception("db down"),
+    )
+    statuses = _per_stop_closure_status([_stop(place_id="p1"), _stop(place_id="p2")])
+    assert statuses == [False, False]
+```
+
+- [ ] **Step 7.2: Confirm it fails**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k closure_status`
+Expected: ImportError — `app.agent.swap` doesn't exist.
+
+- [ ] **Step 7.3: Create `app/agent/swap.py`**
+
+```python
+"""Closure-aware itinerary swap node.
+
+Sits between `retime` and END in the agent graph. Detects committed stops
+that will be closed at their planned arrival time, deterministically swaps
+in walking-distance alternatives of the same category where possible,
+escalates to a single user question per turn when not, and remembers every
+closure event so refinement turns never re-suggest the same closed place.
+
+See docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
+for the architecture rationale and contract details.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from psycopg2.extras import RealDictCursor
+
+from app.agent.state import (
+    ClosureContext,
+    ItineraryState,
+    Stop,
+)
+from app.db import get_conn
+
+logger = logging.getLogger(__name__)
+
+
+def _execute_closure_query(
+    place_ids: list[str],
+    arrivals: list[Any],
+) -> dict[str, bool]:
+    """One SQL round-trip via `place_is_open`. Returns {place_id: is_open}.
+
+    Mirrors temporal_coherence at app/agent/critique/checks.py:69-79; that
+    pattern unnests the two arrays in lockstep so an N-stop itinerary is one
+    round-trip, not N. Stops missing from the result default to open (no row =
+    not in places_raw, which the critique pipeline scores separately).
+    """
+    with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT pr.place_id,
+                   place_is_open(pr.regular_opening_hours, t.arrival) AS is_open
+              FROM unnest(%s::text[], %s::timestamptz[]) AS t(place_id, arrival)
+              JOIN places_raw pr ON pr.place_id = t.place_id
+            """,
+            [place_ids, arrivals],
+        )
+        return {row["place_id"]: bool(row["is_open"]) for row in cur.fetchall()}
+
+
+def _per_stop_closure_status(stops: list[Stop]) -> list[bool]:
+    """Return [is_closed_at_arrival] per stop, in the same order as `stops`.
+
+    True means "we know this stop is closed at its planned arrival time."
+    Stops without an arrival_time, stops missing from places_raw, and full
+    DB failures all return False (fail-open — matches checks.py:200-205
+    precedent so a DB blip doesn't block the /chat response).
+    """
+    if not stops:
+        return []
+    checkable = [(i, s) for i, s in enumerate(stops) if s.arrival_time is not None]
+    if not checkable:
+        return [False] * len(stops)
+    place_ids = [s.place_id for _, s in checkable]
+    arrivals = [s.arrival_time for _, s in checkable]
+    try:
+        is_open_by_id = _execute_closure_query(place_ids, arrivals)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("closure_swap.db_error: %s", e)
+        return [False] * len(stops)
+    out = [False] * len(stops)
+    for i, stop in checkable:
+        # No row -> default to open (matches temporal_coherence semantics).
+        is_open = is_open_by_id.get(stop.place_id, True)
+        out[i] = not is_open
+    return out
+```
+
+- [ ] **Step 7.4: Run the tests**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k closure_status`
+Expected: all 4 pass.
+
+- [ ] **Step 7.5: Lint + typecheck**
+
+Run: `poetry run ruff check app/agent/swap.py tests/unit/test_swap.py && poetry run mypy app/agent/swap.py`
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add app/agent/swap.py tests/unit/test_swap.py
+git commit -m "feat(swap): add closure-status detection helper"
+```
+
+---
+
+## Task 8: Add `_resolve_insert_position`, `CandidateMatch`, `_score_candidate`
+
+**Files:**
+- Modify: `app/agent/swap.py`
+- Modify: `tests/unit/test_swap.py`
+
+- [ ] **Step 8.1: Write the failing tests**
+
+Append to `tests/unit/test_swap.py`:
+
+```python
+def test_resolve_insert_position_uses_insert_after_when_anchor_present() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _resolve_insert_position
+
+    stops = [_stop(place_id="a"), _stop(place_id="b"), _stop(place_id="c")]
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="X",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="a",
+        insert_before_place_id=None,
+        stop_index_hint=99,
+    )
+    # insert_after a (index 0) → position 1
+    assert _resolve_insert_position(ctx, stops) == 1
+
+
+def test_resolve_insert_position_falls_back_to_insert_before() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _resolve_insert_position
+
+    stops = [_stop(place_id="a"), _stop(place_id="b")]
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="X",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="missing",
+        insert_before_place_id="b",
+        stop_index_hint=99,
+    )
+    # insert_after missing; insert_before b (index 1) → position 1
+    assert _resolve_insert_position(ctx, stops) == 1
+
+
+def test_resolve_insert_position_falls_back_to_index_hint_clamped() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _resolve_insert_position
+
+    stops = [_stop(place_id="a"), _stop(place_id="b")]
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="X",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="missing",
+        insert_before_place_id="also_missing",
+        stop_index_hint=99,
+    )
+    # Both anchors absent; clamp hint to len(stops)
+    assert _resolve_insert_position(ctx, stops) == 2
+
+
+def test_score_candidate_prefers_lower_route_impact() -> None:
+    """Two candidates with identical family-match: the one with smaller
+    combined prev+next distance scores higher."""
+    from app.agent.swap import _score_candidate
+
+    closed = _stop(place_id="closed", lat=37.78, lng=-122.41)
+    prev_ = _stop(place_id="prev", lat=37.78, lng=-122.41)
+    next_ = _stop(place_id="next", lat=37.785, lng=-122.41)
+
+    close_candidate = _stop(place_id="c1", lat=37.78, lng=-122.41)
+    far_candidate = _stop(place_id="c2", lat=37.90, lng=-122.41)
+
+    s_close = _score_candidate(close_candidate, closed, prev_, next_, family_match=True)
+    s_far = _score_candidate(far_candidate, closed, prev_, next_, family_match=True)
+    assert s_close > s_far
+
+
+def test_score_candidate_prefers_family_match() -> None:
+    """All else equal, a family-matching candidate beats one that doesn't."""
+    from app.agent.swap import _score_candidate
+
+    closed = _stop(place_id="closed")
+    prev_ = _stop(place_id="prev")
+    next_ = _stop(place_id="next")
+    candidate = _stop(place_id="c", lat=37.78, lng=-122.41)
+
+    s_match = _score_candidate(candidate, closed, prev_, next_, family_match=True)
+    s_nomatch = _score_candidate(candidate, closed, prev_, next_, family_match=False)
+    assert s_match > s_nomatch
+```
+
+- [ ] **Step 8.2: Confirm failure**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k "resolve_insert_position or score_candidate"`
+Expected: ImportError or AttributeError.
+
+- [ ] **Step 8.3: Add helpers to `app/agent/swap.py`**
+
+Append (importing additional symbols first if needed — `from pydantic import BaseModel`, `from app.agent.planning import haversine_m`):
+
+```python
+from pydantic import BaseModel
+
+from app.agent.planning import haversine_m
+
+
+class CandidateMatch(BaseModel):
+    """Internal record returned by candidate-search helpers."""
+
+    stop: Stop
+    distance_m: float
+    family_match_score: float
+    route_impact_score: float
+    total_score: float
+
+
+# Per-leg walking budget (meters) used as the cutoff for the silent-swap
+# path. ~500m at 80 m/min ≈ a 6-minute walk — close enough that swapping
+# doesn't change the user's experience materially. Anything beyond this
+# escalates to a user question.
+_WALKING_DISTANCE_BUDGET_M: int = 500
+
+# Citywide radius used by the fallback search. SF fits comfortably inside
+# 30 km from any anchor in the city; nearby() requires an explicit radius_m.
+_CITYWIDE_RADIUS_M: int = 30_000
+
+
+def _resolve_insert_position(
+    closure: ClosureContext,
+    stops: list[Stop],
+) -> int:
+    """Where in `stops` should we insert the proposed alternative?
+
+    Priority rules (matches ClosureContext docstring in state.py):
+      1) insert_after_place_id present in stops → that index + 1
+      2) else insert_before_place_id present in stops → that index
+      3) else stop_index_hint, clamped to [0, len(stops)]
+    """
+    by_id = {s.place_id: i for i, s in enumerate(stops)}
+    if closure.insert_after_place_id and closure.insert_after_place_id in by_id:
+        return by_id[closure.insert_after_place_id] + 1
+    if closure.insert_before_place_id and closure.insert_before_place_id in by_id:
+        return by_id[closure.insert_before_place_id]
+    return max(0, min(closure.stop_index_hint, len(stops)))
+
+
+def _score_candidate(
+    candidate: Stop,
+    closed_stop: Stop,
+    prev_stop: Stop | None,
+    next_stop: Stop | None,
+    *,
+    family_match: bool,
+) -> float:
+    """Combined score: higher is better.
+
+    Two components:
+      - family_match_score: 1.0 if same family as the closed stop, else 0.0
+      - route_impact_score: -(haversine prev→candidate + candidate→next),
+        scaled so that ~500m total adds ~0.5 to the score, and ~2km zeroes it
+    The two are summed equally weighted (1.0 each). Family match is the
+    primary lever — a 1.0 family bonus dominates any plausible route delta
+    inside the walking radius.
+    """
+    fam = 1.0 if family_match else 0.0
+    total_dist_m = 0.0
+    if prev_stop is not None and prev_stop.latitude is not None and prev_stop.longitude is not None \
+            and candidate.latitude is not None and candidate.longitude is not None:
+        total_dist_m += haversine_m(
+            (prev_stop.latitude, prev_stop.longitude),
+            (candidate.latitude, candidate.longitude),
+        )
+    if next_stop is not None and next_stop.latitude is not None and next_stop.longitude is not None \
+            and candidate.latitude is not None and candidate.longitude is not None:
+        total_dist_m += haversine_m(
+            (candidate.latitude, candidate.longitude),
+            (next_stop.latitude, next_stop.longitude),
+        )
+    # Linear penalty: 0m → 1.0, 1000m → 0.5, 2000m+ → 0
+    route = max(0.0, 1.0 - total_dist_m / 2000.0)
+    return fam + route
+```
+
+- [ ] **Step 8.4: Run the tests**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k "resolve_insert_position or score_candidate"`
+Expected: 5 pass.
+
+- [ ] **Step 8.5: Lint + typecheck**
+
+Run: `poetry run ruff check app/agent/swap.py && poetry run mypy app/agent/swap.py`
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add app/agent/swap.py tests/unit/test_swap.py
+git commit -m "feat(swap): add CandidateMatch + _resolve_insert_position + _score_candidate"
+```
+
+---
+
+## Task 9: Add `_try_walking_distance_swap` and `_try_any_distance_search`
+
+**Files:**
+- Modify: `app/agent/swap.py`
+- Modify: `tests/unit/test_swap.py`
+
+- [ ] **Step 9.1: Write the failing tests**
+
+Append to `tests/unit/test_swap.py`:
+
+```python
+def test_try_walking_distance_swap_uses_family_and_exclusion(mocker) -> None:
+    """The swap helper must:
+    1. Resolve the family from primary_type via family_of.
+    2. Pass family + exclusions to nearby() via SearchFilters.
+    3. Pass open_at = attempted_arrival.
+    4. Return the highest-scoring candidate, if any.
+    """
+    from app.agent.state import ClosureContext, ItineraryState
+    from app.agent.swap import _try_walking_distance_swap
+    from app.tools.retrieval import PlaceHit
+
+    captured_filters: list = []
+
+    def _fake_nearby(place_id, radius_m, filters, k):
+        captured_filters.append((place_id, radius_m, filters, k))
+        return [
+            PlaceHit(
+                place_id="alt1",
+                name="Alt 1",
+                primary_type="Dessert Shop",
+                latitude=37.78,
+                longitude=-122.41,
+                rating=4.5,
+                source="google_places",
+                similarity=0.0,
+                dist_m=300.0,
+            )
+        ]
+
+    mocker.patch("app.agent.swap._nearby_search", side_effect=_fake_nearby)
+    closed = _stop(place_id="closed", primary_type="Dessert Shop")
+    prev_ = _stop(place_id="prev", lat=37.78, lng=-122.41)
+    state = ItineraryState(
+        stops=[prev_, closed],
+        closure_context=[],
+    )
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Closed",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="prev",
+        insert_before_place_id=None,
+        stop_index_hint=1,
+    )
+
+    match = _try_walking_distance_swap(state, ctx, anchor_place_id="prev")
+
+    assert match is not None
+    assert match.stop.place_id == "alt1"
+    # captured: (place_id, radius_m, filters, k)
+    _, radius_m, filters, _ = captured_filters[0]
+    assert radius_m <= 500  # walking budget
+    assert filters.primary_type_family == "dessert"
+    assert "closed" in (filters.excluded_place_ids or [])
+    assert filters.open_at == datetime(2026, 5, 19, 20, 0, tzinfo=SF)
+
+
+def test_try_walking_distance_swap_returns_none_when_no_candidates(mocker) -> None:
+    from app.agent.state import ClosureContext, ItineraryState
+    from app.agent.swap import _try_walking_distance_swap
+
+    mocker.patch("app.agent.swap._nearby_search", return_value=[])
+    closed = _stop(place_id="closed", primary_type="Dessert Shop")
+    state = ItineraryState(stops=[_stop(place_id="prev"), closed])
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Closed",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="prev",
+        insert_before_place_id=None,
+        stop_index_hint=1,
+    )
+    assert _try_walking_distance_swap(state, ctx, anchor_place_id="prev") is None
+
+
+def test_try_any_distance_search_uses_citywide_radius(mocker) -> None:
+    """Fallback search uses _CITYWIDE_RADIUS_M (30km) so the question can
+    propose a drive-distance alternative when nothing is within walking
+    distance."""
+    from app.agent.state import ClosureContext, ItineraryState
+    from app.agent.swap import _try_any_distance_search
+    from app.tools.retrieval import PlaceHit
+
+    captured = []
+
+    def _fake_nearby(place_id, radius_m, filters, k):
+        captured.append(radius_m)
+        return [
+            PlaceHit(
+                place_id="alt2",
+                name="Alt 2 (far)",
+                primary_type="Dessert Shop",
+                latitude=37.80,
+                longitude=-122.45,
+                source="google_places",
+                similarity=0.0,
+                dist_m=4800.0,
+            )
+        ]
+
+    mocker.patch("app.agent.swap._nearby_search", side_effect=_fake_nearby)
+    closed = _stop(place_id="closed", primary_type="Dessert Shop")
+    state = ItineraryState(stops=[_stop(place_id="prev"), closed])
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Closed",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="prev",
+        insert_before_place_id=None,
+        stop_index_hint=1,
+    )
+
+    match = _try_any_distance_search(state, ctx, anchor_place_id="prev")
+    assert match is not None
+    assert match.distance_m == 4800.0
+    assert captured[0] == 30_000
+```
+
+- [ ] **Step 9.2: Run to confirm failure**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k "walking_distance_swap or any_distance_search"`
+Expected: AttributeError.
+
+- [ ] **Step 9.3: Implement the helpers**
+
+Append to `app/agent/swap.py` (the import block needs to grow — add the marked imports):
+
+```python
+from app.tools.filters import SearchFilters, family_of
+from app.tools.retrieval import PlaceHit
+from app.tools.retrieval import nearby as _nearby_search  # aliased for test patching
+```
+
+Then the helper bodies:
+
+```python
+def _resolve_anchor(state: ItineraryState, closed_stop: Stop) -> str | None:
+    """Pick a stable anchor place_id to search around when looking for an
+    alternative to the closed stop. Prefer the previous stop; if there is no
+    previous (closed_stop is index 0), fall back to the next stop; if
+    neither has a place_id we can use, fall back to the closed stop itself
+    (Google will return same-coords neighbors)."""
+    try:
+        idx = state.stops.index(closed_stop)
+    except ValueError:
+        return closed_stop.place_id
+    if idx > 0:
+        return state.stops[idx - 1].place_id
+    if idx + 1 < len(state.stops):
+        return state.stops[idx + 1].place_id
+    return closed_stop.place_id
+
+
+def _candidates_to_matches(
+    candidates: list[PlaceHit],
+    closed_stop: Stop,
+    state: ItineraryState,
+) -> list[CandidateMatch]:
+    """Score each candidate and sort descending. Family match is computed
+    against the closed stop's primary_type."""
+    closed_family = family_of(closed_stop.primary_type)
+    try:
+        idx = state.stops.index(closed_stop)
+    except ValueError:
+        idx = len(state.stops)
+    prev_stop = state.stops[idx - 1] if idx > 0 else None
+    next_stop = state.stops[idx + 1] if idx + 1 < len(state.stops) else None
+
+    matches: list[CandidateMatch] = []
+    for c in candidates:
+        candidate_stop = Stop(
+            place_id=c.place_id,
+            name=c.name,
+            address=c.formatted_address,
+            rating=c.rating,
+            primary_type=c.primary_type,
+            latitude=c.latitude,
+            longitude=c.longitude,
+            arrival_time=closed_stop.arrival_time,
+            planned_duration_min=closed_stop.planned_duration_min,
+            rationale=f"Walking-distance alternative for {closed_stop.name}",
+            source=c.source,
+        )
+        candidate_family = family_of(c.primary_type)
+        family_match = candidate_family is not None and candidate_family == closed_family
+        score = _score_candidate(
+            candidate_stop, closed_stop, prev_stop, next_stop, family_match=family_match
+        )
+        matches.append(
+            CandidateMatch(
+                stop=candidate_stop,
+                distance_m=c.dist_m if c.dist_m is not None else 0.0,
+                family_match_score=1.0 if family_match else 0.0,
+                route_impact_score=score - (1.0 if family_match else 0.0),
+                total_score=score,
+            )
+        )
+    matches.sort(key=lambda m: m.total_score, reverse=True)
+    return matches
+
+
+def _excluded_place_ids_from_state(
+    state: ItineraryState,
+    extra: list[str] | None = None,
+) -> list[str]:
+    """All place_ids the swap node must not re-propose:
+    current stops + every closure_context entry's source place_id + extras.
+    Every outcome contributes per the spec — once recorded, never re-suggested.
+    """
+    excluded = {s.place_id for s in state.stops}
+    excluded.update(entry.place_id for entry in state.closure_context)
+    if extra:
+        excluded.update(extra)
+    return sorted(excluded)
+
+
+def _try_walking_distance_swap(
+    state: ItineraryState,
+    closure: ClosureContext,
+    *,
+    anchor_place_id: str,
+) -> CandidateMatch | None:
+    """Search within _WALKING_DISTANCE_BUDGET_M for an alternative of the
+    same family that's open at the closed stop's attempted_arrival. Returns
+    the highest-scoring match or None if no candidates are within the
+    walking radius. DB errors return None and log."""
+    closed_stop = next((s for s in state.stops if s.place_id == closure.place_id), None)
+    if closed_stop is None:
+        return None
+    if not closure.family:
+        # Without a resolved family we can't do a category-matched search;
+        # the caller will escalate to the user.
+        return None
+    if closure.family not in {"dessert", "bar", "restaurant", "cafe"}:
+        return None
+    excluded = _excluded_place_ids_from_state(state)
+    filters = SearchFilters(
+        primary_type_family=closure.family,  # type: ignore[arg-type]
+        excluded_place_ids=excluded,
+        open_at=closure.attempted_arrival,
+    )
+    try:
+        candidates = _nearby_search(
+            place_id=anchor_place_id,
+            radius_m=_WALKING_DISTANCE_BUDGET_M,
+            filters=filters,
+            k=8,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("closure_swap.db_error during walking-distance search: %s", e)
+        return None
+    if not candidates:
+        return None
+    matches = _candidates_to_matches(candidates, closed_stop, state)
+    if not matches:
+        return None
+    return matches[0]
+
+
+def _try_any_distance_search(
+    state: ItineraryState,
+    closure: ClosureContext,
+    *,
+    anchor_place_id: str,
+) -> CandidateMatch | None:
+    """Citywide fallback — only used to populate the user-facing question's
+    proposed_alternative when the walking-distance pass failed. Uses
+    _CITYWIDE_RADIUS_M (30 km, covers all of SF). Same family + exclusion
+    rules as walking-distance."""
+    closed_stop = next((s for s in state.stops if s.place_id == closure.place_id), None)
+    if closed_stop is None:
+        return None
+    if not closure.family or closure.family not in {"dessert", "bar", "restaurant", "cafe"}:
+        return None
+    excluded = _excluded_place_ids_from_state(state)
+    filters = SearchFilters(
+        primary_type_family=closure.family,  # type: ignore[arg-type]
+        excluded_place_ids=excluded,
+        open_at=closure.attempted_arrival,
+    )
+    try:
+        candidates = _nearby_search(
+            place_id=anchor_place_id,
+            radius_m=_CITYWIDE_RADIUS_M,
+            filters=filters,
+            k=5,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("closure_swap.db_error during any-distance search: %s", e)
+        return None
+    if not candidates:
+        return None
+    matches = _candidates_to_matches(candidates, closed_stop, state)
+    if not matches:
+        return None
+    return matches[0]
+```
+
+- [ ] **Step 9.4: Run tests**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k "walking_distance_swap or any_distance_search"`
+Expected: 3 pass.
+
+- [ ] **Step 9.5: Lint + typecheck**
+
+Run: `poetry run ruff check app/agent/swap.py tests/unit/test_swap.py && poetry run mypy app/agent/swap.py`
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add app/agent/swap.py tests/unit/test_swap.py
+git commit -m "feat(swap): add walking-distance + citywide candidate search"
+```
+
+---
+
+## Task 10: Add `_bounded_retime_after_swap`, `_apply_swap`, `_promote_pending`, `_formulate_closure_question`
+
+**Files:**
+- Modify: `app/agent/swap.py`
+- Modify: `tests/unit/test_swap.py`
+
+- [ ] **Step 10.1: Write the failing tests**
+
+Append to `tests/unit/test_swap.py`:
+
+```python
+def test_apply_swap_replaces_stop_at_position(mocker) -> None:
+    from app.agent.state import ClosureContext, ItineraryState
+    from app.agent.swap import CandidateMatch, _apply_swap
+
+    s1 = _stop(place_id="s1", name="S1")
+    s2_closed = _stop(place_id="s2_closed", name="S2 closed")
+    s3 = _stop(place_id="s3", name="S3")
+    state = ItineraryState(stops=[s1, s2_closed, s3])
+    replacement = _stop(place_id="s2_new", name="S2 new")
+    leg_durations_min = [10.0, 5.0]
+
+    # Avoid touching the real DB during enrich
+    mocker.patch("app.agent.swap.enrich_stops_with_booking", return_value=None)
+
+    new_stops = _apply_swap(
+        state,
+        stop_index=1,
+        replacement=replacement,
+        leg_durations_min=leg_durations_min,
+    )
+
+    assert [s.place_id for s in new_stops] == ["s1", "s2_new", "s3"]
+
+
+def test_bounded_retime_after_swap_calls_route_legs_once(mocker) -> None:
+    """The bounded retime helper makes at most ONE extra route_legs call per
+    swap-node invocation. Mock route_legs and confirm call_count == 1."""
+    from app.agent.state import ItineraryState
+    from app.agent.swap import _bounded_retime_after_swap
+    from app.tools.directions import DirectionsLeg, DirectionsResult
+
+    call_count = {"n": 0}
+
+    async def _fake_route(stops, mode="walk"):
+        call_count["n"] += 1
+        legs = [DirectionsLeg(duration_s=600, distance_m=400.0)] * max(len(stops) - 1, 1)
+        return DirectionsResult(
+            legs=legs,
+            total_duration_s=600 * len(legs),
+            mode=mode,
+            source="haversine_fallback",
+        )
+
+    mocker.patch("app.agent.swap.route_legs", side_effect=_fake_route)
+    state = ItineraryState(
+        stops=[_stop(place_id="a"), _stop(place_id="b"), _stop(place_id="c")],
+    )
+    import asyncio
+
+    retimed = asyncio.run(_bounded_retime_after_swap(state.stops))
+    assert call_count["n"] == 1
+    assert len(retimed) == 3
+
+
+def test_promote_pending_flips_first_queued_to_pending() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _promote_pending
+
+    queued1 = ClosureContext(
+        place_id="q1",
+        place_name="Q1",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="queued_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=0,
+    )
+    queued2 = queued1.model_copy(update={"place_id": "q2"})
+    auto = queued1.model_copy(update={"place_id": "a", "outcome": "auto_swapped"})
+
+    promoted = _promote_pending([auto, queued1, queued2])
+    outcomes = [c.outcome for c in promoted]
+    assert outcomes == ["auto_swapped", "pending_user_decision", "queued_user_decision"]
+
+
+def test_promote_pending_is_noop_when_no_queued() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _promote_pending
+
+    auto = ClosureContext(
+        place_id="a",
+        place_name="A",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="auto_swapped",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=0,
+    )
+    assert [c.outcome for c in _promote_pending([auto])] == ["auto_swapped"]
+
+
+def test_formulate_closure_question_with_proposal() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _formulate_closure_question
+
+    proposal = _stop(place_id="alt", name="Sophie's Crepes")
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Mochill Mochidonut",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=2,
+        proposed_alternative=proposal,
+        proposed_distance_m=4800.0,
+    )
+    q = _formulate_closure_question(ctx)
+    assert "Sophie's Crepes" in q
+    assert "Mochill Mochidonut" in q
+    # ~3 mi rounding from 4800m is expected
+    assert "3" in q
+
+
+def test_formulate_closure_question_without_proposal() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _formulate_closure_question
+
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Mochill Mochidonut",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=2,
+        proposed_alternative=None,
+        proposed_distance_m=None,
+    )
+    q = _formulate_closure_question(ctx)
+    assert "Mochill Mochidonut" in q
+    # No proposal → message should ask the user to pick / change category
+    assert "pick" in q.lower() or "different" in q.lower() or "skip" in q.lower()
+```
+
+- [ ] **Step 10.2: Confirm failure**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k "apply_swap or bounded_retime or promote_pending or formulate"`
+Expected: AttributeError.
+
+- [ ] **Step 10.3: Implement the helpers**
+
+Append to `app/agent/swap.py` (imports first — add `from app.agent.commit import enrich_stops_with_booking`, `from app.agent.planning import chain_arrival_times`, `from app.tools.directions import route_legs`):
+
+```python
+from app.agent.commit import enrich_stops_with_booking
+from app.agent.planning import chain_arrival_times
+from app.tools.directions import route_legs
+```
+
+Then:
+
+```python
+async def _bounded_retime_after_swap(stops: list[Stop]) -> list[Stop]:
+    """One extra `route_legs` call after a swap → re-chain arrival_times.
+
+    Strictly bounded: no recursion, no loop. Called at most once per swap
+    node invocation. Falls back to the input stops on any failure (mirrors
+    retime() in graph.py:319-323)."""
+    coords = [
+        (s.latitude, s.longitude)
+        for s in stops
+        if s.latitude is not None and s.longitude is not None
+    ]
+    if len(coords) < 2 or len(coords) != len(stops):
+        return stops
+    try:
+        result = await route_legs(coords, mode="walk")
+        leg_min = [leg.duration_s / 60 for leg in result.legs]
+        retimed = chain_arrival_times(stops, leg_min)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("closure_swap.retime_failure: %s", e)
+        return stops
+    return retimed
+
+
+def _apply_swap(
+    state: ItineraryState,
+    stop_index: int,
+    replacement: Stop,
+    leg_durations_min: list[float],
+) -> list[Stop]:
+    """Replace stops[stop_index] with `replacement` and re-chain arrivals.
+
+    Returns the new stops list. Caller is responsible for substituting it
+    into state.
+    """
+    new_stops = list(state.stops)
+    new_stops[stop_index] = replacement
+    if leg_durations_min and new_stops and new_stops[0].arrival_time is not None:
+        new_stops = chain_arrival_times(new_stops, leg_durations_min)
+    enrich_stops_with_booking(new_stops, state)
+    return new_stops
+
+
+def _promote_pending(
+    closure_context: list[ClosureContext],
+) -> list[ClosureContext]:
+    """If there is no pending entry, promote the first queued one (if any).
+
+    Returns a new list. Caller substitutes it into state.closure_context.
+    """
+    if any(c.outcome == "pending_user_decision" for c in closure_context):
+        return list(closure_context)
+    promoted = list(closure_context)
+    for i, c in enumerate(promoted):
+        if c.outcome == "queued_user_decision":
+            promoted[i] = c.model_copy(update={"outcome": "pending_user_decision"})
+            break
+    return promoted
+
+
+def _miles_from_meters(m: float) -> int:
+    """Round to nearest mile for user-facing text. 1609m → 1mi, 4800m → 3mi."""
+    return round(m / 1609.34)
+
+
+def _formulate_closure_question(pending: ClosureContext) -> str:
+    """User-facing question text for a pending closure decision.
+
+    Two shapes:
+      - With proposed_alternative: 'The closest open <family> is <name>,
+        about <N> mi (drive/transit). Want it, or pick something else?'
+      - Without: 'I couldn't find an open <family> alternative for <name>.
+        Want me to skip that stop, or pick a different category?'
+    """
+    if pending.proposed_alternative is not None:
+        distance = pending.proposed_distance_m or 0.0
+        miles = _miles_from_meters(distance)
+        mode = "drive" if distance > 1500 else "walk/transit"
+        return (
+            f"{pending.place_name} is closed at the planned arrival time. "
+            f"The closest open {pending.family} place is "
+            f"{pending.proposed_alternative.name}, about {miles} mi ({mode}). "
+            f"Want me to add it, or pick something else?"
+        )
+    return (
+        f"{pending.place_name} is closed at the planned arrival time and I "
+        f"couldn't find an open {pending.family} alternative. Want me to "
+        f"skip that stop, or pick a different category?"
+    )
+```
+
+- [ ] **Step 10.4: Run tests**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k "apply_swap or bounded_retime or promote_pending or formulate"`
+Expected: 6 pass.
+
+- [ ] **Step 10.5: Lint + typecheck**
+
+Run: `poetry run ruff check app/agent/swap.py && poetry run mypy app/agent/swap.py`
+
+- [ ] **Step 10.6: Commit**
+
+```bash
+git add app/agent/swap.py tests/unit/test_swap.py
+git commit -m "feat(swap): add bounded retime + apply_swap + promote_pending + question text"
+```
+
+---
+
+## Task 11: Implement `swap_closed_stops` node
+
+**Files:**
+- Modify: `app/agent/swap.py`
+- Create: `tests/unit/test_swap_node.py`
+
+This is the orchestrator. It composes everything from Tasks 7-10.
+
+- [ ] **Step 11.1: Write the failing tests**
+
+Create `tests/unit/test_swap_node.py`:
+
+```python
+"""Smoke tests for the swap_closed_stops graph node.
+
+Uses real ItineraryState + Stop models, with the SQL helpers and Routes API
+mocked. Verifies the orchestration: no-op when nothing's closed, auto-swap
+batches, escalation to pending, queueing additional pending entries, etc.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.agent.state import ClosureContext, ItineraryState, Stop
+from app.tools.directions import DirectionsLeg, DirectionsResult
+from app.tools.retrieval import PlaceHit
+
+SF = ZoneInfo("America/Los_Angeles")
+
+
+def _stop(
+    place_id: str,
+    *,
+    name: str = "X",
+    arrival_iso: str = "2026-05-19T19:00:00-07:00",
+    primary_type: str = "Bar",
+    lat: float = 37.78,
+    lng: float = -122.41,
+) -> Stop:
+    return Stop(
+        place_id=place_id,
+        name=name,
+        rationale="r",
+        source="google_places",
+        arrival_time=datetime.fromisoformat(arrival_iso),
+        latitude=lat,
+        longitude=lng,
+        primary_type=primary_type,
+        planned_duration_min=60,
+    )
+
+
+def _fake_route(stops, mode="walk"):
+    async def _r(*args, **kwargs):
+        legs = [DirectionsLeg(duration_s=600, distance_m=400.0)] * max(len(stops) - 1, 1)
+        return DirectionsResult(
+            legs=legs, total_duration_s=600 * len(legs), mode=mode, source="haversine_fallback"
+        )
+
+    return _r
+
+
+def test_swap_node_noop_when_nothing_closed(mocker) -> None:
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch("app.agent.swap._execute_closure_query", return_value={"a": True, "b": True})
+    state = ItineraryState(
+        stops=[_stop("a"), _stop("b")],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    # No-op → empty or stops unchanged
+    assert update.get("stops") in (None, state.stops)
+    assert not any(
+        e.outcome != "auto_swapped" for e in update.get("closure_context", [])
+    ), "no new pending entries"
+
+
+def test_swap_node_auto_swap_silent_when_candidate_found(mocker) -> None:
+    """Closure detected at stop 1; walking-distance candidate exists →
+    silent swap, closure_context records auto_swapped, summary reply."""
+    from app.agent.swap import swap_closed_stops
+
+    # Stop b is closed
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        side_effect=[
+            {"a": True, "b": False, "c": True},  # initial closure check
+            {"a": True, "b_alt": True, "c": True},  # post-swap re-check
+        ],
+    )
+    candidate = PlaceHit(
+        place_id="b_alt",
+        name="B Alt",
+        primary_type="Bar",
+        latitude=37.78,
+        longitude=-122.41,
+        source="google_places",
+        similarity=0.0,
+        dist_m=200.0,
+    )
+    mocker.patch("app.agent.swap._nearby_search", return_value=[candidate])
+    mocker.patch("app.agent.swap.route_legs", side_effect=_fake_route([1, 2, 3]))
+    mocker.patch("app.agent.swap.enrich_stops_with_booking", return_value=None)
+
+    state = ItineraryState(
+        stops=[
+            _stop("a", primary_type="Bar"),
+            _stop("b", primary_type="Bar"),
+            _stop("c", primary_type="Bar"),
+        ],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    new_stops = update.get("stops")
+    assert new_stops is not None
+    assert [s.place_id for s in new_stops] == ["a", "b_alt", "c"]
+    new_ctx = update["closure_context"]
+    assert any(c.outcome == "auto_swapped" and c.place_id == "b" for c in new_ctx)
+    # Silent swap → reply is the regenerated summary
+    reply = update.get("final_reply", "")
+    assert "Caveats" not in reply
+    assert "B Alt" in reply
+
+
+def test_swap_node_escalates_to_pending_when_no_walking_match(mocker) -> None:
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"a": True, "b": False},
+    )
+    # Walking search returns empty; citywide search returns one far candidate.
+    mocker.patch(
+        "app.agent.swap._nearby_search",
+        side_effect=[
+            [],  # walking-distance result
+            [
+                PlaceHit(
+                    place_id="b_far",
+                    name="B Far",
+                    primary_type="Bar",
+                    latitude=37.80,
+                    longitude=-122.45,
+                    source="google_places",
+                    similarity=0.0,
+                    dist_m=4800.0,
+                )
+            ],  # citywide fallback
+        ],
+    )
+    state = ItineraryState(
+        stops=[_stop("a", primary_type="Bar"), _stop("b", primary_type="Bar")],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    new_ctx = update["closure_context"]
+    pending = [c for c in new_ctx if c.outcome == "pending_user_decision"]
+    assert len(pending) == 1
+    assert pending[0].place_id == "b"
+    assert pending[0].proposed_alternative is not None
+    assert pending[0].proposed_alternative.place_id == "b_far"
+    # Reply is the question text, not a summary
+    assert update["final_reply"]
+    assert "B" in update["final_reply"]
+
+
+def test_swap_node_queues_additional_pending_closures(mocker) -> None:
+    """Two stops closed, neither walking-fixable → first becomes pending,
+    second becomes queued."""
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"a": False, "b": False},
+    )
+    mocker.patch("app.agent.swap._nearby_search", return_value=[])
+    state = ItineraryState(
+        stops=[_stop("a", primary_type="Bar"), _stop("b", primary_type="Bar")],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    outcomes = [c.outcome for c in update["closure_context"]]
+    assert outcomes.count("pending_user_decision") == 1
+    assert outcomes.count("queued_user_decision") == 1
+
+
+def test_swap_node_skips_when_family_unresolved(mocker) -> None:
+    """A stop whose primary_type has no family (e.g. 'Spaceship') escalates
+    to a pending entry with no proposal — we can't search."""
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"a": True, "b": False},
+    )
+    mocker.patch("app.agent.swap._nearby_search", return_value=[])  # not called for unresolved
+    state = ItineraryState(
+        stops=[
+            _stop("a", primary_type="Bar"),
+            _stop("b", primary_type="Spaceship"),  # unknown family
+        ],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    new_ctx = update["closure_context"]
+    pending = [c for c in new_ctx if c.outcome == "pending_user_decision"]
+    assert len(pending) == 1
+    assert pending[0].family == ""
+    assert pending[0].proposed_alternative is None
+
+
+def test_swap_node_caps_closure_context_at_max(mocker) -> None:
+    """When closure_context grows past MAX_CLOSURE_CONTEXT_ENTRIES, oldest
+    entries are dropped."""
+    from app.agent.state import MAX_CLOSURE_CONTEXT_ENTRIES
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        side_effect=[{"x": False}, {"y_alt": True}],
+    )
+    candidate = PlaceHit(
+        place_id="y_alt",
+        name="Y Alt",
+        primary_type="Bar",
+        latitude=37.78,
+        longitude=-122.41,
+        source="google_places",
+        similarity=0.0,
+        dist_m=200.0,
+    )
+    mocker.patch("app.agent.swap._nearby_search", return_value=[candidate])
+    mocker.patch("app.agent.swap.route_legs", side_effect=_fake_route([1]))
+    mocker.patch("app.agent.swap.enrich_stops_with_booking", return_value=None)
+
+    existing = [
+        ClosureContext(
+            place_id=f"old_{i}",
+            place_name=f"Old {i}",
+            family="bar",
+            attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+            outcome="auto_swapped",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=0,
+        )
+        for i in range(MAX_CLOSURE_CONTEXT_ENTRIES)
+    ]
+    state = ItineraryState(
+        stops=[_stop("x", primary_type="Bar")],
+        closure_context=existing,
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    new_ctx = update["closure_context"]
+    assert len(new_ctx) == MAX_CLOSURE_CONTEXT_ENTRIES
+    # The oldest "old_0" should be dropped; the new entry should be present.
+    place_ids = {c.place_id for c in new_ctx}
+    assert "old_0" not in place_ids
+    assert "x" in place_ids
+
+
+def test_swap_node_fail_open_on_initial_db_error(mocker) -> None:
+    """If the initial closure query fails, the node is a no-op and ships
+    the plan as-is. Matches checks.py:200-205 precedent."""
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        side_effect=Exception("db down"),
+    )
+    state = ItineraryState(
+        stops=[_stop("a", primary_type="Bar"), _stop("b", primary_type="Bar")],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    # Either no update or stops unchanged + empty closure_context
+    new_stops = update.get("stops", state.stops)
+    assert [s.place_id for s in new_stops] == ["a", "b"]
+```
+
+- [ ] **Step 11.2: Confirm failure**
+
+Run: `poetry run pytest tests/unit/test_swap_node.py -v`
+Expected: ImportError for `swap_closed_stops`.
+
+- [ ] **Step 11.3: Implement `swap_closed_stops`**
+
+Append to `app/agent/swap.py`:
+
+```python
+from app.agent.state import MAX_CLOSURE_CONTEXT_ENTRIES
+from app.agent.revision import summarize_stops
+
+
+def _cap_closure_context(entries: list[ClosureContext]) -> list[ClosureContext]:
+    """Append-and-drop-oldest to MAX_CLOSURE_CONTEXT_ENTRIES."""
+    if len(entries) <= MAX_CLOSURE_CONTEXT_ENTRIES:
+        return entries
+    dropped = len(entries) - MAX_CLOSURE_CONTEXT_ENTRIES
+    logger.warning("closure_context.cap_exceeded: dropped %d oldest entries", dropped)
+    return entries[dropped:]
+
+
+def _resolve_family_for_stop(stop: Stop) -> str:
+    """family from primary_type first, then nothing (we don't have types[]
+    on Stop). Returns "" when nothing resolves so the caller can still
+    record the closure (without searching)."""
+    fam = family_of(stop.primary_type) if stop.primary_type else None
+    return fam or ""
+
+
+def _build_closure_context_entry(
+    stops: list[Stop],
+    closed_index: int,
+    proposed: CandidateMatch | None,
+    outcome: str,
+) -> ClosureContext:
+    """Build a ClosureContext entry for a closed stop at `closed_index`,
+    with stable anchors derived from neighboring stops."""
+    closed = stops[closed_index]
+    insert_after = stops[closed_index - 1].place_id if closed_index > 0 else None
+    insert_before = (
+        stops[closed_index + 1].place_id if closed_index + 1 < len(stops) else None
+    )
+    return ClosureContext(
+        place_id=closed.place_id,
+        place_name=closed.name,
+        family=_resolve_family_for_stop(closed),
+        attempted_arrival=closed.arrival_time
+        or datetime.fromtimestamp(0, tz=ZoneInfo("America/Los_Angeles")),
+        outcome=outcome,  # type: ignore[arg-type]
+        insert_after_place_id=insert_after,
+        insert_before_place_id=insert_before,
+        stop_index_hint=closed_index,
+        proposed_alternative=proposed.stop if proposed else None,
+        proposed_distance_m=proposed.distance_m if proposed else None,
+    )
+
+
+async def swap_closed_stops(state: ItineraryState) -> dict[str, Any]:
+    """LangGraph node — closure-aware swap pass.
+
+    1. Per-stop closure check on real arrival times.
+    2. For each closed stop, try a walking-distance swap of the same family.
+    3. Auto-swaps batched; one bounded retime + re-check covers all of them.
+    4. Any remaining closures → first becomes pending_user_decision, the
+       rest queued_user_decision. Citywide fallback search populates the
+       pending entry's proposed_alternative when possible.
+    5. Final reply = the question text if anything is pending, else the
+       regenerated summary.
+
+    Returns the LangGraph update dict (subset of ItineraryState fields).
+    No-op (empty update) when no closures are detected.
+    """
+    if not state.stops:
+        return {}
+
+    closed = _per_stop_closure_status(state.stops)
+    if not any(closed):
+        return {}
+
+    # Phase 1: try a walking-distance swap for each closed stop.
+    working_stops = list(state.stops)
+    auto_swapped_entries: list[tuple[int, CandidateMatch]] = []
+    pending_indices: list[int] = []
+
+    for idx, is_closed in enumerate(closed):
+        if not is_closed:
+            continue
+        closed_stop = working_stops[idx]
+        family = _resolve_family_for_stop(closed_stop)
+        if not family:
+            pending_indices.append(idx)
+            continue
+        anchor = _resolve_anchor(state, closed_stop)
+        if anchor is None:
+            pending_indices.append(idx)
+            continue
+        probe_ctx = ClosureContext(
+            place_id=closed_stop.place_id,
+            place_name=closed_stop.name,
+            family=family,
+            attempted_arrival=closed_stop.arrival_time or datetime.now(),
+            outcome="pending_user_decision",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=idx,
+        )
+        match = _try_walking_distance_swap(state, probe_ctx, anchor_place_id=anchor)
+        if match is None:
+            pending_indices.append(idx)
+            continue
+        auto_swapped_entries.append((idx, match))
+
+    # Apply auto-swaps in one pass.
+    new_closure_entries: list[ClosureContext] = []
+    if auto_swapped_entries:
+        for idx, match in auto_swapped_entries:
+            working_stops[idx] = match.stop
+            new_closure_entries.append(
+                _build_closure_context_entry(
+                    state.stops, idx, proposed=match, outcome="auto_swapped"
+                )
+            )
+        # One bounded retime + re-check (Phase 2).
+        retimed = await _bounded_retime_after_swap(working_stops)
+        # Re-check on the retimed plan to catch a swap that's open at the
+        # OLD projected arrival but not the NEW one after re-routing.
+        re_closed = _per_stop_closure_status(retimed)
+        # Pull DB enrichment in once on the retimed set so cards stay fresh.
+        enrich_stops_with_booking(retimed, state)
+        working_stops = retimed
+        for idx, is_closed in enumerate(re_closed):
+            if is_closed and idx not in pending_indices:
+                pending_indices.append(idx)
+
+    # Phase 3: escalate unresolved closures.
+    pending_indices.sort()
+    for n, idx in enumerate(pending_indices):
+        closed_stop = working_stops[idx]
+        family = _resolve_family_for_stop(closed_stop)
+        outcome = "pending_user_decision" if n == 0 else "queued_user_decision"
+
+        proposal: CandidateMatch | None = None
+        if family:
+            anchor = _resolve_anchor(state, closed_stop)
+            if anchor:
+                probe_ctx = ClosureContext(
+                    place_id=closed_stop.place_id,
+                    place_name=closed_stop.name,
+                    family=family,
+                    attempted_arrival=closed_stop.arrival_time or datetime.now(),
+                    outcome="pending_user_decision",
+                    insert_after_place_id=None,
+                    insert_before_place_id=None,
+                    stop_index_hint=idx,
+                )
+                proposal = _try_any_distance_search(state, probe_ctx, anchor_place_id=anchor)
+        new_closure_entries.append(
+            _build_closure_context_entry(
+                state.stops, idx, proposed=proposal, outcome=outcome
+            )
+        )
+
+    # Drop the closed (unswapped) stops from working_stops so the summary
+    # doesn't show a place we're asking about.
+    pending_set = set(pending_indices)
+    final_stops = [s for i, s in enumerate(working_stops) if i not in pending_set]
+
+    merged_context = _cap_closure_context([*state.closure_context, *new_closure_entries])
+
+    pending_entry = next(
+        (c for c in new_closure_entries if c.outcome == "pending_user_decision"),
+        None,
+    )
+    if pending_entry is not None:
+        final_reply = _formulate_closure_question(pending_entry)
+    else:
+        probe_state = state.model_copy(update={"stops": final_stops})
+        final_reply = summarize_stops(probe_state)
+
+    return {
+        "stops": final_stops,
+        "closure_context": merged_context,
+        "final_reply": final_reply,
+    }
+```
+
+Also add `from datetime import datetime` and `from zoneinfo import ZoneInfo` to the top of the file.
+
+- [ ] **Step 11.4: Run the swap node tests**
+
+Run: `poetry run pytest tests/unit/test_swap_node.py -v`
+Expected: all 7 pass.
+
+- [ ] **Step 11.5: Run the full swap tests**
+
+Run: `poetry run pytest tests/unit/test_swap.py tests/unit/test_swap_node.py -v`
+Expected: all pass.
+
+- [ ] **Step 11.6: Lint + typecheck**
+
+Run: `poetry run ruff check app/agent/swap.py tests/unit/test_swap.py tests/unit/test_swap_node.py && poetry run mypy app/agent/swap.py`
+
+- [ ] **Step 11.7: Commit**
+
+```bash
+git add app/agent/swap.py tests/unit/test_swap_node.py
+git commit -m "feat(swap): implement swap_closed_stops orchestrator node"
+```
+
+---
+
+## Task 12: Add `_inject_closure_exclusions` helper
+
+**Files:**
+- Modify: `app/agent/swap.py`
+- Modify: `tests/unit/test_swap.py`
+
+This is the belt-and-suspenders enforcement so the prompt guidance isn't the only line of defense.
+
+- [ ] **Step 12.1: Write the failing tests**
+
+Append to `tests/unit/test_swap.py`:
+
+```python
+def test_inject_closure_exclusions_merges_into_semantic_search_filters() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _inject_closure_exclusions
+    from app.tools.filters import SearchFilters
+
+    ctx = [
+        ClosureContext(
+            place_id="closed1",
+            place_name="C1",
+            family="bar",
+            attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+            outcome="auto_swapped",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=0,
+        ),
+        ClosureContext(
+            place_id="closed2",
+            place_name="C2",
+            family="bar",
+            attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+            outcome="user_accepted_drive",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=0,
+        ),
+    ]
+    # LLM-supplied args
+    args = {
+        "query": "ramen",
+        "filters": SearchFilters(min_rating=4.0, excluded_place_ids=["llm_excluded"]),
+    }
+    out = _inject_closure_exclusions("semantic_search", args, ctx)
+    excluded = out["filters"].excluded_place_ids
+    assert set(excluded) == {"llm_excluded", "closed1", "closed2"}
+    # Returns a new args dict (not in-place mutation)
+    assert out is not args
+
+
+def test_inject_closure_exclusions_creates_filters_when_absent() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _inject_closure_exclusions
+
+    ctx = [
+        ClosureContext(
+            place_id="closed1",
+            place_name="C1",
+            family="bar",
+            attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+            outcome="auto_swapped",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=0,
+        )
+    ]
+    args = {"query": "ramen"}
+    out = _inject_closure_exclusions("semantic_search", args, ctx)
+    assert "filters" in out
+    assert out["filters"].excluded_place_ids == ["closed1"]
+
+
+def test_inject_closure_exclusions_kg_traverse_is_top_level() -> None:
+    """kg_traverse takes excluded_place_ids as a top-level arg, not via
+    filters."""
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _inject_closure_exclusions
+
+    ctx = [
+        ClosureContext(
+            place_id="closed1",
+            place_name="C1",
+            family="bar",
+            attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+            outcome="auto_swapped",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=0,
+        )
+    ]
+    args = {"place_id": "anchor", "relation_type": "SIMILAR_VECTOR"}
+    out = _inject_closure_exclusions("kg_traverse", args, ctx)
+    assert out["excluded_place_ids"] == ["closed1"]
+
+
+def test_inject_closure_exclusions_empty_context_is_noop() -> None:
+    from app.agent.swap import _inject_closure_exclusions
+
+    args = {"query": "ramen"}
+    out = _inject_closure_exclusions("semantic_search", args, [])
+    assert out == args
+    # New dict either way, but contents identical
+    assert "filters" not in out
+
+
+def test_inject_closure_exclusions_unknown_tool_is_noop() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _inject_closure_exclusions
+
+    ctx = [
+        ClosureContext(
+            place_id="closed1",
+            place_name="C1",
+            family="bar",
+            attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+            outcome="auto_swapped",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=0,
+        )
+    ]
+    args = {"foo": "bar"}
+    out = _inject_closure_exclusions("get_details", args, ctx)
+    assert out == args
+```
+
+- [ ] **Step 12.2: Run to confirm failure**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k "inject_closure_exclusions"`
+Expected: AttributeError.
+
+- [ ] **Step 12.3: Implement `_inject_closure_exclusions`**
+
+Append to `app/agent/swap.py`:
+
+```python
+def _inject_closure_exclusions(
+    tool_name: str,
+    args: dict[str, Any],
+    closure_context: list[ClosureContext],
+) -> dict[str, Any]:
+    """Merge closure_context place_ids into a tool call's exclusion argument.
+
+    Server-side belt-and-suspenders enforcement so the prompt guidance is an
+    optimization, not the only line of defense. Routes by tool name because
+    the exclusion argument lives in different places per tool:
+
+      - semantic_search / nearby → args["filters"].excluded_place_ids
+      - kg_traverse              → args["excluded_place_ids"]  (top-level)
+      - anything else            → no-op
+
+    Returns a NEW args dict; never mutates the input (the graph.act node
+    records the original args verbatim in scratch for tracing).
+    Every closure_context outcome contributes — auto_swapped through
+    pending_user_decision all exclude the source closed place_id. The
+    proposed_alternative.place_id is NOT in this set unless that place was
+    itself later recorded as a closure.
+    """
+    if not closure_context:
+        return dict(args)
+    excluded = {c.place_id for c in closure_context}
+    new_args = dict(args)
+    if tool_name in ("semantic_search", "nearby"):
+        existing_filters = new_args.get("filters")
+        if existing_filters is None:
+            filters = SearchFilters(excluded_place_ids=sorted(excluded))
+        elif isinstance(existing_filters, SearchFilters):
+            llm_excluded = set(existing_filters.excluded_place_ids or [])
+            filters = existing_filters.model_copy(
+                update={"excluded_place_ids": sorted(llm_excluded | excluded)}
+            )
+        else:
+            # LangChain delivers args as plain dicts when StructuredTool
+            # builds Pydantic args_schema — but the args dict here still
+            # carries the inner filters as a dict. Reconstruct via validation.
+            llm = SearchFilters.model_validate(existing_filters)
+            llm_excluded = set(llm.excluded_place_ids or [])
+            filters = llm.model_copy(
+                update={"excluded_place_ids": sorted(llm_excluded | excluded)}
+            )
+        new_args["filters"] = filters
+        return new_args
+    if tool_name == "kg_traverse":
+        llm_excluded = set(new_args.get("excluded_place_ids") or [])
+        new_args["excluded_place_ids"] = sorted(llm_excluded | excluded)
+        return new_args
+    return new_args
+```
+
+- [ ] **Step 12.4: Run the tests**
+
+Run: `poetry run pytest tests/unit/test_swap.py -v -k "inject_closure_exclusions"`
+Expected: 5 pass.
+
+- [ ] **Step 12.5: Lint + typecheck**
+
+Run: `poetry run ruff check app/agent/swap.py && poetry run mypy app/agent/swap.py`
+
+- [ ] **Step 12.6: Commit**
+
+```bash
+git add app/agent/swap.py tests/unit/test_swap.py
+git commit -m "feat(swap): add _inject_closure_exclusions for SQL-layer enforcement"
+```
+
+---
+
+## Task 13: Wire `swap_closed_stops` into the graph + delete the temporal_coherence caveat
+
+**Files:**
+- Modify: `app/agent/graph.py`
+- Modify: `tests/unit/test_agent_graph.py` (extend) or add new test cases
+
+- [ ] **Step 13.1: Write the failing tests**
+
+Append to an appropriate existing test file (`tests/unit/test_agent_graph.py`):
+
+```python
+def test_graph_routes_through_swap_closed_stops_node(mocker) -> None:
+    """The compiled graph must route retime → swap_closed_stops → END."""
+    from langchain_core.language_models.fake_chat_models import FakeChatModel
+
+    from app.agent.graph import build_agent_graph
+
+    # FakeChatModel doesn't actually run — we just need a bound-tools model.
+    # The graph topology check is the only assertion.
+    fake = mocker.Mock()
+    fake.bind_tools = mocker.Mock(return_value=fake)
+    graph = build_agent_graph(fake)
+    # The compiled graph exposes its node ids via .nodes
+    assert "swap_closed_stops" in graph.nodes
+
+
+def test_retime_no_longer_appends_temporal_caveat(mocker) -> None:
+    """Regression: the temporal_coherence caveat is now the swap node's
+    responsibility. The retime node must not append it under any condition.
+    """
+    import inspect
+
+    from app.agent import graph as graph_mod
+
+    src = inspect.getsource(graph_mod)
+    # The string "Caveats:" should no longer appear inside the retime node
+    # body (it lived at lines 327-347). Easiest invariant to assert:
+    assert "_final_with_caveats" not in src or src.count("_final_with_caveats(existing") == 0, (
+        "retime() must not call _final_with_caveats on temporal_coherence; "
+        "closure handling lives in app/agent/swap.py now."
+    )
+```
+
+- [ ] **Step 13.2: Confirm failure**
+
+Run: `poetry run pytest tests/unit/test_agent_graph.py -v -k "swap_closed_stops or temporal_caveat"`
+Expected: failure on both.
+
+- [ ] **Step 13.3: Modify `app/agent/graph.py`**
+
+a) Add the import at the top with the other agent imports (around line 41-42):
+
+```python
+from app.agent.swap import _inject_closure_exclusions, swap_closed_stops
+```
+
+b) Delete lines 327-347 of the existing `retime` function (the entire post-retime `temporal_coherence` check block). The retime function should end at line 326 (`update: dict[str, Any] = {"stops": retimed}`) and `return update`.
+
+Replace the original block:
+
+```python
+        update: dict[str, Any] = {"stops": retimed}
+
+        # Re-run ONLY the open-at-arrival check on the real times. Other
+        # checks (geographic/walking/hallucination) are coord/id-based and
+        # unaffected by re-timing, so re-running them would be wasted work.
+        # temporal_coherence is sync psycopg2 I/O — offload to a thread so
+        # the event loop stays responsive (same pattern as act()).
+        probe = state.model_copy(update={"stops": retimed})
+        try:
+            score = await asyncio.to_thread(temporal_coherence, probe)
+        except Exception:  # noqa: BLE001
+            # Fails open exactly like itinerary_violations(): a DB blip must
+            # not block /chat. Ship the re-timed plan without the re-check.
+            return update
+
+        # Only append a caveat if the revision loop hasn't already shipped
+        # one (the END->retime rewire routes the caveats-exhausted path
+        # through here too; _final_with_caveats is not idempotent, so a
+        # second call would duplicate the identical "Caveats:" paragraph).
+        if score < CRITIQUE_THRESHOLDS["temporal_coherence"]:
+            existing = state.final_reply or ""
+            if "Caveats:" not in existing:
+                update["final_reply"] = _final_with_caveats(existing, ["temporal_coherence"])
+        return update
+```
+
+with:
+
+```python
+        return {"stops": retimed}
+```
+
+c) Remove the now-unused imports at the top of `graph.py`. Drop these from line 31-32 and 34-39 as appropriate:
+
+```python
+from app.agent.critique.checks import CRITIQUE_THRESHOLDS, temporal_coherence  # delete this line
+from app.agent.revision import (
+    _final_with_caveats,                                                        # delete _final_with_caveats
+    critique_final_with_stops,
+    critique_step,
+    finalize_as_is,
+    short_circuit_max_steps,
+)
+```
+
+(Keep the other revision imports — they're still used.)
+
+d) Add the `swap_closed_stops` node and wire it. Find the existing graph-build block at lines 359-369:
+
+```python
+    g = StateGraph(ItineraryState)
+    g.add_node("plan", plan)
+    g.add_node("act", act)
+    g.add_node("critique", critique)
+    g.add_node("retime", retime)
+    g.set_entry_point("plan")
+    g.add_conditional_edges("plan", route_after_plan, {"act": "act", "critique": "critique"})
+    g.add_edge("act", "critique")
+    g.add_conditional_edges("critique", route_after_critique, {"plan": "plan", "retime": "retime"})
+    g.add_edge("retime", END)
+    return g.compile()
+```
+
+Change to:
+
+```python
+    g = StateGraph(ItineraryState)
+    g.add_node("plan", plan)
+    g.add_node("act", act)
+    g.add_node("critique", critique)
+    g.add_node("retime", retime)
+    g.add_node("swap_closed_stops", swap_closed_stops)
+    g.set_entry_point("plan")
+    g.add_conditional_edges("plan", route_after_plan, {"act": "act", "critique": "critique"})
+    g.add_edge("act", "critique")
+    g.add_conditional_edges("critique", route_after_critique, {"plan": "plan", "retime": "retime"})
+    g.add_edge("retime", "swap_closed_stops")
+    g.add_edge("swap_closed_stops", END)
+    return g.compile()
+```
+
+e) Inject closure exclusions in `act()`. Modify the body of the `for tc in ai.tool_calls:` loop (graph.py around lines 204-247). Right before `tool = tool_by_name.get(tc["name"])` (around line 221), insert:
+
+```python
+            # Belt-and-suspenders: merge closure-context exclusions into
+            # the tool args at the SQL layer. The prompt guidance in
+            # _constraints_context is an optimization; this is enforcement.
+            if tc["name"] in ("semantic_search", "nearby", "kg_traverse"):
+                tc["args"] = _inject_closure_exclusions(
+                    tc["name"], tc["args"], state.closure_context
+                )
+```
+
+f) Extend `_constraints_context` to mention closure exclusions. Replace the function body (lines 52-60) with:
+
+```python
+def _constraints_context(state: ItineraryState) -> str:
+    """Human-readable deterministic constraints appended to the system prompt."""
+    parts: list[str] = []
+    if state.constraints.num_stops is not None:
+        parts.append(
+            f"- The user explicitly requested {state.constraints.num_stops} stops. "
+            "Do not ask how many stops they want; plan exactly that many stops."
+        )
+    # Every closure outcome contributes — once a place has been recorded as
+    # closed in this conversation, it must not resurface as a candidate.
+    closures = state.closure_context
+    if closures:
+        names = ", ".join(c.place_name for c in closures)
+        parts.append(
+            f"- Earlier in this conversation, these places were closed at the planned "
+            f"arrival time and should NOT be re-suggested: {names}. "
+            f"Their place_ids are also excluded from your search-result candidates."
+        )
+    if not parts:
+        return ""
+    return "\n\nDETERMINISTIC REQUEST CONTEXT:\n" + "\n".join(parts)
+```
+
+- [ ] **Step 13.4: Run the graph tests**
+
+Run: `poetry run pytest tests/unit/test_agent_graph.py -v -k "swap_closed_stops or temporal_caveat"`
+Expected: pass.
+
+- [ ] **Step 13.5: Run the full agent test suite**
+
+Run: `poetry run pytest tests/unit/test_agent_graph.py tests/unit/test_agent_smoke.py tests/unit/test_agent_self_correct.py tests/unit/test_agent_self_correct_functional.py -v`
+Expected: pass (the deleted caveat block had tests that explicitly looked for "Caveats:" — these should now be removed or rewritten to expect no caveat; check the failing ones and either delete the corresponding assertions or replace them with assertions that the swap node ran instead).
+
+If any existing test asserts the temporal caveat behavior, update it. Run with `--tb=short` to see exactly which tests broke.
+
+- [ ] **Step 13.6: Lint + typecheck**
+
+Run: `poetry run ruff check app/agent/graph.py && poetry run mypy app/agent/graph.py`
+Expected: clean (unused-import errors here mean step 13.3c is incomplete — go back and remove them).
+
+- [ ] **Step 13.7: Commit**
+
+```bash
+git add app/agent/graph.py tests/unit/test_agent_graph.py
+git commit -m "feat(graph): wire swap_closed_stops node + drop temporal_coherence caveat"
+```
+
+If existing agent tests had to be updated, this commit can be split — do "remove obsolete temporal_caveat assertions" as a separate commit before this one if cleaner.
+
+---
+
+## Task 14: Extend `/chat` request/response with `conversation_state`
+
+**Files:**
+- Modify: `app/main.py`
+- Modify: `tests/unit/test_chat_endpoint.py` (extend)
+
+- [ ] **Step 14.1: Write the failing tests**
+
+Append to `tests/unit/test_chat_endpoint.py`:
+
+```python
+def test_chat_endpoint_accepts_conversation_state(mocker) -> None:
+    """An inbound conversation_state must hydrate into ItineraryState.closure_context."""
+    fake_graph = mocker.Mock()
+    captured: dict = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "make stop 2 cheaper",
+                "history": [
+                    {"role": "user", "content": "plan a 3-stop date"},
+                    {"role": "assistant", "content": "Here's your itinerary..."},
+                ],
+                "conversation_state": {
+                    "schema_version": 1,
+                    "closure_context": [
+                        {
+                            "schema_version": 1,
+                            "place_id": "ChIJ_closed",
+                            "place_name": "Mochill",
+                            "family": "dessert",
+                            "attempted_arrival": "2026-05-19T20:02:00-07:00",
+                            "outcome": "auto_swapped",
+                            "insert_after_place_id": "ChIJ_prev",
+                            "insert_before_place_id": None,
+                            "stop_index_hint": 2,
+                            "proposed_alternative": None,
+                            "proposed_distance_m": None,
+                        }
+                    ],
+                    "prior_stops": [],
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    state = captured["state"]
+    assert len(state.closure_context) == 1
+    assert state.closure_context[0].place_id == "ChIJ_closed"
+    assert state.closure_context[0].outcome == "auto_swapped"
+
+
+def test_chat_endpoint_returns_conversation_state(mocker) -> None:
+    """Final state's closure_context must be echoed in the response."""
+    fake_graph = mocker.Mock()
+
+    async def _ainvoke(state, config=None):
+        d = _final_state_dict(reply="ok")
+        d["closure_context"] = [
+            {
+                "schema_version": 1,
+                "place_id": "ChIJ_closed",
+                "place_name": "Mochill",
+                "family": "dessert",
+                "attempted_arrival": "2026-05-19T20:02:00-07:00",
+                "outcome": "auto_swapped",
+                "insert_after_place_id": None,
+                "insert_before_place_id": None,
+                "stop_index_hint": 2,
+                "proposed_alternative": None,
+                "proposed_distance_m": None,
+            }
+        ]
+        return d
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={"message": "plan a date", "history": []},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "conversation_state" in body
+    cs = body["conversation_state"]
+    assert cs["schema_version"] == 1
+    assert len(cs["closure_context"]) == 1
+    assert cs["closure_context"][0]["place_id"] == "ChIJ_closed"
+
+
+def test_chat_endpoint_degrades_on_malformed_conversation_state(mocker) -> None:
+    """A malformed conversation_state must not 422 — the handler logs and
+    falls back to empty state."""
+    fake_graph = mocker.Mock()
+    captured: dict = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "anything",
+                "conversation_state": {"schema_version": 1, "closure_context": "not-a-list"},
+            },
+        )
+    # Degrades silently → 200, no closure_context hydrated.
+    assert response.status_code == 200
+    assert captured["state"].closure_context == []
+
+
+def test_chat_endpoint_first_turn_omits_conversation_state(mocker) -> None:
+    fake_graph = mocker.Mock()
+
+    async def _ainvoke(state, config=None):
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post("/chat", json={"message": "hi"})
+
+    assert response.status_code == 200
+    body = response.json()
+    # Backend always emits a typed conversation_state, never null
+    assert "conversation_state" in body
+    assert body["conversation_state"]["schema_version"] == 1
+    assert body["conversation_state"]["closure_context"] == []
+```
+
+- [ ] **Step 14.2: Confirm failure**
+
+Run: `poetry run pytest tests/unit/test_chat_endpoint.py -v -k "conversation_state"`
+Expected: failures — request body validation might 422, response shape missing the field, etc.
+
+- [ ] **Step 14.3: Modify `app/main.py`**
+
+a) Add imports:
+
+```python
+from pydantic import ValidationError
+
+from .agent.state import ClosureContext, Stop
+```
+
+b) After the existing `ChatMessage` class (line 76-78), add:
+
+```python
+class ConversationState(BaseModel):
+    schema_version: int = 1
+    closure_context: list[ClosureContext] = Field(default_factory=list)
+    prior_stops: list[Stop] = Field(default_factory=list)
+```
+
+c) Update `ChatRequest` (line 81-83) and `ChatResponse` (line 86-90):
+
+```python
+class ChatRequest(BaseModel):
+    message: str
+    history: list[ChatMessage] = Field(default_factory=list)
+    # Opaque dict so a malformed nested object doesn't 422 before the
+    # handler runs — `/chat` does manual ConversationState.model_validate
+    # and degrades to empty state on ValidationError. dict | None still
+    # 422s on non-object payloads (string/list/number), which is the right
+    # answer for those (developer / curl mistakes).
+    conversation_state: dict[str, Any] | None = None
+
+
+class ChatResponse(BaseModel):
+    # Field name matches the frontend contract (frontend/src/api/chat.js).
+    reply: str
+    places: list[dict]
+    ragLabel: str  # noqa: N815
+    # Always emit a valid shape — strictly typed on the response side.
+    conversation_state: ConversationState | None = None
+```
+
+d) Replace the `/chat` handler body (lines 283-312) with:
+
+```python
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest, request: Request) -> ChatResponse:
+    graph = getattr(request.app.state, "agent_graph", None)
+    if graph is None:
+        raise HTTPException(status_code=503, detail=AGENT_UNAVAILABLE_DETAIL)
+
+    rag_label = getattr(request.app.state, "rag_label", _rag_label_for(None))
+
+    # Hydrate inbound conversation_state. Manual validate so we degrade
+    # rather than 422 on schema mismatch (matches the warning-log path used
+    # by other "untrusted opaque state" decoders in the codebase).
+    incoming: ConversationState
+    if req.conversation_state is None:
+        incoming = ConversationState()
+    else:
+        try:
+            incoming = ConversationState.model_validate(req.conversation_state)
+        except ValidationError:
+            logger.warning("conversation_state.decode_failed", exc_info=True)
+            incoming = ConversationState()
+
+    with trace_request("chat", message=req.message[:200]) as trace_id:
+        state = ItineraryState(
+            messages=[
+                *messages_from_history(req.history),
+                HumanMessage(content=req.message),
+            ],
+            constraints=UserConstraints(
+                num_stops=explicit_num_stops_from_conversation(req.history, req.message),
+            ),
+            closure_context=incoming.closure_context,
+        )
+        raw = await graph.ainvoke(
+            state,
+            config={
+                "callbacks": langgraph_callbacks(),
+                "metadata": {"trace_id": trace_id},
+            },
+        )
+    final_state = raw if isinstance(raw, ItineraryState) else ItineraryState(**raw)
+
+    # Build outbound conversation_state. prior_stops carries the stops the
+    # user just saw so a follow-up turn can act on them without /chat
+    # round-tripping the full places list.
+    outbound = ConversationState(
+        schema_version=1,
+        closure_context=final_state.closure_context,
+        prior_stops=final_state.stops,
+    )
+
+    return ChatResponse(
+        reply=final_state.final_reply or "",
+        places=state_to_cards(final_state),
+        ragLabel=rag_label,
+        conversation_state=outbound,
+    )
+```
+
+- [ ] **Step 14.4: Run the new tests**
+
+Run: `poetry run pytest tests/unit/test_chat_endpoint.py -v -k "conversation_state"`
+Expected: 4 pass.
+
+- [ ] **Step 14.5: Run the full chat endpoint suite**
+
+Run: `poetry run pytest tests/unit/test_chat_endpoint.py -v`
+Expected: existing tests may need adjustment for the new `conversation_state` key in responses — update `expected_place_keys` assertion if it checks response top-level keys. (Looking at the existing `test_chat_endpoint_returns_reply_places_raglabel` it asserts `set(body.keys()) == {"reply", "places", "ragLabel"}`. Update this to include `"conversation_state"`.)
+
+In `tests/unit/test_chat_endpoint.py:72`, change:
+
+```python
+assert set(body.keys()) == {"reply", "places", "ragLabel"}
+```
+
+to:
+
+```python
+assert set(body.keys()) == {"reply", "places", "ragLabel", "conversation_state"}
+```
+
+- [ ] **Step 14.6: Lint + typecheck**
+
+Run: `poetry run ruff check app/main.py && poetry run mypy app/main.py`
+
+- [ ] **Step 14.7: Commit**
+
+```bash
+git add app/main.py tests/unit/test_chat_endpoint.py
+git commit -m "feat(chat): add conversation_state round-trip on /chat"
+```
+
+---
+
+## Task 15: Implement accept/decline/alternative early-return branches
+
+**Files:**
+- Modify: `app/main.py`
+- Modify: `tests/unit/test_chat_endpoint.py`
+
+This is the user-decision routing that runs BEFORE the graph when a pending entry is present.
+
+- [ ] **Step 15.1: Write the failing tests**
+
+Append to `tests/unit/test_chat_endpoint.py`:
+
+```python
+def _pending_state(
+    place_id: str = "ChIJ_closed",
+    family: str = "dessert",
+    proposed_id: str = "ChIJ_sophies",
+    prior_stop_id: str = "ChIJ_stop1",
+) -> dict:
+    return {
+        "schema_version": 1,
+        "closure_context": [
+            {
+                "schema_version": 1,
+                "place_id": place_id,
+                "place_name": "Mochill",
+                "family": family,
+                "attempted_arrival": "2026-05-19T20:02:00-07:00",
+                "outcome": "pending_user_decision",
+                "insert_after_place_id": prior_stop_id,
+                "insert_before_place_id": None,
+                "stop_index_hint": 2,
+                "proposed_alternative": {
+                    "place_id": proposed_id,
+                    "name": "Sophie's Crepes",
+                    "rationale": "closest open dessert",
+                    "source": "google_places",
+                    "latitude": 37.7849,
+                    "longitude": -122.4093,
+                    "primary_type": "Dessert Shop",
+                    "arrival_time": "2026-05-19T20:02:00-07:00",
+                    "planned_duration_min": 30,
+                },
+                "proposed_distance_m": 4800.0,
+            }
+        ],
+        "prior_stops": [
+            {
+                "place_id": prior_stop_id,
+                "name": "Stop 1",
+                "rationale": "anchor",
+                "source": "google_places",
+                "latitude": 37.78,
+                "longitude": -122.41,
+                "primary_type": "Bar",
+                "arrival_time": "2026-05-19T18:00:00-07:00",
+                "planned_duration_min": 60,
+            },
+            {
+                "place_id": "ChIJ_stop2",
+                "name": "Stop 2",
+                "rationale": "anchor",
+                "source": "google_places",
+                "latitude": 37.785,
+                "longitude": -122.41,
+                "primary_type": "Restaurant",
+                "arrival_time": "2026-05-19T19:00:00-07:00",
+                "planned_duration_min": 90,
+            },
+        ],
+    }
+
+
+def test_chat_endpoint_accept_path_inserts_proposed_alternative(mocker) -> None:
+    """User replies "yes" → proposed_alternative inserted, graph NOT
+    invoked, response carries 3 stops + user_accepted_drive outcome."""
+    fake_graph = mocker.Mock()
+    fake_graph.ainvoke = mocker.AsyncMock(
+        side_effect=AssertionError("graph should not run on accept path")
+    )
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+    # Re-validation of proposed_alternative: re-fetch get_details, re-check open
+    from app.tools.retrieval import PlaceDetails
+
+    mocker.patch(
+        "app.main.get_details",
+        return_value=PlaceDetails(
+            place_id="ChIJ_sophies",
+            name="Sophie's Crepes",
+            source="google_places",
+            similarity=0.0,
+            latitude=37.7849,
+            longitude=-122.4093,
+            primary_type="Dessert Shop",
+            formatted_address="123 Fillmore",
+            regular_opening_hours={
+                "periods": [{"open": {"day": 2, "hour": 10}, "close": {"day": 2, "hour": 22}}]
+            },
+        ),
+    )
+    mocker.patch("app.main._place_is_open_now", return_value=True)
+    mocker.patch("app.main._per_stop_closure_status", return_value=[False, False, False])
+    mocker.patch("app.main._bounded_retime_after_swap", side_effect=lambda stops: stops)
+    mocker.patch("app.main.enrich_stops_with_booking", return_value=None)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "yes",
+                "history": [
+                    {"role": "user", "content": "plan a date"},
+                    {"role": "assistant", "content": "The closest open dessert..."},
+                ],
+                "conversation_state": _pending_state(),
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    place_ids = [p["place_id"] for p in body["places"]]
+    assert "ChIJ_sophies" in place_ids
+    cs = body["conversation_state"]
+    outcomes = [c["outcome"] for c in cs["closure_context"]]
+    assert "user_accepted_drive" in outcomes
+
+
+def test_chat_endpoint_decline_path_drops_closed_stop(mocker) -> None:
+    """User replies "no" → closed stop dropped, no graph invocation."""
+    fake_graph = mocker.Mock()
+    fake_graph.ainvoke = mocker.AsyncMock(
+        side_effect=AssertionError("graph should not run on decline path")
+    )
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "no thanks",
+                "conversation_state": _pending_state(),
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    # prior_stops had 2 stops; dropping leaves 2 stops (closed was never on
+    # the prior_stops list — it was the pending entry). Outcome flips.
+    cs = body["conversation_state"]
+    outcomes = [c["outcome"] for c in cs["closure_context"]]
+    assert "user_declined_dropped" in outcomes
+
+
+def test_chat_endpoint_alternative_path_falls_through_to_graph(mocker) -> None:
+    """User replies "find something cheaper" → graph IS invoked with a
+    HumanMessage hint about the declined drive option."""
+    fake_graph = mocker.Mock()
+    captured: dict = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "find something cheaper instead",
+                "conversation_state": _pending_state(),
+            },
+        )
+
+    assert response.status_code == 200
+    state = captured["state"]
+    # The last message should reference the closed place name + the hint.
+    last_human = next(
+        (m for m in reversed(state.messages) if m.type == "human"), None
+    )
+    assert last_human is not None
+    assert "Mochill" in last_human.content or "find something cheaper" in last_human.content
+
+
+def test_chat_endpoint_accept_escalates_when_proposed_alternative_missing(mocker) -> None:
+    """Accept path with proposed_alternative no longer in DB → graph runs
+    (not early-return) with the closure_context preserved minus the bad entry."""
+    fake_graph = mocker.Mock()
+    captured: dict = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+    mocker.patch("app.main.get_details", return_value=None)  # gone from DB
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "yes",
+                "conversation_state": _pending_state(),
+            },
+        )
+
+    assert response.status_code == 200
+    # Graph WAS invoked → not an early return
+    assert "state" in captured
+```
+
+- [ ] **Step 15.2: Confirm failure**
+
+Run: `poetry run pytest tests/unit/test_chat_endpoint.py -v -k "accept_path or decline_path or alternative_path or escalates"`
+Expected: failures — these patches reference symbols (`_place_is_open_now`, `_per_stop_closure_status`, `_bounded_retime_after_swap`, `enrich_stops_with_booking`, `get_details`) that haven't been imported into `app.main` yet.
+
+- [ ] **Step 15.3: Implement the early-return branches in `app/main.py`**
+
+a) Add imports:
+
+```python
+from datetime import datetime
+
+from .agent.input_parsing import parse_closure_decision
+from .agent.commit import enrich_stops_with_booking
+from .agent.swap import (
+    _apply_swap,
+    _bounded_retime_after_swap,
+    _per_stop_closure_status,
+    _promote_pending,
+    _resolve_insert_position,
+    _formulate_closure_question,
+    _try_walking_distance_swap,
+)
+from .agent.revision import summarize_stops
+from .tools.retrieval import get_details
+```
+
+b) Add a small helper `_place_is_open_now` near the top of `main.py` (or use the existing `temporal_coherence` helpers — but the simplest is a direct SQL call mirroring `swap._execute_closure_query`). Drop in right before the `chat` handler:
+
+```python
+def _place_is_open_now(hours: dict | None, when: datetime) -> bool:
+    """One-shot SQL call mirroring closure_swap's check, for a single
+    proposed alternative on the accept path. Fails OPEN — a DB blip must
+    not block the swap, matching the codebase's fail-open precedent."""
+    import json as _json
+
+    import psycopg2
+
+    from .db import get_conn
+
+    if not hours:
+        return True
+    try:
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT place_is_open(%s::jsonb, %s)",
+                [_json.dumps(hours), when],
+            )
+            row = cur.fetchone()
+            return bool(row[0]) if row else True
+    except psycopg2.Error:
+        logger.warning("_place_is_open_now DB error; treating as open", exc_info=True)
+        return True
+```
+
+c) Extract the existing `chat()` handler body into a helper, and route based on whether there's a pending closure decision. Replace the `chat()` function (the version produced in Task 14) with:
+
+```python
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest, request: Request) -> ChatResponse:
+    graph = getattr(request.app.state, "agent_graph", None)
+    if graph is None:
+        raise HTTPException(status_code=503, detail=AGENT_UNAVAILABLE_DETAIL)
+
+    rag_label = getattr(request.app.state, "rag_label", _rag_label_for(None))
+
+    incoming: ConversationState
+    if req.conversation_state is None:
+        incoming = ConversationState()
+    else:
+        try:
+            incoming = ConversationState.model_validate(req.conversation_state)
+        except ValidationError:
+            logger.warning("conversation_state.decode_failed", exc_info=True)
+            incoming = ConversationState()
+
+    pending = next(
+        (c for c in incoming.closure_context if c.outcome == "pending_user_decision"),
+        None,
+    )
+
+    if pending is not None and req.message.strip():
+        decision = parse_closure_decision(req.message)
+        if decision == "accept":
+            early = await _try_accept_path(
+                pending, incoming, rag_label
+            )
+            if early is not None:
+                return early
+            # else fall through to graph (re-validation failed)
+        elif decision == "decline":
+            return _decline_path(pending, incoming, rag_label)
+        # "alternative" intentionally falls through to the graph
+
+    with trace_request("chat", message=req.message[:200]) as trace_id:
+        # If "alternative", prepend a HumanMessage hint so the model sees
+        # the user declined the drive option but still wants help.
+        hint_messages: list[HumanMessage] = []
+        if pending is not None and req.message.strip():
+            decision = parse_closure_decision(req.message)
+            if decision == "alternative":
+                hint_messages.append(
+                    HumanMessage(
+                        content=(
+                            f"User declined the drive option for "
+                            f"{pending.place_name}. They want: "
+                            f"'{req.message}'. Plan again with this guidance."
+                        )
+                    )
+                )
+
+        state = ItineraryState(
+            messages=[
+                *messages_from_history(req.history),
+                *hint_messages,
+                HumanMessage(content=req.message),
+            ],
+            constraints=UserConstraints(
+                num_stops=explicit_num_stops_from_conversation(req.history, req.message),
+            ),
+            closure_context=incoming.closure_context,
+        )
+        raw = await graph.ainvoke(
+            state,
+            config={
+                "callbacks": langgraph_callbacks(),
+                "metadata": {"trace_id": trace_id},
+            },
+        )
+    final_state = raw if isinstance(raw, ItineraryState) else ItineraryState(**raw)
+
+    outbound = ConversationState(
+        schema_version=1,
+        closure_context=final_state.closure_context,
+        prior_stops=final_state.stops,
+    )
+
+    return ChatResponse(
+        reply=final_state.final_reply or "",
+        places=state_to_cards(final_state),
+        ragLabel=rag_label,
+        conversation_state=outbound,
+    )
+
+
+async def _try_accept_path(
+    pending: ClosureContext,
+    incoming: ConversationState,
+    rag_label: str,
+) -> ChatResponse | None:
+    """User accepted the proposed drive alternative.
+
+    Returns a built ChatResponse for the early-return path, or None if
+    re-validation fails (caller falls through to the graph).
+    """
+    if pending.proposed_alternative is None:
+        return None
+    # Re-fetch the proposal — defense in depth against stale state.
+    details = get_details(pending.proposed_alternative.place_id)
+    if details is None:
+        logger.warning("closure_swap.proposed_alternative_invalidated: place_id=%s",
+                       pending.proposed_alternative.place_id)
+        return None
+    # Re-check open-at for the proposal at attempted_arrival
+    if not _place_is_open_now(details.regular_opening_hours, pending.attempted_arrival):
+        logger.warning("closure_swap.proposed_alternative_invalidated: now closed")
+        return None
+
+    # Insert into prior_stops at the resolved position
+    insert_at = _resolve_insert_position(pending, incoming.prior_stops)
+    replacement = pending.proposed_alternative.model_copy()
+    new_stops = list(incoming.prior_stops)
+    new_stops.insert(insert_at, replacement)
+
+    # Bounded retime + closure re-check on the new plan
+    retimed = await _bounded_retime_after_swap(new_stops)
+    re_closed = _per_stop_closure_status(retimed)
+
+    # Build a probe state so we can re-use swap helpers
+    probe_state = ItineraryState(
+        stops=retimed,
+        closure_context=incoming.closure_context,
+    )
+    # Mark the pending entry as accepted
+    updated_context: list[ClosureContext] = []
+    for c in incoming.closure_context:
+        if c.place_id == pending.place_id and c.outcome == "pending_user_decision":
+            updated_context.append(c.model_copy(update={"outcome": "user_accepted_drive"}))
+        else:
+            updated_context.append(c)
+
+    # If the retime created a new closure, try to walking-distance-swap it
+    # (bounded — one more pass), then escalate anything still closed.
+    new_pending_entries: list[ClosureContext] = []
+    if any(re_closed):
+        from .agent.swap import _build_closure_context_entry, _resolve_anchor, _resolve_family_for_stop
+
+        still_closed_indices = [i for i, c_flag in enumerate(re_closed) if c_flag]
+        for idx in still_closed_indices:
+            closed_stop = retimed[idx]
+            family = _resolve_family_for_stop(closed_stop)
+            anchor = _resolve_anchor(probe_state, closed_stop)
+            match = None
+            if family and anchor:
+                probe_ctx = ClosureContext(
+                    place_id=closed_stop.place_id,
+                    place_name=closed_stop.name,
+                    family=family,
+                    attempted_arrival=closed_stop.arrival_time or datetime.now(),
+                    outcome="pending_user_decision",
+                    insert_after_place_id=None,
+                    insert_before_place_id=None,
+                    stop_index_hint=idx,
+                )
+                match = _try_walking_distance_swap(probe_state, probe_ctx, anchor_place_id=anchor)
+            if match is not None:
+                # Apply the swap inline
+                retimed[idx] = match.stop
+                updated_context.append(
+                    _build_closure_context_entry(retimed, idx, match, "auto_swapped")
+                )
+            else:
+                # Escalate
+                new_pending_entries.append(
+                    _build_closure_context_entry(retimed, idx, None,
+                        "pending_user_decision" if not new_pending_entries else "queued_user_decision")
+                )
+        if new_pending_entries:
+            updated_context.extend(new_pending_entries)
+            # Drop the closed stops from the surfaced plan
+            keep_idx = set(range(len(retimed))) - {
+                i for i, e in zip(still_closed_indices, new_pending_entries)
+                if e.outcome == "pending_user_decision"
+            }
+            retimed = [s for i, s in enumerate(retimed) if i in keep_idx]
+
+    # Promote the next queued entry if pending is gone
+    updated_context = _promote_pending(updated_context)
+
+    # If anything is still pending, surface the question; otherwise summarize
+    next_pending = next(
+        (c for c in updated_context if c.outcome == "pending_user_decision"),
+        None,
+    )
+    if next_pending is not None:
+        final_reply = _formulate_closure_question(next_pending)
+        # Drop the stop the new pending refers to from the surfaced plan
+        retimed = [s for s in retimed if s.place_id != next_pending.place_id]
+    else:
+        enrich_stops_with_booking(retimed, probe_state)
+        final_reply = summarize_stops(
+            probe_state.model_copy(update={"stops": retimed})
+        )
+
+    final_state = ItineraryState(stops=retimed, closure_context=updated_context)
+    outbound = ConversationState(
+        schema_version=1,
+        closure_context=updated_context,
+        prior_stops=retimed,
+    )
+    return ChatResponse(
+        reply=final_reply,
+        places=state_to_cards(final_state),
+        ragLabel=rag_label,
+        conversation_state=outbound,
+    )
+
+
+def _decline_path(
+    pending: ClosureContext,
+    incoming: ConversationState,
+    rag_label: str,
+) -> ChatResponse:
+    """User declined the drive option. Drop the closed stop entirely.
+
+    If queued entries exist, promote the first to pending and ask about it.
+    Otherwise summarize the (now shorter) plan.
+    """
+    # The closed stop wasn't on prior_stops to begin with (it was demoted to
+    # pending before the user saw the plan). Just flip the outcome.
+    updated_context: list[ClosureContext] = []
+    for c in incoming.closure_context:
+        if c.place_id == pending.place_id and c.outcome == "pending_user_decision":
+            updated_context.append(c.model_copy(update={"outcome": "user_declined_dropped"}))
+        else:
+            updated_context.append(c)
+    updated_context = _promote_pending(updated_context)
+    new_pending = next(
+        (c for c in updated_context if c.outcome == "pending_user_decision"),
+        None,
+    )
+    probe_state = ItineraryState(
+        stops=incoming.prior_stops,
+        closure_context=updated_context,
+    )
+    if new_pending is not None:
+        final_reply = _formulate_closure_question(new_pending)
+        surfaced_stops = [s for s in incoming.prior_stops if s.place_id != new_pending.place_id]
+    else:
+        final_reply = summarize_stops(probe_state)
+        surfaced_stops = list(incoming.prior_stops)
+
+    final_state = ItineraryState(stops=surfaced_stops, closure_context=updated_context)
+    outbound = ConversationState(
+        schema_version=1,
+        closure_context=updated_context,
+        prior_stops=surfaced_stops,
+    )
+    return ChatResponse(
+        reply=final_reply,
+        places=state_to_cards(final_state),
+        ragLabel=rag_label,
+        conversation_state=outbound,
+    )
+```
+
+- [ ] **Step 15.4: Run the tests**
+
+Run: `poetry run pytest tests/unit/test_chat_endpoint.py -v -k "accept_path or decline_path or alternative_path or escalates"`
+Expected: 4 pass.
+
+- [ ] **Step 15.5: Run the full chat endpoint test suite**
+
+Run: `poetry run pytest tests/unit/test_chat_endpoint.py -v`
+Expected: all pass.
+
+- [ ] **Step 15.6: Lint + typecheck**
+
+Run: `poetry run ruff check app/main.py && poetry run mypy app/main.py`
+
+- [ ] **Step 15.7: Commit**
+
+```bash
+git add app/main.py tests/unit/test_chat_endpoint.py
+git commit -m "feat(chat): add accept/decline/alternative early-return paths"
+```
+
+---
+
+## Task 16: Frontend — opaque `conversation_state` pass-through
+
+**Files:**
+- Modify: `frontend/src/api/chat.js`
+- Modify: `frontend/src/App.jsx`
+- Modify: `frontend/src/api/chat.test.js` if it tests sendMessage signature; otherwise add a tiny test
+
+- [ ] **Step 16.1: Write the failing test**
+
+Append to `frontend/src/api/chat.test.js` (create if necessary; mirror the existing patterns there):
+
+```javascript
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { sendMessage } from './chat'
+
+describe('sendMessage conversation_state round-trip', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sends conversation_state when provided', async () => {
+    const stub = {
+      reply: 'ok',
+      places: [],
+      ragLabel: 'openai:gpt-4o-mini',
+      conversation_state: { schema_version: 1, closure_context: [], prior_stops: [] },
+    }
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(stub),
+    })
+
+    const cs = {
+      schema_version: 1,
+      closure_context: [{ place_id: 'p', outcome: 'auto_swapped' }],
+      prior_stops: [],
+    }
+    await sendMessage('hi', [], cs)
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body)
+    expect(body.conversation_state).toEqual(cs)
+  })
+
+  it('passes null when no conversation_state given', async () => {
+    const stub = { reply: 'ok', places: [], ragLabel: '', conversation_state: null }
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(stub),
+    })
+
+    await sendMessage('hi', [])
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body)
+    expect(body.conversation_state).toBeNull()
+  })
+
+  it('returns conversation_state from response opaquely', async () => {
+    const stub = {
+      reply: 'ok',
+      places: [],
+      ragLabel: '',
+      conversation_state: { schema_version: 1, opaque: true },
+    }
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(stub),
+    })
+
+    const result = await sendMessage('hi', [])
+    expect(result.conversation_state).toEqual({ schema_version: 1, opaque: true })
+  })
+})
+```
+
+- [ ] **Step 16.2: Confirm failure**
+
+Run: `cd frontend && npm test -- chat.test`
+Expected: TypeError or failed assertions (sendMessage signature has no third arg yet).
+
+- [ ] **Step 16.3: Modify `chat.js`**
+
+Change `sendMessage` (lines 34-60):
+
+```javascript
+export async function sendMessage(message, history = [], conversationState = null) {
+  const res = await fetch(`${API_BASE}/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message,
+      history,
+      conversation_state: conversationState ?? null,
+    }),
+  })
+
+  if (!res.ok) {
+    let detail = ''
+    try {
+      const errBody = await res.json()
+      detail = errBody?.detail ? ` — ${errBody.detail}` : ''
+    } catch {
+      /* ignore parse errors */
+    }
+    throw new Error(`API error ${res.status}${detail}`)
+  }
+
+  const data = await res.json()
+  const cards = Array.isArray(data?.places) ? data.places : []
+
+  return {
+    reply: formatReply(data?.reply ?? ''),
+    places: cards.map(toUiPlace),
+    ragLabel: data?.ragLabel || undefined,
+    conversation_state: data?.conversation_state ?? null,
+  }
+}
+```
+
+- [ ] **Step 16.4: Modify `App.jsx`**
+
+Add a `useRef` for the conversation state. Find the imports (line 1) and ensure `useRef` is imported. Then in the component body, immediately after the existing `useState` calls:
+
+```javascript
+import React, { useCallback, useReducer, useRef, useState } from 'react'
+```
+
+In the component (around line 41-44):
+
+```javascript
+const [focusId, setFocusId] = useState(null)
+// Opaque conversation_state from the backend. Stored in a ref so the
+// empty-deps `handleSend` reads the current value at call time — a
+// useState here would be captured stale in the callback closure.
+const conversationStateRef = useRef(null)
+```
+
+Update the `sendMessage` call in `handleSend` (line 81):
+
+```javascript
+const data = await sendMessage(text, history, conversationStateRef.current)
+// Store opaque state for the next request.
+conversationStateRef.current = data.conversation_state ?? null
+```
+
+Also clear the ref in `handleClear` (line 117-121):
+
+```javascript
+const handleClear = useCallback(() => {
+  setMessages(INITIAL_MESSAGES)
+  dispatch({ type: 'clear' })
+  setFocusId(null)
+  conversationStateRef.current = null
+}, [])
+```
+
+- [ ] **Step 16.5: Run the frontend test**
+
+Run: `cd frontend && npm test -- chat.test`
+Expected: 3 pass.
+
+- [ ] **Step 16.6: Run the full frontend test suite**
+
+Run: `cd frontend && npm test`
+Expected: all pass.
+
+- [ ] **Step 16.7: Verify the App.jsx renders (syntax check)**
+
+Run: `cd frontend && npm run build 2>&1 | tail -10`
+Expected: build succeeds.
+
+- [ ] **Step 16.8: Commit**
+
+```bash
+git add frontend/src/api/chat.js frontend/src/api/chat.test.js frontend/src/App.jsx
+git commit -m "feat(frontend): opaque conversation_state round-trip"
+```
+
+---
+
+## Task 17: Integration tests for live DB swap behavior
+
+**Files:**
+- Create: `tests/integration/test_swap_real_db.py`
+
+- [ ] **Step 17.1: Write the integration test**
+
+Create `tests/integration/test_swap_real_db.py`:
+
+```python
+"""Integration tests for the closure-aware swap node — gated on APP_ENV=integration.
+
+These exercise the real place_is_open() PL/pgSQL helper, the real
+_PRIMARY_TYPE_FAMILIES SQL clauses, and the real `nearby()` projection.
+They're the only layer that can catch hours-data drift (Google Places
+hours change) that mocked tests can't.
+
+Run with:
+    APP_ENV=integration make test-integration
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("APP_ENV", "test") != "integration",
+    reason="Set APP_ENV=integration and provide a real DATABASE_URL to run integration tests.",
+)
+
+from app.agent.state import ItineraryState, Stop
+from app.agent.swap import _per_stop_closure_status, _try_walking_distance_swap, swap_closed_stops
+
+SF = ZoneInfo("America/Los_Angeles")
+
+
+def _make_stop(
+    place_id: str, name: str, primary_type: str, arrival: datetime
+) -> Stop:
+    """Build a real-DB-shaped Stop; coords are filled by enrich at runtime."""
+    return Stop(
+        place_id=place_id,
+        name=name,
+        rationale="integration",
+        source="google_places",
+        arrival_time=arrival,
+        primary_type=primary_type,
+        planned_duration_min=30,
+        latitude=37.78,
+        longitude=-122.41,
+    )
+
+
+def test_per_stop_closure_status_detects_real_closed_stop() -> None:
+    """For a known place with a known closing time, planning an arrival
+    AFTER close should return is_closed=True."""
+    # The exact place_ids and hours are DB-dependent; this test asserts the
+    # round-trip works end-to-end against the real `place_is_open` helper.
+    # A failing test here means hours data has drifted in the index — the
+    # remediation is usually re-running ingestion, not changing this code.
+    stops = [
+        _make_stop(
+            place_id="ChIJ_a_real_place_id_in_the_index",
+            name="Test Place",
+            primary_type="Bar",
+            arrival=datetime(2026, 5, 19, 3, 0, tzinfo=SF),  # 3am should be closed
+        ),
+    ]
+    statuses = _per_stop_closure_status(stops)
+    # Either True (real place was closed at 3am) or False (place_id wasn't
+    # in places_raw → defaults to open). Both are acceptable, but the call
+    # must not raise.
+    assert isinstance(statuses, list)
+    assert len(statuses) == 1
+
+
+def test_swap_node_runs_against_live_db_without_raising() -> None:
+    """Smoke: the node must execute against the real DB without exceptions
+    even when no stops are closed."""
+    stops = [
+        _make_stop(
+            place_id="ChIJ_a_real_place_id_in_the_index",
+            name="Anchor",
+            primary_type="Bar",
+            arrival=datetime(2026, 5, 19, 19, 0, tzinfo=SF),
+        ),
+    ]
+    state = ItineraryState(stops=stops)
+    update = asyncio.run(swap_closed_stops(state))
+    # No assertion on the contents — just that it didn't raise.
+    assert isinstance(update, dict)
+
+
+def test_walking_distance_search_uses_real_family_mapping() -> None:
+    """A walking-distance search for a dessert family must return only
+    candidates whose primary_type matches the dessert family list."""
+    from app.tools.filters import _PRIMARY_TYPE_FAMILIES
+
+    dessert_primaries = set(_PRIMARY_TYPE_FAMILIES["dessert"]["primary_types"])
+    closed = _make_stop(
+        place_id="ChIJ_a_dessert_place_id",
+        name="Closed Dessert",
+        primary_type="Dessert Shop",
+        arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+    )
+    state = ItineraryState(stops=[closed])
+    from app.agent.state import ClosureContext
+
+    ctx = ClosureContext(
+        place_id=closed.place_id,
+        place_name=closed.name,
+        family="dessert",
+        attempted_arrival=closed.arrival_time or datetime.now(SF),
+        outcome="pending_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=0,
+    )
+    match = _try_walking_distance_swap(state, ctx, anchor_place_id=closed.place_id)
+    if match is None:
+        pytest.skip("No walking-distance match in the live DB for this anchor.")
+    # primary_type belongs to the dessert family OR is None (rare)
+    assert match.stop.primary_type is None or match.stop.primary_type in dessert_primaries
+```
+
+- [ ] **Step 17.2: Verify the gate works (skip when APP_ENV unset)**
+
+Run: `poetry run pytest tests/integration/test_swap_real_db.py -v`
+Expected: 3 skipped (gate stopped them).
+
+- [ ] **Step 17.3: Document the integration-run command**
+
+Append a short note to `tests/integration/test_swap_real_db.py` in the module docstring if not already present. (It's there in step 17.1.)
+
+- [ ] **Step 17.4: Lint**
+
+Run: `poetry run ruff check tests/integration/test_swap_real_db.py`
+
+- [ ] **Step 17.5: Commit**
+
+```bash
+git add tests/integration/test_swap_real_db.py
+git commit -m "test(integration): add live-DB tests for closure-swap"
+```
+
+---
+
+## Task 18: Full-suite test + lint + typecheck + manual smoke
+
+**Files:** none modified
+
+- [ ] **Step 18.1: Full test suite**
+
+Run: `make test`
+Expected: all unit tests pass (current + ~36). Coverage should not regress.
+
+If a previously-existing test from a non-swap area fails (e.g. a test that explicitly asserted `"Caveats:"`), update or remove the obsolete assertion in a small focused commit.
+
+- [ ] **Step 18.2: Full lint**
+
+Run: `make lint`
+Expected: clean.
+
+- [ ] **Step 18.3: Full typecheck**
+
+Run: `make typecheck`
+Expected: clean.
+
+- [ ] **Step 18.4: Frontend tests + build**
+
+Run: `cd frontend && npm test && npm run build`
+Expected: all pass.
+
+- [ ] **Step 18.5: Live verification with the user**
+
+Surface to the user:
+"All automated checks pass. Ready for live verification with the omakase
+Japantown query. Confirm the MLflow tunnel and Cloud SQL proxy are running:
+- `curl -s -m3 http://localhost:5050/health` (should return 200)
+- `nc -z 127.0.0.1 5433` (should succeed)
+
+Once both are up, start the backend with the proxy-env command from the
+session prompt (NOT `make dev`), and run the demo query 5 times."
+
+The user runs the 5 live runs. Expected per the spec's success criteria:
+- "Caveats: I couldn't fully satisfy temporal_coherence" never appears.
+- Closures within walking distance silent-swap.
+- Closures outside walking distance ask exactly one question; "yes" → drive added; "no" → stop dropped; arbitrary text → graph re-plans.
+- Refinement turns never re-suggest a recorded closure.
+
+- [ ] **Step 18.6: No final commit here**
+
+The user merges PRs themselves. After live verification passes, stop. The branch is ready for the user to push and open a PR.
+
+---
+
+## Self-Review (mandatory before handing off)
+
+1. **Spec coverage:** Walk each spec section and confirm a task implements it.
+   - Architecture diagram: Task 11 + Task 13 (wiring).
+   - API contract (Request/Response/treating as untrusted): Task 14 + Task 15.
+   - state.py `ClosureContext`/`closure_context`: Task 1.
+   - main.py `ConversationState`/early-returns: Task 14 + Task 15.
+   - swap.py module: Tasks 7-12 + Task 11 (node).
+   - retrieval.py / filters.py / graph.py tool changes: Tasks 3, 4, 5, 6.
+   - graph.py wiring + caveat deletion + filter injection: Task 13.
+   - input_parsing.py `parse_closure_decision`: Task 2.
+   - Frontend chat.js + App.jsx ref: Task 16.
+   - Testing layers: every task adds tests; Task 17 covers integration; Task 18 runs the full suite.
+
+2. **Placeholder scan:** No `TBD`/`fill in details`/`similar to Task N`. Every code block is complete.
+
+3. **Type consistency:**
+   - `ClosureContext` is the canonical name everywhere (state, swap, main).
+   - `CandidateMatch` defined Task 8 used Task 9, 10, 11, 12, 15.
+   - `_per_stop_closure_status` defined Task 7, used Tasks 11, 15.
+   - `_bounded_retime_after_swap`, `_apply_swap`, `_promote_pending`, `_resolve_insert_position`, `_formulate_closure_question` all defined Task 10, used Tasks 11, 15.
+   - `_inject_closure_exclusions` defined Task 12, used Task 13.
+   - `_try_walking_distance_swap` / `_try_any_distance_search` defined Task 9, used Tasks 11, 15.
+   - `_PRIMARY_TYPE_FAMILIES` / `family_of` defined Task 3, used Tasks 4, 9.
+   - `primary_type_family` / `excluded_place_ids` on `SearchFilters` defined Task 4, used Tasks 9, 12.
+   - `dist_m` on `PlaceHit` defined Task 5, used Task 9.
+   - `kg_traverse(excluded_place_ids=...)` defined Task 6, used Tasks 12 (via `_inject_closure_exclusions`).
+   - `parse_closure_decision` defined Task 2, used Task 15.
+   - `MAX_CLOSURE_CONTEXT_ENTRIES` defined Task 1, used Task 11.
+
+4. **Cross-cutting risk:** The accept-path logic in Task 15 duplicates some swap-node logic (re-running closure checks, walking-distance swap, escalation). This is intentional — the spec splits early-return (`/chat`) from the graph node, but both must do similar work. If the duplication turns out to be tight enough to factor, do that in a follow-up commit after Task 18 passes — not during the plan execution.
+
+---
+
+## Execution Notes
+
+- **Order is rigid through Task 13** — later tasks import earlier symbols. After Task 13, Tasks 14-17 can technically interleave (they touch different files), but the simplest path is sequential.
+- **Commit cadence:** one commit per task is the norm; split if a task's own steps produce two logically distinct commits (e.g. a test-fix commit before the feature commit when an existing test had a stale assertion).
+- **Pre-commit hooks** run ruff on staged files; if a commit is blocked, re-stage and commit again (don't fight the hook).
+- **Co-author trailer** is added by the harness on the commits you produce — no manual `Co-Authored-By:` line needed in the commit message body.
+- **Don't merge.** The user merges PRs themselves; once the branch is verified live, hand back control and stop.

--- a/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
+++ b/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
@@ -131,7 +131,9 @@ POST /chat
         "family": "dessert",
         "attempted_arrival": "2026-05-19T20:02:33-07:00",
         "outcome": "pending_user_decision",
-        "stop_index": 2,
+        "insert_after_place_id": "ChIJ...stop1...",
+        "insert_before_place_id": null,
+        "stop_index_hint": 2,
         "proposed_alternative": {
           "place_id": "ChIJ...sophies...",
           "name": "Sophie's Crepes",
@@ -220,7 +222,7 @@ on `ItineraryState`:
 ```python
 class ClosureContext(BaseModel):
     schema_version: int = 1
-    place_id: str
+    place_id: str                     # the closed place
     place_name: str
     family: str                       # "dessert", "bar", "restaurant", "cafe"
     attempted_arrival: datetime
@@ -231,7 +233,17 @@ class ClosureContext(BaseModel):
         "pending_user_decision",
         "queued_user_decision",
     ]
-    stop_index: int                   # position in the itinerary where the closure occurred
+    # STABLE PLACEMENT ANCHORS — robust against neighbor drops/inserts
+    # between turns. Resolution rules in priority order:
+    #   1) If insert_after_place_id is in current stops → insert at that index + 1.
+    #   2) Else if insert_before_place_id is in current stops → insert at that index.
+    #   3) Else fall back to stop_index_hint, clamped to len(stops).
+    # Indices alone (without anchors) drift when queued closures get
+    # resolved out of order; place_ids on neighboring stops are durable
+    # except when the user also asked us to remove/swap those.
+    insert_after_place_id: str | None = None   # the stop that should be immediately BEFORE this one
+    insert_before_place_id: str | None = None  # the stop that should be immediately AFTER this one
+    stop_index_hint: int                       # original 0-based position, last-resort fallback
     proposed_alternative: Stop | None
     proposed_distance_m: float | None
 
@@ -255,21 +267,34 @@ class ConversationState(BaseModel):
 class ChatRequest(BaseModel):
     message: str
     history: list[ChatMessage] = Field(default_factory=list)
-    conversation_state: ConversationState | None = None
+    # Accept as opaque dict so a malformed payload doesn't 422 before the
+    # handler runs — `/chat` does manual `ConversationState.model_validate(...)`
+    # and degrades to empty state on ValidationError, matching the
+    # decode_from_history failure mode (warning logged, not user-facing).
+    conversation_state: dict[str, Any] | None = None
 
 class ChatResponse(BaseModel):
     reply: str
     places: list[dict]
     ragLabel: str
+    # Response is typed strictly — backend always emits a valid shape.
     conversation_state: ConversationState | None = None
 ```
 
 Extend `/chat` to:
 
-1. Hydrate state from request:
+1. Hydrate state from request (manual validation — handler degrades, never
+   422s):
    ```python
-   incoming = req.conversation_state or ConversationState()
-   closure_context = _validated_closure_context(incoming.closure_context)
+   try:
+       incoming = (
+           ConversationState.model_validate(req.conversation_state)
+           if req.conversation_state else ConversationState()
+       )
+   except ValidationError:
+       logger.warning("conversation_state.decode_failed", exc_info=True)
+       incoming = ConversationState()
+   closure_context = incoming.closure_context  # already validated by model_validate
    prior_stops     = _revalidated_prior_stops(incoming.prior_stops)  # re-enrich via DB
    ```
 2. Find any `pending_user_decision` entry (exactly one if present per v1
@@ -278,10 +303,17 @@ Extend `/chat` to:
    `parse_closure_decision(req.message)`.
 4. **Early-return branches** (before invoking graph):
    - `accept` → re-validate the proposed alternative (re-fetch details,
-     re-check open-at). If still good, insert into `prior_stops` at
-     `stop_index`, mark entry `user_accepted_drive`, run **one bounded
-     retime** on the new stops, re-run `summarize_stops`, return.
-     If the alternative is no longer valid, escalate to a fresh question.
+     re-check open-at). If still good, insert into `prior_stops` at the
+     pending entry's stable position (see Stop placement below), mark
+     entry `user_accepted_drive`, run **one bounded retime** on the new
+     stops, then **re-run `_per_stop_closure_status` on the retimed
+     itinerary**. If new closures surface (the retime shifted arrivals
+     enough to close a different stop): try walking-distance swaps for
+     them (same logic as the swap node) and re-check once more (still
+     bounded — no loops). If anything is still closed after that, mark
+     it pending/queued and ask the user. Only if everything is clean do
+     we ship the summary. If the alternative is no longer valid in the
+     initial re-check, escalate to a fresh question.
    - `decline` → drop the closed stop entirely; if queued entries exist,
      promote the first to `pending_user_decision` and ask about it.
      Otherwise re-run `summarize_stops` and return.
@@ -309,12 +341,15 @@ Internal helpers (underscore-prefixed; white-box tests import them):
   round-trip via `place_is_open`; fail-open on DB error (matches
   graph.py:336-338 precedent).
 - `_try_walking_distance_swap(state, stop_index, per_leg_budget_m) -> CandidateMatch | None`
-  — calls `nearby()` with `open_at`, `primary_types_any` (family
-  members), and place_id exclusions; scores returned candidates and
-  returns the best, or None.
+  — calls `nearby()` with `open_at`, `primary_type_family` (resolved
+  via `family_of(closed_stop.primary_type)`), and place_id exclusions;
+  scores returned candidates and returns the best, or None.
 - `_try_any_distance_search(state, closed_stop) -> CandidateMatch | None`
-  — fallback after walking-distance fails; broader `nearby()` (no
-  budget) for the pending-question proposal.
+  — fallback after walking-distance fails. `nearby()` currently requires
+  `radius_m: int`; pass `_CITYWIDE_RADIUS_M = 30_000` (covers all of SF
+  from any anchor inside it; cheaper than a separate citywide function
+  and keeps SQL behavior consistent). Used only to populate the pending
+  question's `proposed_alternative` + `proposed_distance_m`.
 - `_score_candidate(candidate, closed_stop, prev_stop, next_stop) -> float`
   — combined score: category match + route impact (distance from prev +
   distance to next, both relative to closed_stop's original position).
@@ -324,7 +359,15 @@ Internal helpers (underscore-prefixed; white-box tests import them):
   loop, NO recursion — at most one extra call per swap node invocation.
 - `_promote_pending(closure_context) -> closure_context` — when the
   current pending entry is resolved, promote the first queued entry to
-  pending. Returns the updated list.
+  pending. Returns the updated list. Placement anchors
+  (`insert_after_place_id` / `insert_before_place_id`) are not
+  recomputed here; they remain stable across promotions because they
+  anchor to neighbor place_ids, not indices.
+- `_resolve_insert_position(closure: ClosureContext, stops: list[Stop]) -> int`
+  — applies the placement priority rules from `ClosureContext`:
+  insert_after → insert_before → stop_index_hint (clamped). Used by the
+  accept early-return and by `_apply_swap` to figure out where the
+  replacement goes.
 - `_formulate_closure_question(pending: ClosureContext) -> str` — builds
   question text; differs when `proposed_alternative is None` vs
   populated.
@@ -354,15 +397,38 @@ class CandidateMatch(BaseModel):
 
 **`filters.py` changes:**
 
-- Refactor existing `_DESSERT_TYPES` into a shared
-  `_PRIMARY_TYPE_FAMILIES: dict[str, tuple[str, ...]]` with entries for
-  `dessert`, `bar`, `restaurant`, `cafe`. Single source of truth.
-- Add `family_of(primary_type: str) -> str | None`.
-- Rewire `serves_dessert` to use `_PRIMARY_TYPE_FAMILIES["dessert"]`.
+- Refactor existing `_DESSERT_TYPES` (snake_case, for the `types` array
+  column) and `_DESSERT_PRIMARY_TYPES` (Title Case, for the `primary_type`
+  scalar column) into a single nested mapping that preserves the **two
+  distinct column conventions** the DB uses:
+  ```python
+  _PRIMARY_TYPE_FAMILIES: dict[str, dict[str, tuple[str, ...]]] = {
+      "dessert": {
+          "types":        ("dessert_shop", "bakery", "ice_cream_shop", ...),       # snake, secondary
+          "primary_types": ("Dessert Shop", "Bakery", "Ice Cream Shop", ...),     # Title, primary
+      },
+      "bar":     {"types": ("bar", "cocktail_bar", "wine_bar", ...),
+                  "primary_types": ("Bar", "Cocktail Bar", "Wine Bar", ...)},
+      "restaurant": {...},
+      "cafe":    {...},
+  }
+  ```
+  Each family must define both lists. `serves_dessert` continues to use
+  the family entry. The category filter at search time uses the existing
+  `(types && %s OR primary_type = ANY(%s))` clause pattern from
+  `filters.py:211` so a place can match by either column.
+- Add `family_of(primary_type: str) -> str | None` and
+  `family_of_types(types: list[str]) -> str | None` — both perform the
+  reverse lookup against the same `_PRIMARY_TYPE_FAMILIES` (no
+  case-normalization needed because the table preserves casings
+  verbatim). When recording `ClosureContext.family`, prefer the
+  primary-type match; fall back to types array; otherwise leave family
+  empty and skip the swap (still ask the user).
 - Add to `SearchFilters`:
-  - `primary_types_any: list[str] | None = None` — compiles to
-    `primary_type = ANY(%s)` for category constraint. (Distinct from
-    existing `types_any` which queries the `types` array column.)
+  - `primary_type_family: str | None = None` — when set, expands to
+    `(types && %s OR primary_type = ANY(%s))` against the family's
+    members; **one** filter field, not two. (Distinct from existing
+    `types_any` which only queries `types`.)
   - `excluded_place_ids: list[str] | None = None` — compiles to
     `place_id != ALL(%s)` for exclusion.
 
@@ -384,6 +450,27 @@ class CandidateMatch(BaseModel):
     arrival time and should NOT be re-suggested: <comma-separated names>.
     Their place_ids are also excluded from your search-result candidates.
   ```
+- **Server-side filter injection in `act()`** (belt-and-suspenders so the
+  exclusion is enforced at the SQL layer regardless of LLM compliance).
+  Before invoking `semantic_search` / `nearby` / `kg_traverse` tool
+  calls, merge `state.closure_context` exclusions into the tool's
+  `filters.excluded_place_ids` argument:
+  ```python
+  # In act(), after looking up the tool and BEFORE asyncio.to_thread:
+  if tc["name"] in ("semantic_search", "nearby", "kg_traverse"):
+      tc["args"] = _inject_closure_exclusions(tc["args"], state.closure_context)
+  ```
+  `_inject_closure_exclusions` (new helper in `swap.py` so the same logic
+  is testable in isolation):
+  - Extracts `excluded` = list of `place_id`s from closure_context where
+    `outcome in {"auto_swapped", "user_declined_dropped",
+    "queued_user_decision"}`.
+  - Reads `args.get("filters", {})`, merges/creates
+    `excluded_place_ids` = union of any LLM-supplied value + `excluded`.
+  - Returns a new args dict; never mutates `tc["args"]` in place to
+    keep act()'s scratch-recording semantics intact.
+  This makes the prompt guidance an optimization (helps the LLM pick
+  better in the first place); the SQL filter is the enforcement.
 
 ### 6. `app/agent/input_parsing.py`
 
@@ -420,9 +507,27 @@ return {
 }
 ```
 
-Caller code in `App.jsx` stores the last `conversation_state` in state and
-passes it to the next `sendMessage` call. ~3 lines in `App.jsx`. The
-frontend never inspects the field's contents.
+Caller code in `App.jsx` stores the last `conversation_state` in a
+**`useRef`**, not `useState`. Reason: `handleSend` is a
+`useCallback(..., [])` with empty deps (see
+`frontend/src/App.jsx:46`). A `useState` value would be captured stale
+in the closure and never update across renders, so every request after
+the first would send the value from the initial render. `useRef.current`
+reads through the closure at call time and stays current:
+
+```js
+const conversationStateRef = useRef(null)
+
+const handleSend = useCallback(async (text) => {
+  // ...build userMsg, append to messages...
+  const data = await sendMessage(text, history, conversationStateRef.current)
+  conversationStateRef.current = data.conversation_state ?? null
+  // ...rest of handler...
+}, [])  // deps still empty — ref handles freshness
+```
+
+The frontend never inspects the field's contents. ~5 lines in `App.jsx`
+plus the 2 in `api/chat.js`.
 
 ## Data Flow
 
@@ -438,7 +543,10 @@ ItineraryState built; graph runs:
     _apply_swap replaces state.stops[K]
     _bounded_retime_after_swap → one extra route_legs call, re-chain
     _per_stop_closure_status re-run → no closures
-    closure_context += ClosureContext(outcome="auto_swapped", stop_index=K, ...)
+    closure_context += ClosureContext(outcome="auto_swapped",
+                                      insert_after_place_id=state.stops[K-1].place_id if K>0 else None,
+                                      insert_before_place_id=state.stops[K+1].place_id if K+1<len(state.stops) else None,
+                                      stop_index_hint=K, ...)
     final_reply = summarize_stops(state)
   ↓
 response: {
@@ -453,11 +561,13 @@ response: {
 **Turn 1:**
 ```
 swap_closed_stops:
-  closure detected at stop_index=2
+  closure detected at position 2 (between stops[1] and end)
   _try_walking_distance_swap → None
   _try_any_distance_search → CandidateMatch(Sophie's Crepes, 4800m)
   closure_context += ClosureContext(outcome="pending_user_decision",
-                                    stop_index=2,
+                                    insert_after_place_id=state.stops[1].place_id,
+                                    insert_before_place_id=None,
+                                    stop_index_hint=2,
                                     proposed_alternative=Sophie's,
                                     proposed_distance_m=4800.0)
   state.final_reply = "The closest open dessert place is Sophie's Crepes,
@@ -575,7 +685,7 @@ Structured warning logs:
 | `tests/unit/test_swap.py` | new | 10 | unit + mock |
 | `tests/unit/test_swap_node.py` | new | 7 | smoke (graph runs, LLM scripted, DB mocked) |
 | `tests/unit/test_chat_endpoint.py` | extend | +8 | functional (TestClient, graph mocked) |
-| `tests/unit/test_filters.py` | extend | +3 | unit (primary_types_any + excluded_place_ids + family_of) |
+| `tests/unit/test_filters.py` | extend | +3 | unit (primary_type_family + excluded_place_ids + family_of) |
 | `tests/integration/test_swap_real_db.py` | new | 3 | integration (`APP_ENV=integration` gate) |
 
 Notable coverage:

--- a/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
+++ b/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
@@ -267,10 +267,17 @@ class ConversationState(BaseModel):
 class ChatRequest(BaseModel):
     message: str
     history: list[ChatMessage] = Field(default_factory=list)
-    # Accept as opaque dict so a malformed payload doesn't 422 before the
-    # handler runs — `/chat` does manual `ConversationState.model_validate(...)`
-    # and degrades to empty state on ValidationError, matching the
-    # decode_from_history failure mode (warning logged, not user-facing).
+    # Accept as opaque dict so a malformed nested object doesn't 422
+    # before the handler runs — `/chat` does manual
+    # `ConversationState.model_validate(...)` and degrades to empty state
+    # on ValidationError, matching the decode_from_history failure mode
+    # (warning logged, not user-facing). Deliberate scope: `dict | None`
+    # still 422s on non-object payloads (string/list/number), which is
+    # the right answer for those — they're developer/curl mistakes, not
+    # things the real frontend can send. Switching to `Any` would
+    # additionally swallow those at the cost of losing OpenAPI schema
+    # documentation for the field; not worth it for this single-tenant
+    # known-sender frontend.
     conversation_state: dict[str, Any] | None = None
 
 class ChatResponse(BaseModel):
@@ -432,6 +439,36 @@ class CandidateMatch(BaseModel):
   - `excluded_place_ids: list[str] | None = None` — compiles to
     `place_id != ALL(%s)` for exclusion.
 
+### 4a. `app/tools/graph.py` (kg_traverse)
+
+`kg_traverse` doesn't use `SearchFilters` — it's a graph traversal with a
+purpose-built signature. Without an exclusion path here, KG-discovered
+places can still surface closed candidates that the model then commits,
+defeating the SQL-level enforcement promise. Add it as a first-class
+parameter:
+
+```python
+def kg_traverse(
+    place_id: str,
+    relation_type: str = "SIMILAR_VECTOR",
+    k: int = 5,
+    excluded_place_ids: list[str] | None = None,   # NEW
+) -> list[RelatedPlace]:
+```
+
+SQL change: append one new clause to the existing `WHERE`:
+
+```sql
+WHERE r.src_place_id = %s
+  AND r.relation_type = %s
+  AND (%s::text[] IS NULL OR pd.place_id != ALL(%s::text[]))   -- NEW
+```
+
+Params: pass `excluded_place_ids` twice (once for the NULL guard, once
+for the comparison) so an unset/None argument is a no-op and a populated
+list filters at the DB layer. Belt-and-suspenders coverage for the KG
+tool reaches feature parity with `nearby`/`semantic_search`.
+
 ### 5. `app/agent/graph.py`
 
 - **Delete** lines 327-347 of `retime` (post-retime `temporal_coherence`
@@ -454,19 +491,25 @@ class CandidateMatch(BaseModel):
   exclusion is enforced at the SQL layer regardless of LLM compliance).
   Before invoking `semantic_search` / `nearby` / `kg_traverse` tool
   calls, merge `state.closure_context` exclusions into the tool's
-  `filters.excluded_place_ids` argument:
+  exclusion argument (shape differs per tool — see bullet below):
   ```python
   # In act(), after looking up the tool and BEFORE asyncio.to_thread:
   if tc["name"] in ("semantic_search", "nearby", "kg_traverse"):
       tc["args"] = _inject_closure_exclusions(tc["args"], state.closure_context)
   ```
-  `_inject_closure_exclusions` (new helper in `swap.py` so the same logic
-  is testable in isolation):
+  `_inject_closure_exclusions(tool_name, args, closure_context)` (new
+  helper in `swap.py` so the same logic is testable in isolation):
   - Extracts `excluded` = list of `place_id`s from closure_context where
     `outcome in {"auto_swapped", "user_declined_dropped",
-    "queued_user_decision"}`.
-  - Reads `args.get("filters", {})`, merges/creates
-    `excluded_place_ids` = union of any LLM-supplied value + `excluded`.
+    "queued_user_decision"}`. Also adds the closure's own `place_id`
+    (the closed source) so the model can't propose it again either.
+  - Routes by tool name because arg shapes differ:
+    - `semantic_search` / `nearby` → exclusion lives under `args["filters"]`:
+      read or create `filters`, set `excluded_place_ids` = union of any
+      LLM-supplied value + `excluded`.
+    - `kg_traverse` → exclusion is a top-level arg:
+      set `args["excluded_place_ids"]` = union of any LLM-supplied value
+      + `excluded`.
   - Returns a new args dict; never mutates `tc["args"]` in place to
     keep act()'s scratch-recording semantics intact.
   This makes the prompt guidance an optimization (helps the LLM pick
@@ -482,13 +525,19 @@ def parse_closure_decision(text: str) -> Literal["accept", "decline", "alternati
 ```
 
 Accepted patterns:
-- `accept`: "yes", "yeah", "yep", "sure", "ok", "okay", "👍", "y"
-- `decline`: "no", "nope", "n", "nah"
-- `alternative`: anything else (including questions, free text, "yes! 4 stops")
+- `accept`: any message starting with (or whose first word is) "yes",
+  "yeah", "yep", "sure", "ok", "okay", "👍", "y" — even if other content
+  follows. Examples that match accept: `"yes"`, `"yes! make it 4 stops"`,
+  `"sure thing"`, `"ok let's go"`.
+- `decline`: same first-token logic for "no", "nope", "n", "nah".
+- `alternative`: anything else — questions, free text suggestions, empty
+  string, requests that don't start with a yes/no token. Examples:
+  `"find something cheaper instead"`, `"what about ramen?"`, `""`.
 
-The function returns `accept` even if `req.message` also contains a
-num_stops change ("yes! make it 4 stops"); the existing
-`explicit_num_stops_from_conversation` handles the count separately.
+The first-token rule resolves the "yes + num_stops change" case
+unambiguously: `"yes! make it 4 stops"` returns `accept`, and the
+existing `explicit_num_stops_from_conversation` separately handles the
+count update.
 
 ### 7. Frontend: `frontend/src/api/chat.js` (only frontend change)
 

--- a/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
+++ b/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
@@ -480,8 +480,12 @@ tool reaches feature parity with `nearby`/`semantic_search`.
   g.add_edge("swap_closed_stops", END)
   ```
 - Extend `_constraints_context` to include closure exclusion guidance
-  when `state.closure_context` has any `auto_swapped` /
-  `user_declined_dropped` / `queued_user_decision` entries:
+  whenever `state.closure_context` is non-empty — i.e. on *every*
+  outcome including `auto_swapped`, `user_accepted_drive`,
+  `user_declined_dropped`, `pending_user_decision`, and
+  `queued_user_decision`. Even after the user accepts the drive
+  alternative, the original closed source place must stay excluded on
+  refinement turns so the model doesn't re-suggest it:
   ```
   - Earlier in this conversation, these places were closed at the planned
     arrival time and should NOT be re-suggested: <comma-separated names>.
@@ -495,14 +499,18 @@ tool reaches feature parity with `nearby`/`semantic_search`.
   ```python
   # In act(), after looking up the tool and BEFORE asyncio.to_thread:
   if tc["name"] in ("semantic_search", "nearby", "kg_traverse"):
-      tc["args"] = _inject_closure_exclusions(tc["args"], state.closure_context)
+      tc["args"] = _inject_closure_exclusions(
+          tc["name"], tc["args"], state.closure_context
+      )
   ```
   `_inject_closure_exclusions(tool_name, args, closure_context)` (new
   helper in `swap.py` so the same logic is testable in isolation):
-  - Extracts `excluded` = list of `place_id`s from closure_context where
-    `outcome in {"auto_swapped", "user_declined_dropped",
-    "queued_user_decision"}`. Also adds the closure's own `place_id`
-    (the closed source) so the model can't propose it again either.
+  - Extracts `excluded = {entry.place_id for entry in closure_context}`.
+    Every outcome contributes — once a place has been recorded as closed
+    in this conversation, it must never resurface as a candidate
+    regardless of whether the user accepted a drive alternative,
+    declined, or hasn't answered yet. The `proposed_alternative.place_id`
+    is NOT in this set unless it was itself later recorded as a closure.
   - Routes by tool name because arg shapes differ:
     - `semantic_search` / `nearby` → exclusion lives under `args["filters"]`:
       read or create `filters`, set `excluded_place_ids` = union of any
@@ -638,8 +646,14 @@ response: {
   re-fetch get_details(proposed_alternative.place_id) → exists ✓
   re-run place_is_open(proposed.hours, proposed.attempted_arrival) → open ✓
   EARLY RETURN:
-    insert Sophie's into prior_stops at index=2
+    resolve placement via _resolve_insert_position (insert_after_place_id → idx)
+    insert Sophie's into prior_stops at that idx
     _bounded_retime on the new 3-stop set (one route_legs call)
+    _per_stop_closure_status(retimed) → no new closures ✓
+    # If the retime exposed a new closure on a different stop:
+    #   try walking-distance swap once; re-check; remaining unresolved
+    #   closures get promoted to pending/queued and a fresh question is
+    #   surfaced instead of summarize_stops.
     closure_context entry → mark "user_accepted_drive"
     final_reply = summarize_stops(state)
 response: {

--- a/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
+++ b/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
@@ -1,8 +1,8 @@
 # Closure-Aware Itinerary Swap — Design
 
-**Status:** Draft, awaiting user approval
+**Status:** Draft, awaiting user approval (revised post-review)
 **Date:** 2026-05-19
-**Branch:** `fix/agent-reliability-review` (will spawn a sub-PR or new branch on implementation)
+**Branch:** `fix/agent-reliability-review`
 
 ## Problem
 
@@ -31,27 +31,51 @@ agent's planned arrival time (re-checked against real travel times):
    already learned are closed.
 
 The temporal_coherence caveat is removed. Closure handling is the new
-responsibility of a dedicated node.
+responsibility of a dedicated node + an explicit conversation-state API
+field.
 
 ## Non-goals
 
 - Generic preference memory ("I don't like ramen") — closure_context is
   closure-specific.
-- Multi-conversation persistence — context is scoped to one `/chat`
-  conversation thread (`req.history`).
-- Real server-side session state — out of scope; this design uses
-  history-encoded markers (Option 2 from brainstorming; Option 3 was
-  punted as a multi-PR architectural shift).
-- Frontend changes — the agent asking a question is an existing supported
-  state; no new UI work.
+- Multi-conversation persistence — state is scoped to one /chat
+  conversation thread.
+- Real server-side session state (Redis / per-user store) — out of scope;
+  this design uses a stateless API with an explicit opaque
+  `conversation_state` field round-tripped by the frontend.
+- More than one unresolved closure decision per turn — v1 resolves one
+  user-facing decision at a time even if multiple stops are pending.
+  (Auto-swaps still batch.)
+
+## Design summary (what changed in revision)
+
+The original draft hid closure state inside an HTML-comment marker on the
+assistant reply and reconstructed it server-side from chat history. Code
+review (correctly) flagged four blocking issues:
+
+- The frontend escapes `<`/`>` in replies via `formatReply()` →
+  `escapeHtml()`, so the marker would be mangled to `&lt;!-- ... --&gt;`
+  before being sent back in history.
+- `/chat` doesn't round-trip prior `places`, so an "early-return accept"
+  path can't reconstruct the full prior itinerary just from the marker.
+- `chain_arrival_times` needs leg durations as input; re-chaining after a
+  swap with the *prior* legs gives stale times. A second bounded
+  `route_legs` call is needed.
+- `nearby()` projects `0.0 AS similarity` and doesn't return `dist_m`,
+  and `SearchFilters` has no family/types filter. The spec's "top
+  similarity within family" was impossible against today's tooling.
+
+The revised design replaces hidden markers with an explicit
+`conversation_state` API field, expands `SearchFilters` and the `nearby`
+projection to support real candidate selection, adds a bounded second
+retime after swaps, and clarifies one-pending-at-a-time semantics.
 
 ## Architecture
 
-Approach B from brainstorming: a new LangGraph node `swap_closed_stops`
-sits between `retime` and `END`. `retime` keeps its existing scope (Google
-Directions retime + chain_arrival_times) but loses its post-retime
-temporal check and caveat-append. All closure-related decisions move to
-the new node.
+A new LangGraph node `swap_closed_stops` sits between `retime` and `END`.
+`retime` keeps its existing scope (Google Directions retime +
+`chain_arrival_times`) but loses its post-retime temporal check and
+caveat-append.
 
 ```
 plan → act → critique → (retime → swap_closed_stops → END)
@@ -64,23 +88,134 @@ The swap node:
 1. Per-stop `place_is_open(hours, retimed.arrival_time)` check (one SQL
    round-trip via the existing helper).
 2. If no closures: no-op return.
-3. For each closed stop, try a deterministic walking-distance swap via the
-   existing `nearby()` tool with `open_at=retimed_arrival`, primary-type
-   family match, and exclusion of place_ids already in `state.stops` plus
-   any in `state.closure_context`.
-4. Successful swaps are recorded as `outcome="auto_swapped"` and applied
-   silently; the reply is regenerated via `summarize_stops(state)` so the
-   visible plan reflects the new stops.
-5. Closed stops with no walking-distance match: record as
-   `outcome="pending_user_decision"`, generate ONE clarifying question
-   (batched if multiple), set `state.awaiting_closure_decision`, return.
+3. For each closed stop, run a deterministic walking-distance swap via
+   `nearby()` with `open_at=retimed_arrival`, primary-type family match,
+   and exclusion of place_ids already in `state.stops` plus any in
+   `state.closure_context`. Successful walking-distance swaps are batched
+   — all of them applied silently in one pass.
+4. After all auto-swaps, run **one** additional `route_legs(...)` call on
+   the updated stops, re-chain arrival times, and re-run
+   `_per_stop_closure_status` once more. (Bounded: no loops; at most one
+   retime + one re-check after the swap pass.) This catches the case
+   where a replacement is open at the *old* projected arrival but not at
+   the *new* one after re-routing.
+5. After the bounded re-check, any remaining closures need a user
+   decision. **v1 promotes only the first one** to
+   `outcome="pending_user_decision"`. The rest are recorded as
+   `outcome="queued_user_decision"` and surface on later turns once the
+   current one is resolved.
+6. The reply is regenerated via `summarize_stops(state)` for the new
+   stops. If a pending decision exists, the reply is the question text
+   instead of the summary.
+
+## API contract change
+
+This is the heart of the revision.
+
+### Request
+
+```json
+POST /chat
+{
+  "message": "yes",
+  "history": [
+    {"role": "user", "content": "plan a 3-stop omakase date night..."},
+    {"role": "assistant", "content": "The closest open dessert place is..."}
+  ],
+  "conversation_state": {
+    "schema_version": 1,
+    "closure_context": [
+      {
+        "place_id": "ChIJ...",
+        "place_name": "Mochill Mochidonut",
+        "family": "dessert",
+        "attempted_arrival": "2026-05-19T20:02:33-07:00",
+        "outcome": "pending_user_decision",
+        "stop_index": 2,
+        "proposed_alternative": {
+          "place_id": "ChIJ...sophies...",
+          "name": "Sophie's Crepes",
+          "latitude": 37.7849,
+          "longitude": -122.4093,
+          "primary_type": "Dessert Shop",
+          "rating": 4.5,
+          "address": "...",
+          "arrival_time": "2026-05-19T20:02:33-07:00",
+          "planned_duration_min": 60,
+          "rationale": "Walking-distance alternative since Mochill closes at 19:00",
+          "source": "google_places"
+        },
+        "proposed_distance_m": 4800.0
+      }
+    ],
+    "prior_stops": [
+      { "place_id": "...", "name": "...", "latitude": ..., "longitude": ..., ... },
+      { ... }
+    ]
+  }
+}
+```
+
+Both `conversation_state` and its inner fields are **optional**. First-turn
+requests omit it entirely.
+
+### Response
+
+```json
+{
+  "reply": "<plain text — no hidden markers>",
+  "places": [ /* cards as today */ ],
+  "ragLabel": "openai:gpt-4o-mini",
+  "conversation_state": {
+    "schema_version": 1,
+    "closure_context": [ /* updated list */ ],
+    "prior_stops": [ /* the stops just shown, so a follow-up turn can act on them */ ]
+  }
+}
+```
+
+### Treating it as untrusted
+
+The backend must rebuild a usable `ItineraryState.closure_context` from
+the incoming `conversation_state`, but it does **not** trust the contents.
+Defense-in-depth:
+
+- Decode via Pydantic — schema mismatches degrade to empty context with a
+  warning log.
+- On an accept path: re-fetch `proposed_alternative` details via
+  `get_details(place_id)` to confirm it still exists in the DB. If it
+  doesn't, escalate to "this place is no longer in our index — pick
+  different?"
+- On an accept path: re-run `place_is_open(proposed.hours,
+  proposed.attempted_arrival)` before applying the swap. If the proposed
+  alternative is *now* closed (e.g. the user took an hour to reply and
+  the alt's closing time also passed), escalate rather than accept.
+- On any received `prior_stops`: re-enrich via
+  `enrich_stops_with_booking` so card field freshness comes from current
+  DB state, not whatever was cached client-side.
+- Missing / malformed `conversation_state` always falls back to the
+  normal-planning path (no early return). Conversation degrades
+  gracefully — the agent forgets, but nothing breaks.
+
+### Why opaque to the frontend
+
+The frontend treats `conversation_state` as a black box: stores it
+verbatim on each response, sends it verbatim on each request. It never
+parses, validates, or renders it. The shape can evolve server-side
+without frontend changes (only the schema_version moves). Two consequences:
+
+- The frontend `api/chat.js` adds two lines (read the field, store it;
+  send the stored field on the next request). No other frontend code
+  touches it.
+- The contract is purely server-side; the Pydantic schema is the source
+  of truth.
 
 ## Components
 
 ### 1. `app/agent/state.py`
 
-New `ClosureContext` Pydantic model and `closure_context` field on
-`ItineraryState`:
+New `ClosureContext` and `Stop`-snapshot Pydantic models, plus a new field
+on `ItineraryState`:
 
 ```python
 class ClosureContext(BaseModel):
@@ -94,7 +229,9 @@ class ClosureContext(BaseModel):
         "user_accepted_drive",
         "user_declined_dropped",
         "pending_user_decision",
+        "queued_user_decision",
     ]
+    stop_index: int                   # position in the itinerary where the closure occurred
     proposed_alternative: Stop | None
     proposed_distance_m: float | None
 
@@ -103,20 +240,133 @@ class ItineraryState(BaseModel):
     closure_context: list[ClosureContext] = Field(default_factory=list)
 ```
 
-Cap at `MAX_CLOSURE_CONTEXT_ENTRIES = 10`, append-and-drop-oldest.
+Cap: `MAX_CLOSURE_CONTEXT_ENTRIES = 10`, append-and-drop-oldest.
 
-### 2. `app/tools/filters.py`
+### 2. `app/main.py`
+
+Extend `ChatRequest` and `ChatResponse`:
+
+```python
+class ConversationState(BaseModel):
+    schema_version: int = 1
+    closure_context: list[ClosureContext] = Field(default_factory=list)
+    prior_stops: list[Stop] = Field(default_factory=list)
+
+class ChatRequest(BaseModel):
+    message: str
+    history: list[ChatMessage] = Field(default_factory=list)
+    conversation_state: ConversationState | None = None
+
+class ChatResponse(BaseModel):
+    reply: str
+    places: list[dict]
+    ragLabel: str
+    conversation_state: ConversationState | None = None
+```
+
+Extend `/chat` to:
+
+1. Hydrate state from request:
+   ```python
+   incoming = req.conversation_state or ConversationState()
+   closure_context = _validated_closure_context(incoming.closure_context)
+   prior_stops     = _revalidated_prior_stops(incoming.prior_stops)  # re-enrich via DB
+   ```
+2. Find any `pending_user_decision` entry (exactly one if present per v1
+   semantics).
+3. If pending and `req.message` is non-empty: parse decision via
+   `parse_closure_decision(req.message)`.
+4. **Early-return branches** (before invoking graph):
+   - `accept` → re-validate the proposed alternative (re-fetch details,
+     re-check open-at). If still good, insert into `prior_stops` at
+     `stop_index`, mark entry `user_accepted_drive`, run **one bounded
+     retime** on the new stops, re-run `summarize_stops`, return.
+     If the alternative is no longer valid, escalate to a fresh question.
+   - `decline` → drop the closed stop entirely; if queued entries exist,
+     promote the first to `pending_user_decision` and ask about it.
+     Otherwise re-run `summarize_stops` and return.
+   - `alternative` → fall through to the graph with a HumanMessage hint:
+     `"User declined the drive option for <closed_place>. They want:
+     '<user message>'. Plan again with this guidance."`
+5. Otherwise (no pending): build `ItineraryState` with the decoded
+   `closure_context` populated and run the graph normally.
+6. On response: serialize the updated `closure_context` and the
+   currently-shown stops into `ConversationState`, attach to
+   `ChatResponse`.
+
+### 3. `app/agent/swap.py` (new module)
+
+Public node entry point:
+
+```python
+async def swap_closed_stops(state: ItineraryState) -> dict[str, Any]:
+    """LangGraph node. See design Architecture for flow."""
+```
+
+Internal helpers (underscore-prefixed; white-box tests import them):
+
+- `_per_stop_closure_status(stops: list[Stop]) -> list[bool]` — one SQL
+  round-trip via `place_is_open`; fail-open on DB error (matches
+  graph.py:336-338 precedent).
+- `_try_walking_distance_swap(state, stop_index, per_leg_budget_m) -> CandidateMatch | None`
+  — calls `nearby()` with `open_at`, `primary_types_any` (family
+  members), and place_id exclusions; scores returned candidates and
+  returns the best, or None.
+- `_try_any_distance_search(state, closed_stop) -> CandidateMatch | None`
+  — fallback after walking-distance fails; broader `nearby()` (no
+  budget) for the pending-question proposal.
+- `_score_candidate(candidate, closed_stop, prev_stop, next_stop) -> float`
+  — combined score: category match + route impact (distance from prev +
+  distance to next, both relative to closed_stop's original position).
+  Distance comes from the new projected `dist_m` (see #4).
+- `_bounded_retime_after_swap(state) -> ItineraryState` — one extra
+  `route_legs` call on the updated stops, re-chains arrival times. NO
+  loop, NO recursion — at most one extra call per swap node invocation.
+- `_promote_pending(closure_context) -> closure_context` — when the
+  current pending entry is resolved, promote the first queued entry to
+  pending. Returns the updated list.
+- `_formulate_closure_question(pending: ClosureContext) -> str` — builds
+  question text; differs when `proposed_alternative is None` vs
+  populated.
+- `_apply_swap(state, stop_index, replacement, leg_durations) -> ItineraryState`
+  — replaces stop, re-chains arrival_times using `leg_durations` from
+  the second `route_legs`, re-runs `enrich_stops_with_booking` for the
+  new stop, regenerates `final_reply` via `summarize_stops`.
+
+```python
+class CandidateMatch(BaseModel):
+    stop: Stop
+    distance_m: float
+    family_match_score: float
+    route_impact_score: float
+    total_score: float
+```
+
+### 4. `app/tools/retrieval.py` and `app/tools/filters.py`
+
+**`retrieval.py` change to `nearby()`:**
+
+- Project `dist_m` into the result so callers can use it. Add a
+  `dist_m: float | None = None` field to `PlaceHit` (default None so
+  `semantic_search` results — which don't have it — stay backward
+  compatible). Update `nearby` SQL to select `dist_m` in the final
+  projection alongside the existing fields.
+
+**`filters.py` changes:**
 
 - Refactor existing `_DESSERT_TYPES` into a shared
   `_PRIMARY_TYPE_FAMILIES: dict[str, tuple[str, ...]]` with entries for
-  `dessert`, `bar`, `restaurant`, `cafe`.
+  `dessert`, `bar`, `restaurant`, `cafe`. Single source of truth.
 - Add `family_of(primary_type: str) -> str | None`.
-- Rewire `serves_dessert` to use `_PRIMARY_TYPE_FAMILIES["dessert"]` so
-  there's one source of truth.
-- Add `excluded_place_ids: list[str] | None` field to `SearchFilters` with
-  SQL clause `place_id != ALL(%s)` when populated.
+- Rewire `serves_dessert` to use `_PRIMARY_TYPE_FAMILIES["dessert"]`.
+- Add to `SearchFilters`:
+  - `primary_types_any: list[str] | None = None` — compiles to
+    `primary_type = ANY(%s)` for category constraint. (Distinct from
+    existing `types_any` which queries the `types` array column.)
+  - `excluded_place_ids: list[str] | None = None` — compiles to
+    `place_id != ALL(%s)` for exclusion.
 
-### 3. `app/agent/graph.py`
+### 5. `app/agent/graph.py`
 
 - **Delete** lines 327-347 of `retime` (post-retime `temporal_coherence`
   check + `_final_with_caveats` append).
@@ -126,59 +376,14 @@ Cap at `MAX_CLOSURE_CONTEXT_ENTRIES = 10`, append-and-drop-oldest.
   g.add_edge("retime", "swap_closed_stops")
   g.add_edge("swap_closed_stops", END)
   ```
-- Extend `_constraints_context` to include closure exclusion guidance when
-  `state.closure_context` is non-empty:
+- Extend `_constraints_context` to include closure exclusion guidance
+  when `state.closure_context` has any `auto_swapped` /
+  `user_declined_dropped` / `queued_user_decision` entries:
   ```
   - Earlier in this conversation, these places were closed at the planned
     arrival time and should NOT be re-suggested: <comma-separated names>.
     Their place_ids are also excluded from your search-result candidates.
   ```
-
-### 4. `app/agent/swap.py` (new module)
-
-Public node entry point:
-
-```python
-async def swap_closed_stops(state: ItineraryState) -> dict[str, Any]:
-    """LangGraph node. See design for the full flow."""
-```
-
-Internal helpers (underscore-prefixed; white-box tests import them):
-
-- `_per_stop_closure_status(stops: list[Stop]) -> list[bool]` — single SQL
-  round-trip via `place_is_open`; fail-open on DB error (matches
-  graph.py:336-338 precedent).
-- `_try_walking_distance_swap(state, stop_index, per_leg_budget_m) -> Stop | None`
-  — calls `nearby()` with `open_at`, family filter, and place_id
-  exclusions; returns top-similarity candidate or None.
-- `_try_any_distance_search(state, closed_stop, per_leg_budget_m) -> Stop | None`
-  — fallback after walking-distance fails; broader `nearby()` (no budget)
-  used to populate `proposed_alternative` for the user question.
-- `_formulate_closure_question(closure_entries: list[ClosureContext]) -> str`
-  — builds question text; differs when `proposed_alternative is None`
-  ("no alternatives at any distance") vs. populated ("Sophie's, 3mi —
-  drive or pick different?").
-- `_apply_swap(state, stop_index, replacement) -> ItineraryState` —
-  replaces stop, re-chains arrival_times from that index onward,
-  re-runs `enrich_stops_with_booking` for the new stop, regenerates
-  `final_reply` via `summarize_stops`.
-
-### 5. `app/agent/closure_marker.py` (new module)
-
-Marker encoding/decoding for history-resident closure context.
-
-```python
-def encode(closure_context: list[ClosureContext]) -> str:
-    """Returns '<!-- CC_CLOSURE_CONTEXT:<base64-json> -->'."""
-
-def decode_from_history(history: list[ChatMessage]) -> list[ClosureContext]:
-    """Walks history backward; reads the most-recent assistant message that
-    has a marker; returns the decoded closure_context, or [] on absence /
-    parse failure (warning logged)."""
-```
-
-The encoded JSON includes `schema_version`; mismatched versions decode as
-empty (graceful degradation).
 
 ### 6. `app/agent/input_parsing.py`
 
@@ -192,51 +397,55 @@ def parse_closure_decision(text: str) -> Literal["accept", "decline", "alternati
 Accepted patterns:
 - `accept`: "yes", "yeah", "yep", "sure", "ok", "okay", "👍", "y"
 - `decline`: "no", "nope", "n", "nah"
-- `alternative`: anything else (including empty, including questions, including the user proposing something specific)
+- `alternative`: anything else (including questions, free text, "yes! 4 stops")
 
-### 7. `app/main.py`
+The function returns `accept` even if `req.message` also contains a
+num_stops change ("yes! make it 4 stops"); the existing
+`explicit_num_stops_from_conversation` handles the count separately.
 
-Extend `/chat`:
+### 7. Frontend: `frontend/src/api/chat.js` (only frontend change)
 
-1. Call `closure_marker.decode_from_history(req.history)` →
-   `closure_context: list[ClosureContext]`.
-2. Find any `pending_user_decision` entry (at most one — see Edge cases).
-3. If pending and `req.message` is non-empty: parse decision.
-4. **Early-return branches** (before invoking graph):
-   - `accept` → build state with `state.stops` + `proposed_alternative`
-     inserted at the appropriate index, re-chain arrivals, mark the entry
-     `user_accepted_drive`, emit `summarize_stops` + new marker, return.
-   - `decline` → build state with `state.stops` minus the closed stop,
-     re-chain arrivals, mark the entry `user_declined_dropped`, emit
-     summary + new marker, return.
-   - `alternative` → fall through to the graph with a HumanMessage hint
-     prepended: `"User declined the drive option for <closed_place>.
-     They want: '<user message>'. Plan again with this guidance."`
-5. Otherwise (no pending): normal flow, build `ItineraryState` with the
-   decoded `closure_context` passed in.
+Two-line change:
 
-The final assistant reply on every itinerary-shipping turn ends with a
-fresh marker reflecting the current `closure_context`.
+```js
+// On the way out — send any state we got back from the last response.
+body: JSON.stringify({ message, history, conversation_state: conversationState ?? null }),
+// ...
+// On the way in — store opaque state for next call.
+return {
+  reply: formatReply(data?.reply ?? ''),
+  places: cards.map(toUiPlace),
+  ragLabel: data?.ragLabel || undefined,
+  conversation_state: data?.conversation_state ?? null,  // opaque pass-through
+}
+```
+
+Caller code in `App.jsx` stores the last `conversation_state` in state and
+passes it to the next `sendMessage` call. ~3 lines in `App.jsx`. The
+frontend never inspects the field's contents.
 
 ## Data Flow
 
 ### Single-turn (closure detected, walking-distance match found)
 
 ```
-/chat
-  ↓
-read marker → closure_context=[]
-parse num_stops, no pending decision
+/chat (no conversation_state)
   ↓
 ItineraryState built; graph runs:
   plan → act → critique → retime → swap_closed_stops
+    detects 1 closure
+    _try_walking_distance_swap succeeds → CandidateMatch
+    _apply_swap replaces state.stops[K]
+    _bounded_retime_after_swap → one extra route_legs call, re-chain
+    _per_stop_closure_status re-run → no closures
+    closure_context += ClosureContext(outcome="auto_swapped", stop_index=K, ...)
+    final_reply = summarize_stops(state)
   ↓
-swap detects 1 closure; _try_walking_distance_swap succeeds
-state.stops[K] replaced; arrival_times re-chained
-closure_context += ClosureContext(outcome="auto_swapped", ...)
-final_reply = summarize_stops(state)
-  ↓
-response: {reply: "<itinerary>" + marker, places: [3 cards]}
+response: {
+  reply: <itinerary text>,
+  places: [3 cards],
+  conversation_state: { closure_context: [auto_swapped × 1], prior_stops: [3] }
+}
 ```
 
 ### Two-turn (closure detected, no walking-distance match, user accepts drive)
@@ -244,144 +453,205 @@ response: {reply: "<itinerary>" + marker, places: [3 cards]}
 **Turn 1:**
 ```
 swap_closed_stops:
-  closure detected
+  closure detected at stop_index=2
   _try_walking_distance_swap → None
-  _try_any_distance_search → Sophie's Crepes (3.0 mi)
-  closure_context += ClosureContext(outcome="pending_user_decision", ...)
-  state.final_reply = "The closest open dessert place is Sophie's Crepes, about 3 mi (drive/transit). Want me to add it, or pick something else?"
-response: reply + marker carrying the pending entry, places: 2 cards
+  _try_any_distance_search → CandidateMatch(Sophie's Crepes, 4800m)
+  closure_context += ClosureContext(outcome="pending_user_decision",
+                                    stop_index=2,
+                                    proposed_alternative=Sophie's,
+                                    proposed_distance_m=4800.0)
+  state.final_reply = "The closest open dessert place is Sophie's Crepes,
+                      about 3 mi (drive/transit). Want me to add it, or
+                      pick something else?"
+response: {
+  reply: <question>,
+  places: [2 cards],   # closed stop dropped
+  conversation_state: { closure_context: [pending × 1], prior_stops: [2] }
+}
 ```
-
-`places` on a pending turn contains only the successfully-placed stops
-(the closed one is dropped from the card payload). The frontend renders
-the question in chat; the existing 2 stops stay on the map. When the user
-accepts on turn 2, the response's `places` returns to 3 cards.
 
 **Turn 2 (user replies "yes"):**
 ```
-/chat: read marker → 1 pending entry, parse "yes" → accept
-EARLY RETURN: insert Sophie's into stops, re-chain, mark entry "user_accepted_drive"
-response: summarize_stops + new marker (1 user_accepted_drive entry), places: 3 cards
+/chat:
+  incoming conversation_state has 1 pending entry
+  _revalidated_prior_stops: re-fetch+re-enrich 2 stops → confirmed
+  parse_closure_decision("yes") → accept
+  re-fetch get_details(proposed_alternative.place_id) → exists ✓
+  re-run place_is_open(proposed.hours, proposed.attempted_arrival) → open ✓
+  EARLY RETURN:
+    insert Sophie's into prior_stops at index=2
+    _bounded_retime on the new 3-stop set (one route_legs call)
+    closure_context entry → mark "user_accepted_drive"
+    final_reply = summarize_stops(state)
+response: {
+  reply: <itinerary>,
+  places: [3 cards],
+  conversation_state: { closure_context: [user_accepted_drive × 1], prior_stops: [3] }
+}
+```
+
+### Two-turn with degraded state (corrupted / stale conversation_state)
+
+**Turn 2 alt path** if `proposed_alternative.place_id` no longer in DB:
+```
+/chat:
+  parse decision → accept
+  get_details(proposed.place_id) → None
+  ESCALATE: do NOT early-return; build a fresh state with the
+  closure_context preserved minus the bad pending entry, prepend a
+  HumanMessage: "The previously proposed alternative is no longer
+  available. Plan again, excluding [list of closed places]."
+  run graph normally
 ```
 
 ### Refinement turn ("make stop 2 cheaper")
 
 ```
-/chat: read marker → closure_context=[ClosureContext(Mochill, "auto_swapped", ...)]
-no pending decision; normal flow
-  ↓
-ItineraryState.closure_context populated
-graph runs; _constraints_context tells the model:
-  "...these places were closed and should NOT be re-suggested: Mochill Mochidonut..."
-agent's semantic_search tool call uses SearchFilters with
-  excluded_place_ids=[ChIJYTeHK0SBhYARyEEvKzjrBl8]  (Mochill)
-SQL filter enforces exclusion at retrieval time
-  ↓
-agent commits a different (cheaper) dessert place; swap_closed_stops re-runs;
-no new closures detected (it's open); final_reply via summarize_stops
-response: reply + marker (same auto_swapped entry preserved), places: 3 cards
+/chat:
+  incoming conversation_state has [auto_swapped(Mochill) × 1] in
+  closure_context and prior_stops with 3 entries
+  no pending decision
+  normal graph flow
+  state.closure_context populated from incoming
+  _constraints_context tells the LLM:
+    "...these places were closed and should NOT be re-suggested: Mochill..."
+  agent's semantic_search tool call uses SearchFilters with
+    excluded_place_ids=[Mochill's place_id]
+  agent commits a different (cheaper) dessert stop
+  swap node re-runs; no new closures detected
+  final_reply via summarize_stops
+response: {
+  reply: <itinerary>,
+  places: [3 cards],
+  conversation_state: { closure_context: [auto_swapped × 1 (preserved)], prior_stops: [3] }
+}
 ```
 
 ## Error Handling
 
-Five paths; principle is graceful degradation over correctness theatre.
+Five paths; graceful degradation over correctness theatre.
 
 1. **No `nearby()` candidates at any distance** → `pending_user_decision`
    with `proposed_alternative=None`; question text shifts to "no
    alternatives at all, want to skip / pick different category?"
 
 2. **`nearby()` raises (psycopg2 error)** → caught in swap.py; log
-   warning; record `pending_user_decision` with no proposal; append a
-   soft note to the reply ("I had trouble checking for alternatives —
-   double-check hours before heading out").
+   warning `closure_swap.db_error`; record `pending_user_decision` with
+   no proposal; append a soft note ("I had trouble checking for
+   alternatives — double-check hours before heading out").
 
-3. **Marker decode failure** → `closure_marker.decode_from_history`
-   catches `binascii.Error`, `json.JSONDecodeError`,
-   `pydantic.ValidationError`; returns `[]` with warning log; conversation
-   proceeds without prior closure memory.
+3. **`conversation_state` decode failure** → Pydantic validation rejects
+   it; `/chat` falls back to empty state with warning log
+   `conversation_state.decode_failed`. The agent "forgets" prior
+   closures, but the request succeeds.
 
 4. **`place_is_open` mid-graph DB failure** → `_per_stop_closure_status`
-   fail-open returns `[False] * n` (matches the existing fail-open
-   precedent at graph.py:336-338); no swap happens, no question, plan
-   ships as-is.
+   fail-open returns `[False] * n` (matches graph.py:336-338 precedent);
+   no swap happens, no question, plan ships as-is.
 
 5. **Unparseable user reply to a closure question** → falls into
    `alternative` bucket by design; routed back into the graph with a
    HumanMessage hint.
 
-Structured warning logs for each path:
+6. **Re-validation failures on accept path** (proposed alternative
+   missing from DB, or its hours flipped during the back-and-forth) →
+   do NOT silently swap; do NOT silently fail. Escalate to a fresh
+   question or a new graph run with the bad place excluded.
+
+Structured warning logs:
 - `closure_swap.db_error`
-- `closure_marker.decode_failed`
+- `conversation_state.decode_failed`
 - `closure_context.cap_exceeded`
+- `closure_swap.proposed_alternative_invalidated`
+- `closure_swap.retime_failure`
 
 ## Testing
 
-~34 tests across three layers per the project's test-layering convention.
+~36 tests across three layers per the project's test-layering convention.
 
 | File | New? | Tests | Layer |
 |---|---|---|---|
-| `tests/unit/test_closure_marker.py` | new | 7 | unit |
 | `tests/unit/test_agent_input_parsing.py` | extend | +5 | unit |
-| `tests/unit/test_swap.py` | new | 8 | unit + mock |
-| `tests/unit/test_swap_node.py` | new | 6 | smoke (graph runs, LLM scripted, DB mocked) |
-| `tests/unit/test_chat_endpoint.py` | extend | +5 | functional (TestClient, graph mocked) |
+| `tests/unit/test_swap.py` | new | 10 | unit + mock |
+| `tests/unit/test_swap_node.py` | new | 7 | smoke (graph runs, LLM scripted, DB mocked) |
+| `tests/unit/test_chat_endpoint.py` | extend | +8 | functional (TestClient, graph mocked) |
+| `tests/unit/test_filters.py` | extend | +3 | unit (primary_types_any + excluded_place_ids + family_of) |
 | `tests/integration/test_swap_real_db.py` | new | 3 | integration (`APP_ENV=integration` gate) |
 
 Notable coverage:
-- Marker round-trip including the 10-entry cap boundary.
-- Two-turn accept/decline/alternative paths verified at the /chat layer.
+- `parse_closure_decision` covering accept / decline / alternative /
+  empty.
+- Candidate scoring: route impact + family match deterministic.
+- Two-turn accept/decline/alternative paths verified at the /chat layer
+  with explicit `conversation_state` round-trip.
 - Refinement turn verified to thread closure_context into the graph's
-  SearchFilters at the SQL layer (belt-and-suspenders for the prompt
-  guidance).
+  SearchFilters at the SQL layer (the "belt-and-suspenders" enforcement
+  for the prompt guidance).
+- Re-validation on accept: proposed_alternative missing from DB →
+  escalation; proposed_alternative now closed → escalation.
+- Bounded retime: ensure `_bounded_retime_after_swap` calls
+  `route_legs` at most once per swap node invocation (mock and count).
 - Integration tests detect closure data drift (Google Places hours
   changes) that mocked tests can't catch.
 
+Tests for the HTML-comment marker approach are NOT in this design — the
+marker is gone.
+
 ## Edge cases (explicitly handled)
 
-- **Multiple closed stops in one plan** → batched: walking-distance
-  swaps applied for the ones that can be, single question covers all
-  that can't (one entry per pending stop in closure_context, one question
-  text covering them all).
-- **User accepts but the proposed alternative just closed** (clock
-  advanced past *its* closing during the back-and-forth) → re-run
-  `place_is_open(proposed_alternative.place_id, now)` in the accept
-  early-return; if closed, escalate to a new question rather than
-  shipping a now-closed stop.
+- **Multiple closed stops in one plan, all walking-distance fixable** →
+  all swapped silently in one swap pass; closure_context has multiple
+  `auto_swapped` entries. One bounded retime covers all of them.
+- **Multiple closed stops, some need user input** → auto-swaps applied
+  in batch; remaining unresolved closures: the first becomes
+  `pending_user_decision`, the rest `queued_user_decision`. v1 only
+  surfaces one question per turn. Once the user resolves the pending
+  one (accept/decline early-return path in `/chat`),
+  `_promote_pending(closure_context)` runs **inside that same early
+  return** — it scans for the first `queued_user_decision`, flips it to
+  `pending_user_decision`, and the response's `final_reply` becomes the
+  next question. No separate turn / no graph invocation needed to
+  promote.
+- **User accepts but the proposed alternative just closed** → re-run
+  `place_is_open(proposed.hours, proposed.attempted_arrival)` in the
+  accept early-return; if closed, escalate.
 - **closure_context cap exceeded** → drop oldest, log
   `closure_context.cap_exceeded`. With cap=10 this is a long-conversation
   edge case.
-- **User asks "what were the closed places?"** → no special handling;
-  the LLM gets closure_context via `_constraints_context` and narrates
-  naturally.
+- **conversation_state missing on a turn that should have it** (frontend
+  bug, dev console, curl test) → falls back to no-prior-context normal
+  flow.
 
 ## Edge cases (explicitly NOT handled)
 
-- **Marker forgery / replay** — not a security concern in this
-  single-tenant app.
-- **Marker on user messages** — encoder reads only assistant messages.
-- **Stale marker after backend redeploy** — `schema_version` mismatch
-  decodes as empty; next assistant turn writes a fresh marker.
+- **conversation_state forgery** — single-tenant app; the worst outcome
+  is the agent excludes places it shouldn't or accepts a bogus
+  alternative (which would fail re-validation anyway).
+- **Concurrent /chat requests for the same conversation** — no shared
+  in-memory state; each request is independent.
+- **Stale conversation_state after backend redeploy** — schema_version
+  mismatch decodes as empty; the next assistant turn writes a fresh
+  one.
 
 ## Scope estimate
 
 | | LOC |
 |---|---|
-| Source | ~290-320 |
-| Tests | ~150 |
-| **Total** | **~440-470** |
+| Backend source | ~320-360 |
+| Frontend changes (chat.js + App.jsx wiring) | ~15 |
+| Tests | ~180 |
+| **Total** | **~520-560** |
 
-One PR. Branch is `fix/agent-reliability-review`; this design either
-extends that branch or spawns a successor branch depending on the
-implementation plan.
+One PR, on `fix/agent-reliability-review`.
 
 ## Out-of-scope follow-ups noted but deferred
 
-- **Real session state (Option 3)** — proper architecture, multi-PR
-  investment. Document as future work.
+- **Real session state (server-side store)** — proper architecture,
+  multi-PR investment. Documented as future work.
+- **Batched multi-pending UI** (one question covers multiple unresolved
+  closures with grouped yes/no) — v1 keeps it one-at-a-time.
 - **User explicit overrides** ("include Mochill anyway") — out of scope
   for v1; user can restart the conversation.
-- **Closure context for stops the user manually clicked through on the
-  map** — no such event surface exists today.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
+++ b/docs/superpowers/specs/2026-05-19-closure-aware-itinerary-swap-design.md
@@ -1,0 +1,392 @@
+# Closure-Aware Itinerary Swap — Design
+
+**Status:** Draft, awaiting user approval
+**Date:** 2026-05-19
+**Branch:** `fix/agent-reliability-review` (will spawn a sub-PR or new branch on implementation)
+
+## Problem
+
+The retime node currently appends `"Caveats: I couldn't fully satisfy
+temporal_coherence after revisions."` to the final reply whenever real
+Google Directions travel times push a stop's arrival past that stop's
+closing hours. On the verified demo query this fires ~50% of runs, and the
+caveat is real (the agent genuinely scheduled e.g. Mochill Mochidonut at
+20:02 when it closes at 19:00). The current handling — ship a broken plan
+with a jargon-laden warning — is the worst of both worlds: users see ugly
+text *and* would walk into a locked shop. We need a flow that resolves the
+closure where possible and asks the user when not.
+
+## Goal
+
+When a committed itinerary contains a stop that will be closed at the
+agent's planned arrival time (re-checked against real travel times):
+
+1. Try to deterministically swap in a walking-distance alternative of the
+   same category open at the planned arrival. If a candidate exists, swap
+   silently — the user sees only the corrected plan.
+2. If no walking-distance match exists, ask the user *"the closest open
+   option is X (~Nmi / drive or transit). Want it, or pick something else?"*
+3. Remember every closure event for the whole conversation so refinement
+   turns ("swap stop 2 for something cheaper") don't re-suggest places we
+   already learned are closed.
+
+The temporal_coherence caveat is removed. Closure handling is the new
+responsibility of a dedicated node.
+
+## Non-goals
+
+- Generic preference memory ("I don't like ramen") — closure_context is
+  closure-specific.
+- Multi-conversation persistence — context is scoped to one `/chat`
+  conversation thread (`req.history`).
+- Real server-side session state — out of scope; this design uses
+  history-encoded markers (Option 2 from brainstorming; Option 3 was
+  punted as a multi-PR architectural shift).
+- Frontend changes — the agent asking a question is an existing supported
+  state; no new UI work.
+
+## Architecture
+
+Approach B from brainstorming: a new LangGraph node `swap_closed_stops`
+sits between `retime` and `END`. `retime` keeps its existing scope (Google
+Directions retime + chain_arrival_times) but loses its post-retime
+temporal check and caveat-append. All closure-related decisions move to
+the new node.
+
+```
+plan → act → critique → (retime → swap_closed_stops → END)
+                       ↑                              ↓
+                       └────── revision loop ─────────┘
+```
+
+The swap node:
+
+1. Per-stop `place_is_open(hours, retimed.arrival_time)` check (one SQL
+   round-trip via the existing helper).
+2. If no closures: no-op return.
+3. For each closed stop, try a deterministic walking-distance swap via the
+   existing `nearby()` tool with `open_at=retimed_arrival`, primary-type
+   family match, and exclusion of place_ids already in `state.stops` plus
+   any in `state.closure_context`.
+4. Successful swaps are recorded as `outcome="auto_swapped"` and applied
+   silently; the reply is regenerated via `summarize_stops(state)` so the
+   visible plan reflects the new stops.
+5. Closed stops with no walking-distance match: record as
+   `outcome="pending_user_decision"`, generate ONE clarifying question
+   (batched if multiple), set `state.awaiting_closure_decision`, return.
+
+## Components
+
+### 1. `app/agent/state.py`
+
+New `ClosureContext` Pydantic model and `closure_context` field on
+`ItineraryState`:
+
+```python
+class ClosureContext(BaseModel):
+    schema_version: int = 1
+    place_id: str
+    place_name: str
+    family: str                       # "dessert", "bar", "restaurant", "cafe"
+    attempted_arrival: datetime
+    outcome: Literal[
+        "auto_swapped",
+        "user_accepted_drive",
+        "user_declined_dropped",
+        "pending_user_decision",
+    ]
+    proposed_alternative: Stop | None
+    proposed_distance_m: float | None
+
+class ItineraryState(BaseModel):
+    # ... existing fields ...
+    closure_context: list[ClosureContext] = Field(default_factory=list)
+```
+
+Cap at `MAX_CLOSURE_CONTEXT_ENTRIES = 10`, append-and-drop-oldest.
+
+### 2. `app/tools/filters.py`
+
+- Refactor existing `_DESSERT_TYPES` into a shared
+  `_PRIMARY_TYPE_FAMILIES: dict[str, tuple[str, ...]]` with entries for
+  `dessert`, `bar`, `restaurant`, `cafe`.
+- Add `family_of(primary_type: str) -> str | None`.
+- Rewire `serves_dessert` to use `_PRIMARY_TYPE_FAMILIES["dessert"]` so
+  there's one source of truth.
+- Add `excluded_place_ids: list[str] | None` field to `SearchFilters` with
+  SQL clause `place_id != ALL(%s)` when populated.
+
+### 3. `app/agent/graph.py`
+
+- **Delete** lines 327-347 of `retime` (post-retime `temporal_coherence`
+  check + `_final_with_caveats` append).
+- Register the new node:
+  ```python
+  g.add_node("swap_closed_stops", swap_closed_stops)
+  g.add_edge("retime", "swap_closed_stops")
+  g.add_edge("swap_closed_stops", END)
+  ```
+- Extend `_constraints_context` to include closure exclusion guidance when
+  `state.closure_context` is non-empty:
+  ```
+  - Earlier in this conversation, these places were closed at the planned
+    arrival time and should NOT be re-suggested: <comma-separated names>.
+    Their place_ids are also excluded from your search-result candidates.
+  ```
+
+### 4. `app/agent/swap.py` (new module)
+
+Public node entry point:
+
+```python
+async def swap_closed_stops(state: ItineraryState) -> dict[str, Any]:
+    """LangGraph node. See design for the full flow."""
+```
+
+Internal helpers (underscore-prefixed; white-box tests import them):
+
+- `_per_stop_closure_status(stops: list[Stop]) -> list[bool]` — single SQL
+  round-trip via `place_is_open`; fail-open on DB error (matches
+  graph.py:336-338 precedent).
+- `_try_walking_distance_swap(state, stop_index, per_leg_budget_m) -> Stop | None`
+  — calls `nearby()` with `open_at`, family filter, and place_id
+  exclusions; returns top-similarity candidate or None.
+- `_try_any_distance_search(state, closed_stop, per_leg_budget_m) -> Stop | None`
+  — fallback after walking-distance fails; broader `nearby()` (no budget)
+  used to populate `proposed_alternative` for the user question.
+- `_formulate_closure_question(closure_entries: list[ClosureContext]) -> str`
+  — builds question text; differs when `proposed_alternative is None`
+  ("no alternatives at any distance") vs. populated ("Sophie's, 3mi —
+  drive or pick different?").
+- `_apply_swap(state, stop_index, replacement) -> ItineraryState` —
+  replaces stop, re-chains arrival_times from that index onward,
+  re-runs `enrich_stops_with_booking` for the new stop, regenerates
+  `final_reply` via `summarize_stops`.
+
+### 5. `app/agent/closure_marker.py` (new module)
+
+Marker encoding/decoding for history-resident closure context.
+
+```python
+def encode(closure_context: list[ClosureContext]) -> str:
+    """Returns '<!-- CC_CLOSURE_CONTEXT:<base64-json> -->'."""
+
+def decode_from_history(history: list[ChatMessage]) -> list[ClosureContext]:
+    """Walks history backward; reads the most-recent assistant message that
+    has a marker; returns the decoded closure_context, or [] on absence /
+    parse failure (warning logged)."""
+```
+
+The encoded JSON includes `schema_version`; mismatched versions decode as
+empty (graceful degradation).
+
+### 6. `app/agent/input_parsing.py`
+
+Extend with:
+
+```python
+def parse_closure_decision(text: str) -> Literal["accept", "decline", "alternative"]:
+    """Conservative parser. Empty/whitespace → 'alternative' (no auto-accept)."""
+```
+
+Accepted patterns:
+- `accept`: "yes", "yeah", "yep", "sure", "ok", "okay", "👍", "y"
+- `decline`: "no", "nope", "n", "nah"
+- `alternative`: anything else (including empty, including questions, including the user proposing something specific)
+
+### 7. `app/main.py`
+
+Extend `/chat`:
+
+1. Call `closure_marker.decode_from_history(req.history)` →
+   `closure_context: list[ClosureContext]`.
+2. Find any `pending_user_decision` entry (at most one — see Edge cases).
+3. If pending and `req.message` is non-empty: parse decision.
+4. **Early-return branches** (before invoking graph):
+   - `accept` → build state with `state.stops` + `proposed_alternative`
+     inserted at the appropriate index, re-chain arrivals, mark the entry
+     `user_accepted_drive`, emit `summarize_stops` + new marker, return.
+   - `decline` → build state with `state.stops` minus the closed stop,
+     re-chain arrivals, mark the entry `user_declined_dropped`, emit
+     summary + new marker, return.
+   - `alternative` → fall through to the graph with a HumanMessage hint
+     prepended: `"User declined the drive option for <closed_place>.
+     They want: '<user message>'. Plan again with this guidance."`
+5. Otherwise (no pending): normal flow, build `ItineraryState` with the
+   decoded `closure_context` passed in.
+
+The final assistant reply on every itinerary-shipping turn ends with a
+fresh marker reflecting the current `closure_context`.
+
+## Data Flow
+
+### Single-turn (closure detected, walking-distance match found)
+
+```
+/chat
+  ↓
+read marker → closure_context=[]
+parse num_stops, no pending decision
+  ↓
+ItineraryState built; graph runs:
+  plan → act → critique → retime → swap_closed_stops
+  ↓
+swap detects 1 closure; _try_walking_distance_swap succeeds
+state.stops[K] replaced; arrival_times re-chained
+closure_context += ClosureContext(outcome="auto_swapped", ...)
+final_reply = summarize_stops(state)
+  ↓
+response: {reply: "<itinerary>" + marker, places: [3 cards]}
+```
+
+### Two-turn (closure detected, no walking-distance match, user accepts drive)
+
+**Turn 1:**
+```
+swap_closed_stops:
+  closure detected
+  _try_walking_distance_swap → None
+  _try_any_distance_search → Sophie's Crepes (3.0 mi)
+  closure_context += ClosureContext(outcome="pending_user_decision", ...)
+  state.final_reply = "The closest open dessert place is Sophie's Crepes, about 3 mi (drive/transit). Want me to add it, or pick something else?"
+response: reply + marker carrying the pending entry, places: 2 cards
+```
+
+`places` on a pending turn contains only the successfully-placed stops
+(the closed one is dropped from the card payload). The frontend renders
+the question in chat; the existing 2 stops stay on the map. When the user
+accepts on turn 2, the response's `places` returns to 3 cards.
+
+**Turn 2 (user replies "yes"):**
+```
+/chat: read marker → 1 pending entry, parse "yes" → accept
+EARLY RETURN: insert Sophie's into stops, re-chain, mark entry "user_accepted_drive"
+response: summarize_stops + new marker (1 user_accepted_drive entry), places: 3 cards
+```
+
+### Refinement turn ("make stop 2 cheaper")
+
+```
+/chat: read marker → closure_context=[ClosureContext(Mochill, "auto_swapped", ...)]
+no pending decision; normal flow
+  ↓
+ItineraryState.closure_context populated
+graph runs; _constraints_context tells the model:
+  "...these places were closed and should NOT be re-suggested: Mochill Mochidonut..."
+agent's semantic_search tool call uses SearchFilters with
+  excluded_place_ids=[ChIJYTeHK0SBhYARyEEvKzjrBl8]  (Mochill)
+SQL filter enforces exclusion at retrieval time
+  ↓
+agent commits a different (cheaper) dessert place; swap_closed_stops re-runs;
+no new closures detected (it's open); final_reply via summarize_stops
+response: reply + marker (same auto_swapped entry preserved), places: 3 cards
+```
+
+## Error Handling
+
+Five paths; principle is graceful degradation over correctness theatre.
+
+1. **No `nearby()` candidates at any distance** → `pending_user_decision`
+   with `proposed_alternative=None`; question text shifts to "no
+   alternatives at all, want to skip / pick different category?"
+
+2. **`nearby()` raises (psycopg2 error)** → caught in swap.py; log
+   warning; record `pending_user_decision` with no proposal; append a
+   soft note to the reply ("I had trouble checking for alternatives —
+   double-check hours before heading out").
+
+3. **Marker decode failure** → `closure_marker.decode_from_history`
+   catches `binascii.Error`, `json.JSONDecodeError`,
+   `pydantic.ValidationError`; returns `[]` with warning log; conversation
+   proceeds without prior closure memory.
+
+4. **`place_is_open` mid-graph DB failure** → `_per_stop_closure_status`
+   fail-open returns `[False] * n` (matches the existing fail-open
+   precedent at graph.py:336-338); no swap happens, no question, plan
+   ships as-is.
+
+5. **Unparseable user reply to a closure question** → falls into
+   `alternative` bucket by design; routed back into the graph with a
+   HumanMessage hint.
+
+Structured warning logs for each path:
+- `closure_swap.db_error`
+- `closure_marker.decode_failed`
+- `closure_context.cap_exceeded`
+
+## Testing
+
+~34 tests across three layers per the project's test-layering convention.
+
+| File | New? | Tests | Layer |
+|---|---|---|---|
+| `tests/unit/test_closure_marker.py` | new | 7 | unit |
+| `tests/unit/test_agent_input_parsing.py` | extend | +5 | unit |
+| `tests/unit/test_swap.py` | new | 8 | unit + mock |
+| `tests/unit/test_swap_node.py` | new | 6 | smoke (graph runs, LLM scripted, DB mocked) |
+| `tests/unit/test_chat_endpoint.py` | extend | +5 | functional (TestClient, graph mocked) |
+| `tests/integration/test_swap_real_db.py` | new | 3 | integration (`APP_ENV=integration` gate) |
+
+Notable coverage:
+- Marker round-trip including the 10-entry cap boundary.
+- Two-turn accept/decline/alternative paths verified at the /chat layer.
+- Refinement turn verified to thread closure_context into the graph's
+  SearchFilters at the SQL layer (belt-and-suspenders for the prompt
+  guidance).
+- Integration tests detect closure data drift (Google Places hours
+  changes) that mocked tests can't catch.
+
+## Edge cases (explicitly handled)
+
+- **Multiple closed stops in one plan** → batched: walking-distance
+  swaps applied for the ones that can be, single question covers all
+  that can't (one entry per pending stop in closure_context, one question
+  text covering them all).
+- **User accepts but the proposed alternative just closed** (clock
+  advanced past *its* closing during the back-and-forth) → re-run
+  `place_is_open(proposed_alternative.place_id, now)` in the accept
+  early-return; if closed, escalate to a new question rather than
+  shipping a now-closed stop.
+- **closure_context cap exceeded** → drop oldest, log
+  `closure_context.cap_exceeded`. With cap=10 this is a long-conversation
+  edge case.
+- **User asks "what were the closed places?"** → no special handling;
+  the LLM gets closure_context via `_constraints_context` and narrates
+  naturally.
+
+## Edge cases (explicitly NOT handled)
+
+- **Marker forgery / replay** — not a security concern in this
+  single-tenant app.
+- **Marker on user messages** — encoder reads only assistant messages.
+- **Stale marker after backend redeploy** — `schema_version` mismatch
+  decodes as empty; next assistant turn writes a fresh marker.
+
+## Scope estimate
+
+| | LOC |
+|---|---|
+| Source | ~290-320 |
+| Tests | ~150 |
+| **Total** | **~440-470** |
+
+One PR. Branch is `fix/agent-reliability-review`; this design either
+extends that branch or spawns a successor branch depending on the
+implementation plan.
+
+## Out-of-scope follow-ups noted but deferred
+
+- **Real session state (Option 3)** — proper architecture, multi-PR
+  investment. Document as future work.
+- **User explicit overrides** ("include Mochill anyway") — out of scope
+  for v1; user can restart the conversation.
+- **Closure context for stops the user manually clicked through on the
+  map** — no such event surface exists today.
+
+---
+
+**Status footer (filled in on merge):**
+
+- [ ] Spec approved by user: _________
+- [ ] Implementation plan written: _________
+- [ ] PR merged: _________

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useReducer, useState } from 'react'
+import React, { useCallback, useReducer, useRef, useState } from 'react'
 import TopNav from './components/TopNav'
 import ChatPanel from './components/ChatPanel'
 import RightPanel from './components/RightPanel'
@@ -39,6 +39,11 @@ export default function App() {
   const [placesState, dispatch] = useReducer(placesReducer, emptyPlacesState)
   const [isLoading, setIsLoading] = useState(false)
   const [focusId, setFocusId] = useState(null)
+  // Opaque conversation_state round-tripped to /chat. Stored in a ref so the
+  // empty-deps `handleSend` reads the current value at call time — a useState
+  // would be captured stale in the callback closure and every request after
+  // the first would send the initial-render value.
+  const conversationStateRef = useRef(null)
 
   const places = selectOrderedPlaces(placesState)
 
@@ -78,7 +83,9 @@ export default function App() {
           },
         ])
       } else {
-        const data = await sendMessage(text, history)
+        const data = await sendMessage(text, history, conversationStateRef.current)
+        // Store opaque state for the next request. Ref so the closure stays current.
+        conversationStateRef.current = data.conversation_state ?? null
 
         setMessages((prev) => [
           ...prev,
@@ -118,6 +125,7 @@ export default function App() {
     setMessages(INITIAL_MESSAGES)
     dispatch({ type: 'clear' })
     setFocusId(null)
+    conversationStateRef.current = null
   }, [])
 
   // ── Select a place (chat pill or map pin): focus it on the map ───────────

--- a/frontend/src/api/chat.js
+++ b/frontend/src/api/chat.js
@@ -29,13 +29,22 @@ const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
  *
  * @param {string} message
  * @param {{ role: string, content: string }[]} [history]
- * @returns {Promise<{ reply: string, places: object[], ragLabel?: string }>}
+ * @param {object|null} [conversationState]  Opaque server-owned state from the
+ *   previous response. The frontend stores it verbatim and sends it back on
+ *   each request; the backend is the source of truth for the schema (see
+ *   app/main.py ConversationState).
+ * @returns {Promise<{ reply: string, places: object[], ragLabel?: string,
+ *   conversation_state: object|null }>}
  */
-export async function sendMessage(message, history = []) {
+export async function sendMessage(message, history = [], conversationState = null) {
   const res = await fetch(`${API_BASE}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message, history }),
+    body: JSON.stringify({
+      message,
+      history,
+      conversation_state: conversationState ?? null,
+    }),
   })
 
   if (!res.ok) {
@@ -56,6 +65,7 @@ export async function sendMessage(message, history = []) {
     reply: formatReply(data?.reply ?? ''),
     places: cards.map(toUiPlace),
     ragLabel: data?.ragLabel || undefined,
+    conversation_state: data?.conversation_state ?? null,
   }
 }
 

--- a/frontend/src/api/chat.test.js
+++ b/frontend/src/api/chat.test.js
@@ -89,4 +89,47 @@ describe('sendMessage — /chat adapter', () => {
     mockFetchOnce({ detail: 'agent unavailable' }, false, 503)
     await expect(sendMessage('q')).rejects.toThrow(/503.*agent unavailable/)
   })
+
+  // ─── conversation_state round-trip (closure-aware swap) ────────────────
+
+  it('sends conversation_state when provided', async () => {
+    const stub = {
+      reply: 'ok',
+      places: [],
+      ragLabel: 'openai:gpt-4o-mini',
+      conversation_state: { schema_version: 1, closure_context: [], prior_stops: [] },
+    }
+    mockFetchOnce(stub)
+
+    const cs = {
+      schema_version: 1,
+      closure_context: [{ place_id: 'p', outcome: 'auto_swapped' }],
+      prior_stops: [],
+    }
+    await sendMessage('hi', [], cs)
+
+    const body = JSON.parse(globalThis.fetch.mock.calls[0][1].body)
+    expect(body.conversation_state).toEqual(cs)
+  })
+
+  it('passes null when no conversation_state given', async () => {
+    mockFetchOnce({ reply: 'ok', places: [], ragLabel: '', conversation_state: null })
+
+    await sendMessage('hi', [])
+
+    const body = JSON.parse(globalThis.fetch.mock.calls[0][1].body)
+    expect(body.conversation_state).toBeNull()
+  })
+
+  it('returns conversation_state from response opaquely', async () => {
+    mockFetchOnce({
+      reply: 'ok',
+      places: [],
+      ragLabel: '',
+      conversation_state: { schema_version: 1, opaque: true },
+    })
+
+    const result = await sendMessage('hi', [])
+    expect(result.conversation_state).toEqual({ schema_version: 1, opaque: true })
+  })
 })

--- a/tests/integration/test_swap_real_db.py
+++ b/tests/integration/test_swap_real_db.py
@@ -1,0 +1,124 @@
+"""Integration tests for the closure-aware swap node — gated on APP_ENV=integration.
+
+These exercise the real `place_is_open()` PL/pgSQL helper, the real
+`_PRIMARY_TYPE_FAMILIES` SQL clauses, and the real `nearby()` projection.
+They're the only layer that can catch hours-data drift (Google Places hours
+changes) that mocked tests can't.
+
+Run with:
+    APP_ENV=integration make test-integration
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("APP_ENV", "test") != "integration",
+    reason="Set APP_ENV=integration and provide a real DATABASE_URL to run integration tests.",
+)
+
+
+from app.agent.state import ClosureContext, ItineraryState, Stop  # noqa: E402
+from app.agent.swap import (  # noqa: E402
+    _per_stop_closure_status,
+    _try_walking_distance_swap,
+    swap_closed_stops,
+)
+
+SF = ZoneInfo("America/Los_Angeles")
+
+
+def _make_stop(
+    place_id: str,
+    name: str,
+    primary_type: str,
+    arrival: datetime,
+) -> Stop:
+    """Build a real-DB-shaped Stop; coords are filled by enrich at runtime."""
+    return Stop(
+        place_id=place_id,
+        name=name,
+        rationale="integration",
+        source="google_places",
+        arrival_time=arrival,
+        primary_type=primary_type,
+        planned_duration_min=30,
+        latitude=37.78,
+        longitude=-122.41,
+    )
+
+
+def test_per_stop_closure_status_call_against_live_db_does_not_raise() -> None:
+    """For an arbitrary place_id and a wee-hours arrival, the helper must
+    return a list-of-bools without raising — exercises the live SQL helper.
+
+    The exact True/False outcome depends on the place's hours and on whether
+    the place_id exists in places_raw at test time (a missing row defaults
+    to "open" per the spec). Both outcomes are acceptable; we only assert
+    the contract.
+    """
+    stops = [
+        _make_stop(
+            place_id="ChIJ_a_real_place_id_in_the_index",
+            name="Test Place",
+            primary_type="Bar",
+            arrival=datetime(2026, 5, 19, 3, 0, tzinfo=SF),
+        ),
+    ]
+    statuses = _per_stop_closure_status(stops)
+    assert isinstance(statuses, list)
+    assert len(statuses) == 1
+    assert isinstance(statuses[0], bool)
+
+
+def test_swap_node_runs_against_live_db_without_raising() -> None:
+    """Smoke: the node must execute against the real DB without exceptions
+    even when no stops are closed (or the place_id isn't in the index).
+    """
+    stops = [
+        _make_stop(
+            place_id="ChIJ_a_real_place_id_in_the_index",
+            name="Anchor",
+            primary_type="Bar",
+            arrival=datetime(2026, 5, 19, 19, 0, tzinfo=SF),
+        ),
+    ]
+    state = ItineraryState(stops=stops)
+    update = asyncio.run(swap_closed_stops(state))
+    assert isinstance(update, dict)
+
+
+def test_walking_distance_search_uses_real_family_mapping() -> None:
+    """A walking-distance search for the dessert family must return only
+    candidates whose primary_type belongs to that family list (per the live
+    `_PRIMARY_TYPE_FAMILIES` SQL clauses)."""
+    from app.tools.filters import _PRIMARY_TYPE_FAMILIES
+
+    dessert_primaries = set(_PRIMARY_TYPE_FAMILIES["dessert"]["primary_types"])
+    closed = _make_stop(
+        place_id="ChIJ_a_dessert_place_id",
+        name="Closed Dessert",
+        primary_type="Dessert Shop",
+        arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+    )
+    state = ItineraryState(stops=[closed])
+    ctx = ClosureContext(
+        place_id=closed.place_id,
+        place_name=closed.name,
+        family="dessert",
+        attempted_arrival=closed.arrival_time or datetime.now(SF),
+        outcome="pending_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=0,
+    )
+    match = _try_walking_distance_swap(state, ctx, anchor_place_id=closed.place_id)
+    if match is None:
+        pytest.skip("No walking-distance match in the live DB for this anchor.")
+    assert match.stop.primary_type is None or match.stop.primary_type in dessert_primaries

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -1038,9 +1038,12 @@ async def test_retime_at_most_one_directions_call(monkeypatch, mocker) -> None:
         )
 
     mocker.patch("app.agent.graph.route_legs", _counting_route_legs)
-    # The node calls temporal_coherence (imported into graph.py in Step 3),
-    # NOT itinerary_violations. Patch the symbol the node actually uses.
-    mocker.patch("app.agent.graph.temporal_coherence", lambda _s: 1.0)
+    # The swap_closed_stops node (after retime) runs its own closure check;
+    # stub it to "all open" so we measure retime's route_legs call only.
+    mocker.patch(
+        "app.agent.swap._per_stop_closure_status",
+        side_effect=lambda stops: [False] * len(stops),
+    )
     # Prevent critique from hitting the DB (place_ids p0-p2 don't exist in
     # places_raw in the test environment, which would trigger a revision loop
     # and exhaust the scripted LLM when the full suite runs after any test
@@ -1071,58 +1074,30 @@ async def test_retime_passthrough_when_coordless(monkeypatch, mocker) -> None:
     route.assert_not_called()
 
 
-async def test_retime_does_not_double_caveat_when_reply_already_has_one(
-    monkeypatch, mocker
-) -> None:
-    """The END->retime rewire sends the caveats-exhausted revision path
-    through retime too. If final_reply already has 'Caveats:', retime must
-    NOT append a second identical paragraph."""
+async def test_graph_includes_swap_closed_stops_node(monkeypatch) -> None:
+    """The compiled graph routes retime -> swap_closed_stops -> END so the
+    closure-aware swap pass runs after real-time arrival_times land. Replaces
+    the deleted retime+caveat tests — temporal_coherence handling is now the
+    swap node's job, not retime's."""
+    fake = _make_fake([AIMessage(content="done", tool_calls=[])])
+    graph = build_agent_graph(fake, max_steps=4)
+    assert "swap_closed_stops" in graph.get_graph().nodes
 
-    async def _slow(stops, mode="walk"):
-        return DirectionsResult(
-            legs=[DirectionsLeg(duration_s=600, distance_m=800.0)] * (len(stops) - 1),
-            total_duration_s=600 * (len(stops) - 1),
-            mode=mode,
-            source="google",
-        )
 
-    mocker.patch("app.agent.graph.route_legs", _slow)
-    mocker.patch("app.agent.graph.temporal_coherence", lambda _s: 0.0)  # fails
-    mocker.patch("app.agent.revision.itinerary_violations", return_value=[])
-    st = _committed_state(2, with_coords=True)
-    st = st.model_copy(
-        update={
-            "final_reply": "Plan.\n\nCaveats: I couldn't fully satisfy "
-            "temporal_coherence after revisions. You may want to adjust the plan."
-        }
+async def test_graph_does_not_import_final_with_caveats_in_retime() -> None:
+    """Regression: closure handling lives in app/agent/swap.py now. The
+    retime node must not call _final_with_caveats on temporal_coherence —
+    the caveat text users saw on closure was the worst-of-both-worlds path
+    (broken plan + ugly warning). The swap node replaces it."""
+    import inspect
+
+    from app.agent import graph as graph_mod
+
+    src = inspect.getsource(graph_mod)
+    assert "_final_with_caveats" not in src, (
+        "retime() must not call _final_with_caveats on temporal_coherence; "
+        "closure handling lives in app/agent/swap.py now."
     )
-    fake = _make_fake([AIMessage(content="done", tool_calls=[])])
-    graph = build_agent_graph(fake, max_steps=4)
-    out = await graph.ainvoke(st)
-    assert out["final_reply"].count("Caveats:") == 1
-
-
-async def test_retime_appends_caveat_when_reply_has_none(monkeypatch, mocker) -> None:
-    """Conversely, when no caveat exists yet and the real-time check fails,
-    retime DOES append exactly one."""
-
-    async def _slow(stops, mode="walk"):
-        return DirectionsResult(
-            legs=[DirectionsLeg(duration_s=600, distance_m=800.0)] * (len(stops) - 1),
-            total_duration_s=600 * (len(stops) - 1),
-            mode=mode,
-            source="google",
-        )
-
-    mocker.patch("app.agent.graph.route_legs", _slow)
-    mocker.patch("app.agent.graph.temporal_coherence", lambda _s: 0.0)
-    mocker.patch("app.agent.revision.itinerary_violations", return_value=[])
-    st = _committed_state(2, with_coords=True)  # final_reply has no "Caveats:"
-    fake = _make_fake([AIMessage(content="done", tool_calls=[])])
-    graph = build_agent_graph(fake, max_steps=4)
-    out = await graph.ainvoke(st)
-    assert out["final_reply"].count("Caveats:") == 1
-    assert "temporal_coherence" in out["final_reply"]
 
 
 async def test_retime_noop_when_first_stop_has_no_arrival(monkeypatch, mocker) -> None:

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -1100,6 +1100,117 @@ async def test_graph_does_not_import_final_with_caveats_in_retime() -> None:
     )
 
 
+async def test_act_does_not_mutate_aimessage_tool_call_args_across_steps(
+    mocker,
+) -> None:
+    """Regression for "TypeError: Object of type SearchFilters is not JSON
+    serializable" surfaced live on turn 3 of the omakase flow.
+
+    Failure path: `act()` used to do `tc["args"] = _inject_closure_exclusions(...)`,
+    stuffing a Pydantic SearchFilters into the tool_call args dict that
+    LangChain stores inside AIMessage.tool_calls. On the NEXT plan() pass,
+    langchain serializes the AIMessage for OpenAI's API and `json.dumps`
+    blows up.
+
+    Verify that across a multi-step graph turn — where the same AIMessage
+    survives into a follow-up plan() — its tool_call args stay JSON-safe.
+    """
+    import json as _json
+    from datetime import datetime
+
+    from langchain_core.language_models.chat_models import BaseChatModel
+    from langchain_core.messages import AIMessage, HumanMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+
+    from app.agent.graph import build_agent_graph
+    from app.agent.state import ClosureContext, ItineraryState
+
+    captured: dict = {"step_2_args": None, "step_2_dumps_ok": False}
+
+    class _MultiStepLLM(BaseChatModel):
+        @property
+        def _llm_type(self) -> str:
+            return "multistep"
+
+        def bind_tools(self, tools, **kwargs):  # type: ignore[no-untyped-def]
+            return self
+
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop=None,
+            run_manager=None,
+            **kwargs,
+        ) -> ChatResult:
+            # First call: issue a semantic_search tool call that will get
+            # closure exclusions injected. Subsequent calls: capture the
+            # AIMessage's tool_call args and finalize.
+            issued_tool_calls = sum(
+                1 for m in messages if isinstance(m, AIMessage) and m.tool_calls
+            )
+            if issued_tool_calls == 0:
+                msg = AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "semantic_search",
+                            "args": {"query": "ramen", "filters": {"min_rating": 4.0}},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            else:
+                # Second plan() — find the prior issuing AIMessage and inspect
+                # its tool_call args. This is the exact serialization path
+                # langchain.openai takes when re-sending the conversation.
+                for m in messages:
+                    if isinstance(m, AIMessage) and m.tool_calls:
+                        captured["step_2_args"] = m.tool_calls[0]["args"]
+                        try:
+                            _json.dumps(m.tool_calls[0]["args"])
+                            captured["step_2_dumps_ok"] = True
+                        except TypeError:
+                            captured["step_2_dumps_ok"] = False
+                        break
+                msg = AIMessage(content="done", tool_calls=[])
+            return ChatResult(generations=[ChatGeneration(message=msg)])
+
+    mocker.patch("app.tools.retrieval.semantic_search", return_value=[])
+
+    state = ItineraryState(
+        messages=[HumanMessage(content="start")],
+        closure_context=[
+            ClosureContext(
+                place_id="ChIJ_closed",
+                place_name="Closed",
+                family="bar",
+                attempted_arrival=datetime(2026, 5, 19, 20, 0),
+                outcome="auto_swapped",
+                insert_after_place_id=None,
+                insert_before_place_id=None,
+                stop_index_hint=0,
+            )
+        ],
+    )
+
+    graph = build_agent_graph(_MultiStepLLM(), max_steps=4)
+    await graph.ainvoke(state)
+
+    assert captured["step_2_args"] is not None, "second plan() never ran"
+    # `filters` MUST be a plain dict — Pydantic SearchFilters would break the
+    # OpenAI API re-serialization.
+    filters = captured["step_2_args"].get("filters")
+    assert isinstance(filters, dict), (
+        f"AIMessage.tool_calls[0]['args']['filters'] must be a dict for "
+        f"langchain JSON serialization, got {type(filters).__name__}"
+    )
+    assert captured["step_2_dumps_ok"], (
+        "AIMessage.tool_calls[0]['args'] must be json.dumps-safe — langchain "
+        "re-serializes the message on the next OpenAI call."
+    )
+
+
 async def test_retime_noop_when_first_stop_has_no_arrival(monkeypatch, mocker) -> None:
     """chain_arrival_times raises if stops[0].arrival_time is None (possible
     on a max-steps short-circuit with committed-but-untimed stops). retime

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -11,7 +11,7 @@ import psycopg2
 import pytest
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 
 from app.agent.commit import commit_stops, enrich_stops_with_booking
@@ -39,6 +39,7 @@ def _rich_details_for(place_id: str) -> PlaceDetails:
     return PlaceDetails(
         place_id=place_id,
         name=f"Place {place_id}",
+        primary_type="restaurant",
         source="google_places",
         similarity=0.0,
         formatted_address=f"{place_id} Main St, San Francisco",
@@ -93,6 +94,144 @@ async def test_graph_terminates_on_no_tool_call() -> None:
     out = await graph.ainvoke(ItineraryState(messages=[HumanMessage(content="hi")]))
     assert out["done"] is True
     assert out["final_reply"] == "here is your plan"
+
+
+async def test_graph_retries_unneeded_stop_count_clarification(monkeypatch) -> None:
+    """If the caller has already parsed an explicit stop count, the model
+    should not be allowed to end the request by asking for that same count."""
+    monkeypatch.setattr(
+        "app.agent.tools._semantic_search",
+        lambda **_kw: [
+            PlaceHit(place_id="p1", name="Place p1", source="google_places", similarity=0.9)
+        ],
+    )
+    fake = _make_fake(
+        [
+            AIMessage(content="How many stops would you like?", tool_calls=[]),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "semantic_search",
+                        "id": "search-1",
+                        "args": {"query": "romantic dinner in Japantown"},
+                    }
+                ],
+            ),
+            AIMessage(content="planning from results", tool_calls=[]),
+        ]
+    )
+    graph = build_agent_graph(fake, max_steps=4)
+
+    out = await graph.ainvoke(
+        ItineraryState(
+            messages=[HumanMessage(content="plan a 3-stop date night")],
+            constraints=UserConstraints(num_stops=3),
+        )
+    )
+
+    assert out["done"] is True
+    assert out["final_reply"] == "planning from results"
+    assert "semantic_search" in out["scratch"]
+
+
+async def test_graph_retries_finalize_without_stops_regardless_of_wording(monkeypatch) -> None:
+    """#3C: the retry trigger is structural, not lexical. When num_stops is set
+    and the model finalizes with no stops committed, nudge it — regardless of
+    what the AI's text message says. The old string-match heuristic missed
+    phrasings like "I'd love to know the number of places..." Drop the
+    heuristic; the structural condition is sufficient and unambiguous."""
+    monkeypatch.setattr(
+        "app.agent.tools._semantic_search",
+        lambda **_kw: [
+            PlaceHit(place_id="p1", name="Place p1", source="google_places", similarity=0.9)
+        ],
+    )
+    fake = _make_fake(
+        [
+            # Non-stereotyped phrasing — old heuristic would miss this.
+            AIMessage(content="To narrow it down, what vibe are you going for?", tool_calls=[]),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "semantic_search",
+                        "id": "search-1",
+                        "args": {"query": "romantic dinner in Japantown"},
+                    }
+                ],
+            ),
+            AIMessage(content="planning from results", tool_calls=[]),
+        ]
+    )
+    graph = build_agent_graph(fake, max_steps=4)
+    out = await graph.ainvoke(
+        ItineraryState(
+            messages=[HumanMessage(content="plan a 3-stop date night")],
+            constraints=UserConstraints(num_stops=3),
+        )
+    )
+    # Retry fired, model produced a tool call on its second turn, graph ended cleanly.
+    assert out["done"] is True
+    assert "semantic_search" in out["scratch"]
+
+
+async def test_graph_does_not_retry_when_num_stops_unset(monkeypatch) -> None:
+    """No nudge when there's no explicit count — the model is allowed to
+    clarify ambiguous requests."""
+    fake = _make_fake([AIMessage(content="How many stops?", tool_calls=[])])
+    graph = build_agent_graph(fake, max_steps=4)
+    out = await graph.ainvoke(
+        ItineraryState(messages=[HumanMessage(content="plan something")]),
+    )
+    # Without num_stops, the clarifying question is the legitimate final reply.
+    assert out["done"] is True
+    assert out["final_reply"] == "How many stops?"
+
+
+async def test_graph_retry_is_one_shot(monkeypatch) -> None:
+    """If after the nudge the model STILL finalizes empty, the retry doesn't
+    fire a second time — the conversation ends with whatever the model said."""
+    fake = _make_fake(
+        [
+            AIMessage(content="What's your budget?", tool_calls=[]),
+            AIMessage(content="Could you confirm your neighborhood?", tool_calls=[]),
+        ]
+    )
+    graph = build_agent_graph(fake, max_steps=4)
+    out = await graph.ainvoke(
+        ItineraryState(
+            messages=[HumanMessage(content="plan a 3-stop date night")],
+            constraints=UserConstraints(num_stops=3),
+        )
+    )
+    assert out["done"] is True
+    # The second clarifying turn becomes the final reply — retry did not loop.
+    assert out["final_reply"] == "Could you confirm your neighborhood?"
+
+
+async def test_graph_injects_explicit_stop_count_context() -> None:
+    # Two messages: the first is the model's empty-finalize, which under #3C
+    # triggers the structural retry nudge (num_stops set + no stops yet); the
+    # second is the model's response to that nudge. We only care that the
+    # system prompt contained the deterministic stop-count context.
+    fake = _make_fake(
+        [
+            AIMessage(content="ok", tool_calls=[]),
+            AIMessage(content="planning", tool_calls=[]),
+        ]
+    )
+    graph = build_agent_graph(fake, max_steps=4)
+    out = await graph.ainvoke(
+        ItineraryState(
+            messages=[HumanMessage(content="plan a 3-stop date night")],
+            constraints=UserConstraints(num_stops=3),
+        )
+    )
+
+    system_messages = [m for m in out["messages"] if isinstance(m, SystemMessage)]
+    assert len(system_messages) == 1
+    assert "explicitly requested 3 stops" in system_messages[0].content
 
 
 async def test_graph_executes_tool_and_continues(monkeypatch) -> None:
@@ -599,7 +738,7 @@ def test_enrich_stops_with_booking_mutates_in_place() -> None:
 
 
 def test_enrich_populates_card_fields_from_details() -> None:
-    """address/rating/price_level flow from PlaceDetails onto Stop."""
+    """Authoritative display fields flow from PlaceDetails onto Stop."""
     stops = [Stop(place_id="p1", name="A", rationale="r", source="google_places")]
     state = ItineraryState(
         constraints=UserConstraints(party_size=2, when=datetime(2026, 5, 7, 19, 0)),
@@ -617,6 +756,8 @@ def test_enrich_populates_card_fields_from_details() -> None:
     ):
         enrich_stops_with_booking(stops, state)
 
+    assert stops[0].name == "Place p1"
+    assert stops[0].primary_type == "restaurant"
     assert stops[0].address == "p1 Main St, San Francisco"
     assert stops[0].rating == 4.4
     assert stops[0].price_level == 2

--- a/tests/unit/test_agent_input_parsing.py
+++ b/tests/unit/test_agent_input_parsing.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from app.agent.input_parsing import explicit_num_stops_from_text
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("plan a 3-stop omakase date night", 3),
+        ("make it 4 stops", 4),
+        ("three spots near Japantown", 3),
+        ("just find sushi", None),
+    ],
+)
+def test_explicit_num_stops_from_text(text: str, expected: int | None) -> None:
+    assert explicit_num_stops_from_text(text) == expected

--- a/tests/unit/test_agent_input_parsing.py
+++ b/tests/unit/test_agent_input_parsing.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import pytest
 
-from app.agent.input_parsing import explicit_num_stops_from_text
+from app.agent.input_parsing import (
+    explicit_num_stops_from_conversation,
+    explicit_num_stops_from_text,
+)
 
 
 @pytest.mark.parametrize(
@@ -16,3 +21,41 @@ from app.agent.input_parsing import explicit_num_stops_from_text
 )
 def test_explicit_num_stops_from_text(text: str, expected: int | None) -> None:
     assert explicit_num_stops_from_text(text) == expected
+
+
+@dataclass
+class _Msg:
+    role: str
+    content: str
+
+
+def test_conversation_uses_history_when_current_message_lacks_count() -> None:
+    history = [_Msg("user", "plan a 3-stop omakase date night"), _Msg("assistant", "Done.")]
+    assert explicit_num_stops_from_conversation(history, "make it cheaper") == 3
+
+
+def test_conversation_current_message_overrides_history() -> None:
+    history = [_Msg("user", "plan a 3-stop omakase date night"), _Msg("assistant", "Done.")]
+    # Conservative parser requires a stop-noun; "make it 4" alone wouldn't match.
+    assert explicit_num_stops_from_conversation(history, "actually make it 4 stops") == 4
+
+
+def test_conversation_ignores_assistant_messages() -> None:
+    """Assistant might echo numbers; don't latch onto them."""
+    history = [_Msg("user", "plan a date"), _Msg("assistant", "I'll find 5 spots")]
+    assert explicit_num_stops_from_conversation(history, "go ahead") is None
+
+
+def test_conversation_latest_user_count_wins_when_user_revises_twice() -> None:
+    history = [
+        _Msg("user", "plan a 3-stop omakase date night"),
+        _Msg("assistant", "Done."),
+        _Msg("user", "actually 5 places"),
+        _Msg("assistant", "Updated."),
+    ]
+    assert explicit_num_stops_from_conversation(history, "go ahead") == 5
+
+
+def test_conversation_returns_none_when_neither_history_nor_message_has_count() -> None:
+    history = [_Msg("user", "plan a date"), _Msg("assistant", "How many?")]
+    assert explicit_num_stops_from_conversation(history, "you decide") is None

--- a/tests/unit/test_agent_input_parsing.py
+++ b/tests/unit/test_agent_input_parsing.py
@@ -7,6 +7,7 @@ import pytest
 from app.agent.input_parsing import (
     explicit_num_stops_from_conversation,
     explicit_num_stops_from_text,
+    parse_closure_decision,
 )
 
 
@@ -59,3 +60,36 @@ def test_conversation_latest_user_count_wins_when_user_revises_twice() -> None:
 def test_conversation_returns_none_when_neither_history_nor_message_has_count() -> None:
     history = [_Msg("user", "plan a date"), _Msg("assistant", "How many?")]
     assert explicit_num_stops_from_conversation(history, "you decide") is None
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # accept — first-token rule, anything starting with a yes-ish token
+        ("yes", "accept"),
+        ("Yes", "accept"),
+        ("yes!", "accept"),
+        ("yes, make it 4 stops", "accept"),
+        ("yeah do it", "accept"),
+        ("yep", "accept"),
+        ("sure thing", "accept"),
+        ("ok let's go", "accept"),
+        ("okay", "accept"),
+        ("y", "accept"),
+        ("👍", "accept"),
+        # decline
+        ("no", "decline"),
+        ("No thanks", "decline"),
+        ("nope", "decline"),
+        ("nah", "decline"),
+        ("n", "decline"),
+        # alternative — anything else
+        ("find something cheaper instead", "alternative"),
+        ("what about ramen?", "alternative"),
+        ("pick a different one", "alternative"),
+        ("", "alternative"),
+        ("   ", "alternative"),
+    ],
+)
+def test_parse_closure_decision(text: str, expected: str) -> None:
+    assert parse_closure_decision(text) == expected

--- a/tests/unit/test_agent_input_parsing.py
+++ b/tests/unit/test_agent_input_parsing.py
@@ -62,6 +62,64 @@ def test_conversation_returns_none_when_neither_history_nor_message_has_count() 
     assert explicit_num_stops_from_conversation(history, "you decide") is None
 
 
+def test_conversation_bare_number_after_stops_question_is_count() -> None:
+    """The user replies with just '3' after the assistant asks 'how many stops?'.
+    Without this, the deterministic count guardrail never fires and gpt-4o-mini
+    can over-loop, surfacing as 'I hit the planning step limit'."""
+    history = [
+        _Msg("user", "plan me a date in mission, gf likes omakase"),
+        _Msg(
+            "assistant",
+            "How many stops would you like for your date? Would you prefer just "
+            "dinner, or would you like to include drinks or dessert afterward?",
+        ),
+    ]
+    assert explicit_num_stops_from_conversation(history, "3") == 3
+
+
+def test_conversation_bare_word_number_after_stops_question_is_count() -> None:
+    """Same idea but the user wrote 'three' instead of '3'."""
+    history = [
+        _Msg("user", "plan a date"),
+        _Msg("assistant", "Sure — how many stops would you like?"),
+    ]
+    assert explicit_num_stops_from_conversation(history, "three") == 3
+
+
+def test_conversation_bare_number_ignored_when_assistant_didnt_ask_about_stops() -> None:
+    """A bare number unrelated to a stops-question should NOT latch — the user
+    might be saying 'arrive at 3' or 'I'm 30'. Only activate when the prior
+    assistant turn was clearly a stops-count question."""
+    history = [
+        _Msg("user", "plan a date"),
+        _Msg("assistant", "Got it. What neighborhood?"),
+    ]
+    assert explicit_num_stops_from_conversation(history, "3") is None
+
+
+def test_conversation_bare_number_out_of_range_ignored() -> None:
+    """Even after a stops question, '47' isn't a plausible stop count.
+    Bound to the same 1..10 range the noun-based parser uses."""
+    history = [
+        _Msg("user", "plan a date"),
+        _Msg("assistant", "How many stops would you like?"),
+    ]
+    assert explicit_num_stops_from_conversation(history, "47") is None
+
+
+def test_conversation_bare_number_after_question_loses_to_history_explicit_count() -> None:
+    """If the user said '3 stops' earlier AND the assistant later asks again
+    and the user replies with bare '4', the LATEST hit (current message=4)
+    still wins — same precedence rule as `actually make it 4 stops`."""
+    history = [
+        _Msg("user", "plan a 3-stop date"),
+        _Msg("assistant", "Done."),
+        _Msg("user", "make it different"),
+        _Msg("assistant", "Sure, how many stops do you want now?"),
+    ]
+    assert explicit_num_stops_from_conversation(history, "4") == 4
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [

--- a/tests/unit/test_agent_self_correct.py
+++ b/tests/unit/test_agent_self_correct.py
@@ -632,6 +632,10 @@ def test_final_with_caveats_handles_empty_body() -> None:
             "walking_budget_exceeded",
             "rebalance_walking_budget",
         ),
+        # Stop count mismatches get their own reason+action so debugging and
+        # post-hoc inspection don't confuse them with real constraint violations.
+        # With num_stops=3 and 2 stops committed, the deficit drives "add".
+        ("stop_count_satisfied", "stop_count_mismatch", "add_missing_stops"),
         ("no_hallucinated_place_ids", "hallucinated_place_id", "swap_stop"),
         ("unknown_check_name", "constraint_unmet_in_final", "swap_stop"),
     ],
@@ -644,10 +648,28 @@ def test_hint_for_violation_maps_each_check(
     a `constraint_unmet_in_final` hint rather than crash."""
     from app.agent.revision import _hint_for_violation
 
-    state = ItineraryState(stops=[make_stop("p1", name="A"), make_stop("p2", name="B")])
+    state = ItineraryState(
+        stops=[make_stop("p1", name="A"), make_stop("p2", name="B")],
+        constraints=UserConstraints(num_stops=3),
+    )
     hint = _hint_for_violation(check, state)
     assert hint.reason == expected_reason
     assert hint.suggested_action == expected_action
+
+
+def test_stop_count_mismatch_action_is_directional() -> None:
+    """When the LLM commits MORE stops than the user requested, the suggested
+    action must tell it to remove — not add — so the hint isn't actively
+    misleading. The deficit case is covered above; this is the surplus case."""
+    from app.agent.revision import _hint_for_violation
+
+    state = ItineraryState(
+        stops=[make_stop(f"p{i}", name=f"P{i}") for i in range(4)],
+        constraints=UserConstraints(num_stops=3),
+    )
+    hint = _hint_for_violation("stop_count_satisfied", state)
+    assert hint.reason == "stop_count_mismatch"
+    assert hint.suggested_action == "remove_extra_stops"
 
 
 async def test_diagnose_pairs_by_tool_call_id() -> None:

--- a/tests/unit/test_agent_state.py
+++ b/tests/unit/test_agent_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -8,6 +9,7 @@ from app.agent.io import state_to_cards
 from app.agent.state import (
     DEFAULT_STOP_DURATION_MIN,
     DEFAULT_STOP_DURATION_MIN_FALLBACK,
+    ClosureContext,
     ItineraryState,
     PlaceCard,
     Stop,
@@ -143,3 +145,81 @@ def test_place_card_serialization_keys() -> None:
         "booking_provider",
     }
     assert set(payload.keys()) == expected_keys
+
+
+# ─── ClosureContext + ItineraryState.closure_context (closure-aware swap) ───
+
+_SF = ZoneInfo("America/Los_Angeles")
+
+
+def test_closure_context_minimal_fields_validate() -> None:
+    """Pending entry with no proposal — used when nearby() returns no candidate."""
+    ctx = ClosureContext(
+        place_id="ChIJ_closed",
+        place_name="Mochill Mochidonut",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 2, tzinfo=_SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="ChIJ_stop1",
+        insert_before_place_id=None,
+        stop_index_hint=2,
+        proposed_alternative=None,
+        proposed_distance_m=None,
+    )
+    assert ctx.schema_version == 1
+    assert ctx.outcome == "pending_user_decision"
+    assert ctx.proposed_alternative is None
+
+
+def test_closure_context_with_proposal_validates() -> None:
+    sophies = Stop(
+        place_id="ChIJ_sophies",
+        name="Sophie's Crepes",
+        rationale="closest open dessert",
+        source="google_places",
+        latitude=37.7849,
+        longitude=-122.4093,
+        primary_type="Dessert Shop",
+        planned_duration_min=30,
+    )
+    ctx = ClosureContext(
+        place_id="ChIJ_closed",
+        place_name="Mochill Mochidonut",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 2, tzinfo=_SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="ChIJ_stop1",
+        insert_before_place_id=None,
+        stop_index_hint=2,
+        proposed_alternative=sophies,
+        proposed_distance_m=4800.0,
+    )
+    assert ctx.proposed_alternative is not None
+    assert ctx.proposed_alternative.place_id == "ChIJ_sophies"
+    assert ctx.proposed_distance_m == 4800.0
+
+
+def test_itinerary_state_default_closure_context_empty() -> None:
+    state = ItineraryState()
+    assert state.closure_context == []
+
+
+def test_itinerary_state_accepts_closure_context_list() -> None:
+    state = ItineraryState(
+        closure_context=[
+            ClosureContext(
+                place_id="p",
+                place_name="X",
+                family="bar",
+                attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=_SF),
+                outcome="auto_swapped",
+                insert_after_place_id=None,
+                insert_before_place_id=None,
+                stop_index_hint=0,
+                proposed_alternative=None,
+                proposed_distance_m=None,
+            )
+        ]
+    )
+    assert len(state.closure_context) == 1
+    assert state.closure_context[0].outcome == "auto_swapped"

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -47,6 +47,30 @@ def test_semantic_search_tool_invokes_underlying(monkeypatch) -> None:
     assert captured == {"query": "italian", "filters": None, "k": 3}
 
 
+def test_semantic_search_tool_accepts_serves_dessert_filter(monkeypatch) -> None:
+    captured: dict = {}
+
+    def _fake(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("app.agent.tools._semantic_search", _fake)
+    tools = {t.name: t for t in all_tools()}
+    tools["semantic_search"].invoke(
+        {"query": "dessert in Japantown", "filters": {"serves_dessert": True}}
+    )
+
+    assert captured["filters"].serves_dessert is True
+
+
+def test_semantic_search_tool_rejects_unknown_filter_field() -> None:
+    tools = {t.name: t for t in all_tools()}
+    with pytest.raises(Exception, match="serves_desserts"):
+        tools["semantic_search"].invoke(
+            {"query": "dessert in Japantown", "filters": {"serves_desserts": True}}
+        )
+
+
 def test_nearby_tool_invokes_underlying(monkeypatch) -> None:
     captured: dict = {}
 

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -102,15 +102,30 @@ def test_kg_traverse_tool_delegates_to_graph(monkeypatch) -> None:
     (lazy-imported inside the wrapper body)."""
     captured: dict = {}
 
-    def _fake(place_id: str, relation_type: str = "SIMILAR_VECTOR", k: int = 5):
-        captured.update(place_id=place_id, relation_type=relation_type, k=k)
+    def _fake(
+        place_id: str,
+        relation_type: str = "SIMILAR_VECTOR",
+        k: int = 5,
+        excluded_place_ids: list[str] | None = None,
+    ):
+        captured.update(
+            place_id=place_id,
+            relation_type=relation_type,
+            k=k,
+            excluded_place_ids=excluded_place_ids,
+        )
         return []
 
     monkeypatch.setattr("app.tools.graph.kg_traverse", _fake)
     tools = {t.name: t for t in all_tools()}
     result = tools["kg_traverse"].invoke({"place_id": "p1", "relation_type": "NEAR", "k": 3})
     assert result == []
-    assert captured == {"place_id": "p1", "relation_type": "NEAR", "k": 3}
+    assert captured == {
+        "place_id": "p1",
+        "relation_type": "NEAR",
+        "k": 3,
+        "excluded_place_ids": None,
+    }
     assert "NOT YET AVAILABLE" not in (tools["kg_traverse"].description or "")
 
 

--- a/tests/unit/test_chat_endpoint.py
+++ b/tests/unit/test_chat_endpoint.py
@@ -69,7 +69,7 @@ def test_chat_endpoint_returns_reply_places_raglabel(mocker) -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert set(body.keys()) == {"reply", "places", "ragLabel"}
+    assert set(body.keys()) == {"reply", "places", "ragLabel", "conversation_state"}
     assert body["reply"] == "Trick Dog at 7pm, ~60 min."
     assert body["ragLabel"] == "openai:gpt-4o-mini"
     assert len(body["places"]) == 1
@@ -256,3 +256,155 @@ def test_chat_endpoint_accepts_empty_history(mocker) -> None:
         response = client.post("/chat", json={"message": "hi"})
 
     assert response.status_code == 200
+
+
+# ─── conversation_state round-trip (Task 14) ─────────────────────────────
+
+
+def test_chat_endpoint_accepts_conversation_state(mocker) -> None:
+    """An inbound conversation_state must hydrate into ItineraryState.closure_context."""
+    fake_graph = mocker.Mock()
+    captured: dict = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "make stop 2 cheaper",
+                "history": [
+                    {"role": "user", "content": "plan a 3-stop date"},
+                    {"role": "assistant", "content": "Here's your itinerary..."},
+                ],
+                "conversation_state": {
+                    "schema_version": 1,
+                    "closure_context": [
+                        {
+                            "schema_version": 1,
+                            "place_id": "ChIJ_closed",
+                            "place_name": "Mochill",
+                            "family": "dessert",
+                            "attempted_arrival": "2026-05-19T20:02:00-07:00",
+                            "outcome": "auto_swapped",
+                            "insert_after_place_id": "ChIJ_prev",
+                            "insert_before_place_id": None,
+                            "stop_index_hint": 2,
+                            "proposed_alternative": None,
+                            "proposed_distance_m": None,
+                        }
+                    ],
+                    "prior_stops": [],
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    state = captured["state"]
+    assert len(state.closure_context) == 1
+    assert state.closure_context[0].place_id == "ChIJ_closed"
+    assert state.closure_context[0].outcome == "auto_swapped"
+
+
+def test_chat_endpoint_returns_conversation_state(mocker) -> None:
+    """Final state's closure_context must be echoed in the response."""
+    fake_graph = mocker.Mock()
+
+    async def _ainvoke(state, config=None):
+        d = _final_state_dict(reply="ok")
+        d["closure_context"] = [
+            {
+                "schema_version": 1,
+                "place_id": "ChIJ_closed",
+                "place_name": "Mochill",
+                "family": "dessert",
+                "attempted_arrival": "2026-05-19T20:02:00-07:00",
+                "outcome": "auto_swapped",
+                "insert_after_place_id": None,
+                "insert_before_place_id": None,
+                "stop_index_hint": 2,
+                "proposed_alternative": None,
+                "proposed_distance_m": None,
+            }
+        ]
+        return d
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={"message": "plan a date", "history": []},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "conversation_state" in body
+    cs = body["conversation_state"]
+    assert cs["schema_version"] == 1
+    assert len(cs["closure_context"]) == 1
+    assert cs["closure_context"][0]["place_id"] == "ChIJ_closed"
+
+
+def test_chat_endpoint_degrades_on_malformed_conversation_state(mocker) -> None:
+    """A malformed conversation_state must not 422 — the handler logs and
+    falls back to empty state."""
+    fake_graph = mocker.Mock()
+    captured: dict = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "anything",
+                "conversation_state": {"schema_version": 1, "closure_context": "not-a-list"},
+            },
+        )
+    # Degrades silently -> 200, no closure_context hydrated.
+    assert response.status_code == 200
+    assert captured["state"].closure_context == []
+
+
+def test_chat_endpoint_first_turn_omits_conversation_state(mocker) -> None:
+    fake_graph = mocker.Mock()
+
+    async def _ainvoke(state, config=None):
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post("/chat", json={"message": "hi"})
+
+    assert response.status_code == 200
+    body = response.json()
+    # Backend always emits a typed conversation_state, never null
+    assert "conversation_state" in body
+    assert body["conversation_state"]["schema_version"] == 1
+    assert body["conversation_state"]["closure_context"] == []

--- a/tests/unit/test_chat_endpoint.py
+++ b/tests/unit/test_chat_endpoint.py
@@ -141,6 +141,103 @@ def test_chat_endpoint_passes_history_to_graph(mocker) -> None:
     assert state.messages[1].type == "ai"
     assert state.messages[2].type == "human"
     assert state.messages[2].content == "actually make it 4 stops"
+    assert state.constraints.num_stops == 4
+
+
+def test_chat_endpoint_parses_explicit_stop_count(mocker) -> None:
+    fake_graph = mocker.Mock()
+    captured: dict[str, Any] = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": (
+                    "plan a 3-stop omakase date night near Japantown SF: drinks, dinner, dessert"
+                )
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured["state"].constraints.num_stops == 3
+
+
+def test_chat_endpoint_preserves_explicit_stop_count_across_turns(mocker) -> None:
+    """Multi-turn guardrail: turn 1 says "3 stops", turn 2 refines without
+    naming a count. /chat is stateless — every POST rebuilds ItineraryState
+    from scratch — so num_stops must be parsed across req.history + req.message,
+    not only the current message, or the deterministic count guardrail is lost
+    on every follow-up turn."""
+    fake_graph = mocker.Mock()
+    captured: dict[str, Any] = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "make the second one cheaper",
+                "history": [
+                    {"role": "user", "content": "plan a 3-stop omakase date night"},
+                    {"role": "assistant", "content": "Here's your itinerary: ..."},
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    # The current message has no stop count; the count must come from history.
+    assert captured["state"].constraints.num_stops == 3
+
+
+def test_chat_endpoint_current_message_count_wins_over_history(mocker) -> None:
+    """If the user revises the count mid-conversation, the latest explicit
+    count wins (e.g. "actually make it 4")."""
+    fake_graph = mocker.Mock()
+    captured: dict[str, Any] = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "actually make it 4 stops",
+                "history": [
+                    {"role": "user", "content": "plan a 3-stop omakase date night"},
+                    {"role": "assistant", "content": "Here's your itinerary: ..."},
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured["state"].constraints.num_stops == 4
 
 
 def test_chat_endpoint_accepts_empty_history(mocker) -> None:

--- a/tests/unit/test_chat_endpoint.py
+++ b/tests/unit/test_chat_endpoint.py
@@ -408,3 +408,218 @@ def test_chat_endpoint_first_turn_omits_conversation_state(mocker) -> None:
     assert "conversation_state" in body
     assert body["conversation_state"]["schema_version"] == 1
     assert body["conversation_state"]["closure_context"] == []
+
+
+# ─── Accept / decline / alternative early-return (Task 15) ───────────────
+
+
+def _pending_state(
+    place_id: str = "ChIJ_closed",
+    family: str = "dessert",
+    proposed_id: str = "ChIJ_sophies",
+    prior_stop_id: str = "ChIJ_stop1",
+) -> dict:
+    return {
+        "schema_version": 1,
+        "closure_context": [
+            {
+                "schema_version": 1,
+                "place_id": place_id,
+                "place_name": "Mochill",
+                "family": family,
+                "attempted_arrival": "2026-05-19T20:02:00-07:00",
+                "outcome": "pending_user_decision",
+                "insert_after_place_id": prior_stop_id,
+                "insert_before_place_id": None,
+                "stop_index_hint": 2,
+                "proposed_alternative": {
+                    "place_id": proposed_id,
+                    "name": "Sophie's Crepes",
+                    "rationale": "closest open dessert",
+                    "source": "google_places",
+                    "latitude": 37.7849,
+                    "longitude": -122.4093,
+                    "primary_type": "Dessert Shop",
+                    "arrival_time": "2026-05-19T20:02:00-07:00",
+                    "planned_duration_min": 30,
+                },
+                "proposed_distance_m": 4800.0,
+            }
+        ],
+        "prior_stops": [
+            {
+                "place_id": prior_stop_id,
+                "name": "Stop 1",
+                "rationale": "anchor",
+                "source": "google_places",
+                "latitude": 37.78,
+                "longitude": -122.41,
+                "primary_type": "Bar",
+                "arrival_time": "2026-05-19T18:00:00-07:00",
+                "planned_duration_min": 60,
+            },
+            {
+                "place_id": "ChIJ_stop2",
+                "name": "Stop 2",
+                "rationale": "anchor",
+                "source": "google_places",
+                "latitude": 37.785,
+                "longitude": -122.41,
+                "primary_type": "Restaurant",
+                "arrival_time": "2026-05-19T19:00:00-07:00",
+                "planned_duration_min": 90,
+            },
+        ],
+    }
+
+
+def test_chat_endpoint_accept_path_inserts_proposed_alternative(mocker) -> None:
+    """User replies "yes" → proposed_alternative inserted, graph NOT
+    invoked, response carries 3 stops + user_accepted_drive outcome."""
+    fake_graph = mocker.Mock()
+    fake_graph.ainvoke = mocker.AsyncMock(
+        side_effect=AssertionError("graph should not run on accept path")
+    )
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+    # Re-validation of proposed_alternative: re-fetch details + re-check open
+    from app.tools.retrieval import PlaceDetails
+
+    mocker.patch(
+        "app.main.get_details",
+        return_value=PlaceDetails(
+            place_id="ChIJ_sophies",
+            name="Sophie's Crepes",
+            source="google_places",
+            similarity=0.0,
+            latitude=37.7849,
+            longitude=-122.4093,
+            primary_type="Dessert Shop",
+            formatted_address="123 Fillmore",
+            regular_opening_hours={
+                "periods": [{"open": {"day": 2, "hour": 10}, "close": {"day": 2, "hour": 22}}]
+            },
+        ),
+    )
+    mocker.patch("app.main._place_is_open_now", return_value=True)
+    mocker.patch("app.main._per_stop_closure_status", return_value=[False, False, False])
+    mocker.patch("app.main._bounded_retime_after_swap", side_effect=lambda stops: stops)
+    mocker.patch("app.main.enrich_stops_with_booking", return_value=None)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "yes",
+                "history": [
+                    {"role": "user", "content": "plan a date"},
+                    {"role": "assistant", "content": "The closest open dessert..."},
+                ],
+                "conversation_state": _pending_state(),
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    place_ids = [p["place_id"] for p in body["places"]]
+    assert "ChIJ_sophies" in place_ids
+    cs = body["conversation_state"]
+    outcomes = [c["outcome"] for c in cs["closure_context"]]
+    assert "user_accepted_drive" in outcomes
+
+
+def test_chat_endpoint_decline_path_drops_closed_stop(mocker) -> None:
+    """User replies "no" → closed stop marked declined, no graph invocation."""
+    fake_graph = mocker.Mock()
+    fake_graph.ainvoke = mocker.AsyncMock(
+        side_effect=AssertionError("graph should not run on decline path")
+    )
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "no thanks",
+                "conversation_state": _pending_state(),
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    cs = body["conversation_state"]
+    outcomes = [c["outcome"] for c in cs["closure_context"]]
+    assert "user_declined_dropped" in outcomes
+
+
+def test_chat_endpoint_alternative_path_falls_through_to_graph(mocker) -> None:
+    """User replies "find something cheaper" → graph IS invoked with a
+    HumanMessage hint about the declined drive option."""
+    fake_graph = mocker.Mock()
+    captured: dict = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "find something cheaper instead",
+                "conversation_state": _pending_state(),
+            },
+        )
+
+    assert response.status_code == 200
+    state = captured["state"]
+    # The last human message should reference the closed place name OR the
+    # user's free-text guidance.
+    last_human = next((m for m in reversed(state.messages) if m.type == "human"), None)
+    assert last_human is not None
+    combined_humans = " ".join(
+        m.content for m in state.messages if m.type == "human" and isinstance(m.content, str)
+    )
+    assert "Mochill" in combined_humans or "find something cheaper" in combined_humans
+
+
+def test_chat_endpoint_accept_escalates_when_proposed_alternative_missing(mocker) -> None:
+    """Accept path with proposed_alternative no longer in DB → graph runs
+    (not early-return) with the closure_context preserved."""
+    fake_graph = mocker.Mock()
+    captured: dict = {}
+
+    async def _ainvoke(state, config=None):
+        captured["state"] = state
+        return _final_state_dict(reply="ok")
+
+    fake_graph.ainvoke = _ainvoke
+    mocker.patch(
+        "app.main.load_registered_rag_chain", return_value=_stub_loaded_config(mocker.Mock())
+    )
+    mocker.patch("app.main.build_agent_graph", return_value=fake_graph)
+    mocker.patch("app.main.get_details", return_value=None)  # gone from DB
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/chat",
+            json={
+                "message": "yes",
+                "conversation_state": _pending_state(),
+            },
+        )
+
+    assert response.status_code == 200
+    # Graph WAS invoked -> not an early return
+    assert "state" in captured

--- a/tests/unit/test_chat_functional.py
+++ b/tests/unit/test_chat_functional.py
@@ -283,7 +283,12 @@ def test_chat_retimes_arrival_with_real_directions(monkeypatch, mocker) -> None:
         )
 
     mocker.patch("app.agent.graph.route_legs", _slow_directions)
-    mocker.patch("app.agent.graph.temporal_coherence", lambda _s: 1.0)
+    # Closure detection moved to the swap node; stub it "all open" so retime's
+    # arrival-time projection is the only thing under test.
+    mocker.patch(
+        "app.agent.swap._per_stop_closure_status",
+        side_effect=lambda stops: [False] * len(stops),
+    )
     mocker.patch("app.agent.revision.itinerary_violations", lambda _s: [])
 
     real_graph = build_agent_graph(_ScriptedLLM(scripted=_two_stop_script()), max_steps=6)
@@ -303,42 +308,6 @@ def test_chat_retimes_arrival_with_real_directions(monkeypatch, mocker) -> None:
     assert delta_min == 100  # 60 cocktail_bar dwell + 40 real travel (NOT ~2min haversine)
 
 
-def test_chat_retiming_flips_temporal_pass_to_fail(monkeypatch, mocker) -> None:
-    """Slower real travel pushes stop 2 past its closing time: the re-run
-    temporal check fails and the reply gains the caveat."""
-    _two_hits(monkeypatch)
-
-    async def _slow_directions(stops, mode="walk"):
-        return DirectionsResult(
-            legs=[DirectionsLeg(duration_s=3600, distance_m=4000.0)],
-            total_duration_s=3600,
-            mode=mode,
-            source="google",
-        )
-
-    mocker.patch("app.agent.graph.route_legs", _slow_directions)
-    # temporal_coherence is only called in retime (critique loop uses itinerary_violations,
-    # which is stubbed to []). One call: retime re-check -> fail.
-    scores = iter([0.0])
-    mocker.patch("app.agent.graph.temporal_coherence", lambda _s: next(scores))
-    mocker.patch("app.agent.revision.itinerary_violations", lambda _s: [])
-
-    real_graph = build_agent_graph(_ScriptedLLM(scripted=_two_stop_script()), max_steps=6)
-    mocker.patch("app.main.load_registered_rag_chain", return_value=_stub_loaded_config())
-    mocker.patch("app.main.build_agent_graph", return_value=real_graph)
-
-    with TestClient(app) as client:
-        body = client.post("/chat", json={"message": "two bars, arrive 6pm"}).json()
-
-    assert "Caveats" in body["reply"]
-    assert "temporal_coherence" in body["reply"]
-    # Finalize-on-commit: base reply is synthesized from the stops, then the
-    # retime caveat is appended once.
-    assert body["reply"].startswith("Here's your itinerary:")
-    assert "Bar One" in body["reply"] and "Bar Two" in body["reply"]
-    assert body["reply"].count("Caveats:") == 1
-
-
 def test_chat_directions_failure_keeps_haversine_reply(monkeypatch, mocker) -> None:
     """route_legs internally degrades to fallback -> /chat still 200, no
     spurious caveat, arrival_times come from the haversine fallback."""
@@ -353,7 +322,12 @@ def test_chat_directions_failure_keeps_haversine_reply(monkeypatch, mocker) -> N
         )
 
     mocker.patch("app.agent.graph.route_legs", _fallback_directions)
-    mocker.patch("app.agent.graph.temporal_coherence", lambda _s: 1.0)
+    # Closure detection moved to the swap node; "all open" -> no rewrite,
+    # reply is the synthesized summary.
+    mocker.patch(
+        "app.agent.swap._per_stop_closure_status",
+        side_effect=lambda stops: [False] * len(stops),
+    )
     mocker.patch("app.agent.revision.itinerary_violations", lambda _s: [])
 
     real_graph = build_agent_graph(_ScriptedLLM(scripted=_two_stop_script()), max_steps=6)

--- a/tests/unit/test_critique_checks.py
+++ b/tests/unit/test_critique_checks.py
@@ -20,6 +20,7 @@ from app.agent.critique.checks import (
     geographic_coherence,
     itinerary_violations,
     no_hallucinated_place_ids,
+    stop_count_satisfied,
     temporal_coherence,
     walking_budget_respected,
 )
@@ -321,10 +322,34 @@ def test_constraints_satisfied_skips_hallucinated_pids(patch_db) -> None:
 # --- itinerary_violations aggregation ---------------------------------------
 
 
+def test_stop_count_satisfied_checks_explicit_request() -> None:
+    assert stop_count_satisfied(ItineraryState(stops=[_stop("p1")])) == 1.0
+    assert (
+        stop_count_satisfied(
+            ItineraryState(
+                stops=[_stop("p1"), _stop("p2")],
+                constraints=UserConstraints(num_stops=3),
+            )
+        )
+        == 0.0
+    )
+    assert (
+        stop_count_satisfied(
+            ItineraryState(
+                stops=[_stop("p1"), _stop("p2"), _stop("p3")],
+                constraints=UserConstraints(num_stops=3),
+            )
+        )
+        == 1.0
+    )
+
+
 def test_itinerary_violations_reports_failed_checks_in_order(mocker) -> None:
-    """Order matters: hallucination first, then temporal, geo, walking, then
-    constraints. Mocks each check independently so we can assert the order."""
+    """Order matters: hallucination first, then stop count, temporal, geo,
+    walking, then constraints. Mocks each check independently so we can assert
+    the order."""
     mocker.patch("app.agent.critique.checks.no_hallucinated_place_ids", return_value=0.0)
+    mocker.patch("app.agent.critique.checks.stop_count_satisfied", return_value=0.0)
     mocker.patch("app.agent.critique.checks.temporal_coherence", return_value=0.0)
     mocker.patch("app.agent.critique.checks.geographic_coherence", return_value=0.5)
     mocker.patch("app.agent.critique.checks.walking_budget_respected", return_value=0.0)
@@ -332,6 +357,7 @@ def test_itinerary_violations_reports_failed_checks_in_order(mocker) -> None:
     state = ItineraryState(stops=[_stop("p1")])
     assert itinerary_violations(state) == [
         "no_hallucinated_place_ids",
+        "stop_count_satisfied",
         "temporal_coherence",
         "geographic_coherence",
         "walking_budget_respected",
@@ -342,6 +368,7 @@ def test_itinerary_violations_reports_failed_checks_in_order(mocker) -> None:
 def test_itinerary_violations_empty_when_all_pass(mocker) -> None:
     for fn in (
         "no_hallucinated_place_ids",
+        "stop_count_satisfied",
         "temporal_coherence",
         "geographic_coherence",
         "walking_budget_respected",
@@ -359,6 +386,7 @@ def test_itinerary_violations_fails_open_on_db_error(mocker) -> None:
         "app.agent.critique.checks.no_hallucinated_place_ids",
         side_effect=RuntimeError("db down"),
     )
+    mocker.patch("app.agent.critique.checks.stop_count_satisfied", return_value=1.0)
     mocker.patch("app.agent.critique.checks.temporal_coherence", return_value=1.0)
     mocker.patch("app.agent.critique.checks.geographic_coherence", return_value=1.0)
     mocker.patch("app.agent.critique.checks.walking_budget_respected", return_value=1.0)
@@ -372,6 +400,7 @@ def test_thresholds_are_strict_enough() -> None:
     assert CRITIQUE_THRESHOLDS["geographic_coherence"] == 1.0
     assert CRITIQUE_THRESHOLDS["temporal_coherence"] == 1.0
     assert CRITIQUE_THRESHOLDS["no_hallucinated_place_ids"] == 1.0
+    assert CRITIQUE_THRESHOLDS["stop_count_satisfied"] == 1.0
     assert CRITIQUE_THRESHOLDS["walking_budget_respected"] == 1.0
     # Constraint satisfaction has wiggle room — not every constraint is hard.
     assert CRITIQUE_THRESHOLDS["constraints_satisfied"] == 0.8

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -6,7 +6,13 @@ from zoneinfo import ZoneInfo
 import pytest
 from pydantic import ValidationError
 
-from app.tools.filters import SearchFilters, compile_filters
+from app.tools.filters import (
+    _PRIMARY_TYPE_FAMILIES,
+    SearchFilters,
+    compile_filters,
+    family_of,
+    family_of_types,
+)
 
 
 def test_empty_filters_no_clauses() -> None:
@@ -159,3 +165,39 @@ def test_open_at_accepts_tz_aware_datetime() -> None:
     f_utc = SearchFilters(open_at=datetime(2026, 4, 26, 19, 30, tzinfo=timezone.utc))
     assert f_utc.open_at is not None
     assert f_utc.open_at.tzinfo is timezone.utc
+
+
+# ─── _PRIMARY_TYPE_FAMILIES + family_of (closure-aware swap) ─────────────
+
+
+def test_primary_type_families_all_have_types_and_primary_types() -> None:
+    for family, members in _PRIMARY_TYPE_FAMILIES.items():
+        assert set(members.keys()) == {"types", "primary_types"}, family
+        assert members["types"], f"{family} types must not be empty"
+        assert members["primary_types"], f"{family} primary_types must not be empty"
+
+
+def test_dessert_family_preserves_existing_dessert_members() -> None:
+    dessert = _PRIMARY_TYPE_FAMILIES["dessert"]
+    assert "dessert_shop" in dessert["types"]
+    assert "Dessert Shop" in dessert["primary_types"]
+    assert "Ice Cream Shop" in dessert["primary_types"]
+
+
+def test_family_of_resolves_primary_type() -> None:
+    assert family_of("Dessert Shop") == "dessert"
+    assert family_of("Bar") == "bar"
+    assert family_of("Cafe") == "cafe"
+    assert family_of("Italian Restaurant") == "restaurant"
+
+
+def test_family_of_returns_none_for_unknown_primary_type() -> None:
+    assert family_of("Spaceship") is None
+    assert family_of(None) is None
+    assert family_of("") is None
+
+
+def test_family_of_types_resolves_via_types_array() -> None:
+    assert family_of_types(["italian_restaurant", "restaurant"]) == "restaurant"
+    assert family_of_types(["dessert_shop"]) == "dessert"
+    assert family_of_types([]) is None

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -201,3 +201,48 @@ def test_family_of_types_resolves_via_types_array() -> None:
     assert family_of_types(["italian_restaurant", "restaurant"]) == "restaurant"
     assert family_of_types(["dessert_shop"]) == "dessert"
     assert family_of_types([]) is None
+
+
+def test_primary_type_family_filter_compiles_both_columns() -> None:
+    where, params = compile_filters(
+        SearchFilters(
+            primary_type_family="dessert",
+            business_status=None,
+            min_user_rating_count=None,
+        )
+    )
+    assert "(types && %s OR primary_type = ANY(%s))" in where
+    # types list (snake_case) and primary_types list (Title Case) both as params.
+    # Find the two list params (any in the list — column-conventions are
+    # specific enough to assert membership).
+    list_params = [p for p in params if isinstance(p, list)]
+    assert any("dessert_shop" in p for p in list_params)
+    assert any("Dessert Shop" in p for p in list_params)
+
+
+def test_primary_type_family_unknown_family_raises() -> None:
+    with pytest.raises(ValidationError):
+        SearchFilters.model_validate({"primary_type_family": "spaceship"})
+
+
+def test_excluded_place_ids_filter_compiles_to_not_all() -> None:
+    where, params = compile_filters(
+        SearchFilters(
+            excluded_place_ids=["ChIJ_a", "ChIJ_b"],
+            business_status=None,
+            min_user_rating_count=0,
+        )
+    )
+    assert "place_id != ALL(%s)" in where
+    assert ["ChIJ_a", "ChIJ_b"] in params
+
+
+def test_excluded_place_ids_empty_list_emits_no_clause() -> None:
+    where, _ = compile_filters(
+        SearchFilters(
+            excluded_place_ids=[],
+            business_status=None,
+            min_user_rating_count=0,
+        )
+    )
+    assert "place_id != ALL" not in where

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
+import pytest
+from pydantic import ValidationError
+
 from app.tools.filters import SearchFilters, compile_filters
 
 
@@ -27,10 +30,18 @@ def test_price_and_rating() -> None:
             min_user_rating_count=0,
         )
     )
-    assert "price_level_rank(price_level) <= %s" in where
+    assert "(price_level_rank(price_level) IS NULL OR price_level_rank(price_level) <= %s)" in where
     assert "rating >= %s" in where
     assert 2 in params
     assert 4.3 in params
+
+
+def test_price_filter_keeps_unknown_price_levels() -> None:
+    where, params = compile_filters(
+        SearchFilters(price_level_max=3, business_status=None, min_user_rating_count=0)
+    )
+    assert "price_level_rank(price_level) IS NULL OR" in where
+    assert 3 in params
 
 
 def test_neighborhood_uses_structured_column_with_fallback() -> None:
@@ -57,6 +68,21 @@ def test_types_uses_array_overlap() -> None:
     )
     assert "types && %s" in where
     assert ["bar", "wine_bar"] in params
+
+
+def test_serves_dessert_maps_to_dessert_place_types() -> None:
+    where, params = compile_filters(
+        SearchFilters(serves_dessert=True, business_status=None, min_user_rating_count=0)
+    )
+    assert "types && %s" in where
+    assert "primary_type = ANY(%s)" in where
+    assert "dessert_shop" in params[1]
+    assert "Ice Cream Shop" in params[2]
+
+
+def test_unknown_filter_fields_are_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SearchFilters.model_validate({"serves_desserts": True})
 
 
 def test_open_at_calls_helper() -> None:

--- a/tests/unit/test_kg_traverse.py
+++ b/tests/unit/test_kg_traverse.py
@@ -121,3 +121,29 @@ def test_view_name_resolved(patch_get_conn, monkeypatch) -> None:
     kg_traverse("p1", "NEAR", k=5)
     assert "place_documents_v2" in cursor.executed_sql
     assert "JOIN place_documents pd" not in cursor.executed_sql
+
+
+# --- excluded_place_ids (closure-aware swap) -----------------------------
+
+
+def test_kg_traverse_excluded_place_ids_filters_at_sql_layer(patch_get_conn) -> None:
+    """Closure-swap exclusion: kg_traverse must drop excluded place_ids in
+    the WHERE clause at the SQL layer, not in Python."""
+    cursor = patch_get_conn([])
+    kg_traverse("anchor", excluded_place_ids=["ChIJ_a", "ChIJ_b"])
+
+    # The SQL must include the exclusion guarded by a NULL check so the
+    # no-exclusion call site stays backward-compatible.
+    assert "pd.place_id != ALL(%s::text[])" in cursor.executed_sql
+    assert ["ChIJ_a", "ChIJ_b"] in cursor.executed_params
+
+
+def test_kg_traverse_no_exclusions_is_no_op(patch_get_conn) -> None:
+    """Without excluded_place_ids the SQL must still emit the NULL-guarded
+    clause; the parameter is None so the guard short-circuits and rows
+    aren't filtered."""
+    cursor = patch_get_conn([])
+    kg_traverse("anchor")
+    assert "IS NULL OR pd.place_id != ALL" in cursor.executed_sql
+    # Excluded slot appears twice in params (NULL-guard + comparison); both None.
+    assert cursor.executed_params.count(None) == 2

--- a/tests/unit/test_swap.py
+++ b/tests/unit/test_swap.py
@@ -191,3 +191,127 @@ def test_score_candidate_prefers_family_match() -> None:
     s_match = _score_candidate(candidate, closed, prev_, next_, family_match=True)
     s_nomatch = _score_candidate(candidate, closed, prev_, next_, family_match=False)
     assert s_match > s_nomatch
+
+
+# ─── walking-distance + citywide candidate search (Task 9) ──────────────
+
+
+def test_try_walking_distance_swap_uses_family_and_exclusion(mocker) -> None:
+    """The swap helper must:
+    1. Pass the family to nearby() via SearchFilters.primary_type_family.
+    2. Pass closure_context + current-stops exclusions via excluded_place_ids.
+    3. Pass open_at = attempted_arrival.
+    4. Return the highest-scoring candidate, if any.
+    """
+    from app.agent.state import ClosureContext, ItineraryState
+    from app.agent.swap import _try_walking_distance_swap
+    from app.tools.retrieval import PlaceHit
+
+    captured_calls: list = []
+
+    def _fake_nearby(place_id, radius_m, filters, k):
+        captured_calls.append((place_id, radius_m, filters, k))
+        return [
+            PlaceHit(
+                place_id="alt1",
+                name="Alt 1",
+                primary_type="Dessert Shop",
+                latitude=37.78,
+                longitude=-122.41,
+                rating=4.5,
+                source="google_places",
+                similarity=0.0,
+                dist_m=300.0,
+            )
+        ]
+
+    mocker.patch("app.agent.swap._nearby_search", side_effect=_fake_nearby)
+    closed = _stop(place_id="closed", primary_type="Dessert Shop")
+    prev_ = _stop(place_id="prev", lat=37.78, lng=-122.41)
+    state = ItineraryState(stops=[prev_, closed], closure_context=[])
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Closed",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="prev",
+        insert_before_place_id=None,
+        stop_index_hint=1,
+    )
+
+    match = _try_walking_distance_swap(state, ctx, anchor_place_id="prev")
+
+    assert match is not None
+    assert match.stop.place_id == "alt1"
+    # captured: (place_id, radius_m, filters, k)
+    _, radius_m, filters, _ = captured_calls[0]
+    assert radius_m <= 500  # walking budget
+    assert filters.primary_type_family == "dessert"
+    assert "closed" in (filters.excluded_place_ids or [])
+    assert filters.open_at == datetime(2026, 5, 19, 20, 0, tzinfo=SF)
+
+
+def test_try_walking_distance_swap_returns_none_when_no_candidates(mocker) -> None:
+    from app.agent.state import ClosureContext, ItineraryState
+    from app.agent.swap import _try_walking_distance_swap
+
+    mocker.patch("app.agent.swap._nearby_search", return_value=[])
+    closed = _stop(place_id="closed", primary_type="Dessert Shop")
+    state = ItineraryState(stops=[_stop(place_id="prev"), closed])
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Closed",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="prev",
+        insert_before_place_id=None,
+        stop_index_hint=1,
+    )
+    assert _try_walking_distance_swap(state, ctx, anchor_place_id="prev") is None
+
+
+def test_try_any_distance_search_uses_citywide_radius(mocker) -> None:
+    """Fallback search uses _CITYWIDE_RADIUS_M (30 km) so the question can
+    propose a drive-distance alternative when nothing is within walking
+    distance."""
+    from app.agent.state import ClosureContext, ItineraryState
+    from app.agent.swap import _try_any_distance_search
+    from app.tools.retrieval import PlaceHit
+
+    captured = []
+
+    def _fake_nearby(place_id, radius_m, filters, k):
+        captured.append(radius_m)
+        return [
+            PlaceHit(
+                place_id="alt2",
+                name="Alt 2 (far)",
+                primary_type="Dessert Shop",
+                latitude=37.80,
+                longitude=-122.45,
+                source="google_places",
+                similarity=0.0,
+                dist_m=4800.0,
+            )
+        ]
+
+    mocker.patch("app.agent.swap._nearby_search", side_effect=_fake_nearby)
+    closed = _stop(place_id="closed", primary_type="Dessert Shop")
+    state = ItineraryState(stops=[_stop(place_id="prev"), closed])
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Closed",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="prev",
+        insert_before_place_id=None,
+        stop_index_hint=1,
+    )
+
+    match = _try_any_distance_search(state, ctx, anchor_place_id="prev")
+    assert match is not None
+    assert match.distance_m == 4800.0
+    assert captured[0] == 30_000

--- a/tests/unit/test_swap.py
+++ b/tests/unit/test_swap.py
@@ -475,3 +475,92 @@ def test_formulate_closure_question_without_proposal() -> None:
     assert "Mochill Mochidonut" in q
     # No proposal -> message should ask user to pick / change category
     assert "pick" in q.lower() or "different" in q.lower() or "skip" in q.lower()
+
+
+# ─── _inject_closure_exclusions (Task 12) ────────────────────────────────
+
+
+def _closure_entry(place_id: str = "closed1", outcome: str = "auto_swapped"):
+    from app.agent.state import ClosureContext
+
+    return ClosureContext(
+        place_id=place_id,
+        place_name=place_id,
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome=outcome,  # type: ignore[arg-type]
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=0,
+    )
+
+
+def test_inject_closure_exclusions_merges_into_semantic_search_filters() -> None:
+    from app.agent.swap import _inject_closure_exclusions
+    from app.tools.filters import SearchFilters
+
+    ctx = [
+        _closure_entry("closed1", "auto_swapped"),
+        _closure_entry("closed2", "user_accepted_drive"),
+    ]
+    args = {
+        "query": "ramen",
+        "filters": SearchFilters(min_rating=4.0, excluded_place_ids=["llm_excluded"]),
+    }
+    out = _inject_closure_exclusions("semantic_search", args, ctx)
+    excluded = out["filters"].excluded_place_ids
+    assert set(excluded) == {"llm_excluded", "closed1", "closed2"}
+    # Returns a new args dict (not in-place mutation)
+    assert out is not args
+
+
+def test_inject_closure_exclusions_creates_filters_when_absent() -> None:
+    from app.agent.swap import _inject_closure_exclusions
+
+    ctx = [_closure_entry("closed1", "auto_swapped")]
+    args = {"query": "ramen"}
+    out = _inject_closure_exclusions("semantic_search", args, ctx)
+    assert "filters" in out
+    assert out["filters"].excluded_place_ids == ["closed1"]
+
+
+def test_inject_closure_exclusions_kg_traverse_is_top_level() -> None:
+    """kg_traverse takes excluded_place_ids as a top-level arg, not via filters."""
+    from app.agent.swap import _inject_closure_exclusions
+
+    ctx = [_closure_entry("closed1", "auto_swapped")]
+    args = {"place_id": "anchor", "relation_type": "SIMILAR_VECTOR"}
+    out = _inject_closure_exclusions("kg_traverse", args, ctx)
+    assert out["excluded_place_ids"] == ["closed1"]
+
+
+def test_inject_closure_exclusions_empty_context_is_noop() -> None:
+    from app.agent.swap import _inject_closure_exclusions
+
+    args = {"query": "ramen"}
+    out = _inject_closure_exclusions("semantic_search", args, [])
+    assert out == args
+    assert "filters" not in out
+
+
+def test_inject_closure_exclusions_unknown_tool_is_noop() -> None:
+    from app.agent.swap import _inject_closure_exclusions
+
+    ctx = [_closure_entry("closed1", "auto_swapped")]
+    args = {"foo": "bar"}
+    out = _inject_closure_exclusions("get_details", args, ctx)
+    assert out == args
+
+
+def test_inject_closure_exclusions_accepts_dict_filters_from_llm() -> None:
+    """LangChain may deliver `filters` as a dict (StructuredTool args_schema
+    builds a Pydantic model but tools can pass either shape). The helper
+    must handle dicts by validating into SearchFilters."""
+    from app.agent.swap import _inject_closure_exclusions
+
+    ctx = [_closure_entry("closed1", "auto_swapped")]
+    args = {"query": "ramen", "filters": {"min_rating": 4.0, "excluded_place_ids": ["llm_excl"]}}
+    out = _inject_closure_exclusions("semantic_search", args, ctx)
+    assert out["filters"].excluded_place_ids
+    assert "closed1" in out["filters"].excluded_place_ids
+    assert "llm_excl" in out["filters"].excluded_place_ids

--- a/tests/unit/test_swap.py
+++ b/tests/unit/test_swap.py
@@ -496,6 +496,10 @@ def _closure_entry(place_id: str = "closed1", outcome: str = "auto_swapped"):
 
 
 def test_inject_closure_exclusions_merges_into_semantic_search_filters() -> None:
+    """Filters arrive as either a Pydantic SearchFilters (rare — direct
+    test usage) or a dict (the actual LangChain wire shape). Either way,
+    the returned `filters` MUST be a plain dict so the result is
+    json-serializable when langchain re-sends the AIMessage.tool_calls."""
     from app.agent.swap import _inject_closure_exclusions
     from app.tools.filters import SearchFilters
 
@@ -508,7 +512,8 @@ def test_inject_closure_exclusions_merges_into_semantic_search_filters() -> None
         "filters": SearchFilters(min_rating=4.0, excluded_place_ids=["llm_excluded"]),
     }
     out = _inject_closure_exclusions("semantic_search", args, ctx)
-    excluded = out["filters"].excluded_place_ids
+    assert isinstance(out["filters"], dict)
+    excluded = out["filters"]["excluded_place_ids"]
     assert set(excluded) == {"llm_excluded", "closed1", "closed2"}
     # Returns a new args dict (not in-place mutation)
     assert out is not args
@@ -521,7 +526,8 @@ def test_inject_closure_exclusions_creates_filters_when_absent() -> None:
     args = {"query": "ramen"}
     out = _inject_closure_exclusions("semantic_search", args, ctx)
     assert "filters" in out
-    assert out["filters"].excluded_place_ids == ["closed1"]
+    assert isinstance(out["filters"], dict)
+    assert out["filters"]["excluded_place_ids"] == ["closed1"]
 
 
 def test_inject_closure_exclusions_kg_traverse_is_top_level() -> None:
@@ -553,14 +559,44 @@ def test_inject_closure_exclusions_unknown_tool_is_noop() -> None:
 
 
 def test_inject_closure_exclusions_accepts_dict_filters_from_llm() -> None:
-    """LangChain may deliver `filters` as a dict (StructuredTool args_schema
-    builds a Pydantic model but tools can pass either shape). The helper
-    must handle dicts by validating into SearchFilters."""
+    """LangChain delivers `filters` as a dict in tool_call args (the
+    StructuredTool args_schema is for validation, not for the on-the-wire
+    shape). The helper must accept dicts AND return dicts — anything else
+    breaks JSON serialization when the AIMessage is later sent back to the
+    LLM with the tool_call still attached.
+    """
     from app.agent.swap import _inject_closure_exclusions
 
     ctx = [_closure_entry("closed1", "auto_swapped")]
     args = {"query": "ramen", "filters": {"min_rating": 4.0, "excluded_place_ids": ["llm_excl"]}}
     out = _inject_closure_exclusions("semantic_search", args, ctx)
-    assert out["filters"].excluded_place_ids
-    assert "closed1" in out["filters"].excluded_place_ids
-    assert "llm_excl" in out["filters"].excluded_place_ids
+    assert isinstance(out["filters"], dict), "filters must round-trip as a dict"
+    assert "closed1" in out["filters"]["excluded_place_ids"]
+    assert "llm_excl" in out["filters"]["excluded_place_ids"]
+
+
+def test_inject_closure_exclusions_output_is_json_serializable() -> None:
+    """Regression test for the SearchFilters-in-AIMessage.tool_calls crash:
+    `args["filters"]` was stored as a Pydantic instance and json.dumps on
+    the re-sent message blew up. The helper's output must be a plain dict
+    tree so langchain can serialize it as the tool_call args.
+    """
+    import json as _json
+
+    from app.agent.swap import _inject_closure_exclusions
+    from app.tools.filters import SearchFilters
+
+    ctx = [_closure_entry("closed1", "auto_swapped")]
+    # All three shapes LangChain might deliver: dict, SearchFilters, absent
+    for filters_in in (
+        {"min_rating": 4.0},
+        SearchFilters(min_rating=4.0),
+        None,
+    ):
+        args = (
+            {"query": "ramen"} if filters_in is None else {"query": "ramen", "filters": filters_in}
+        )
+        out = _inject_closure_exclusions("semantic_search", args, ctx)
+        # If json.dumps doesn't raise, langchain's _lc_tool_call_to_openai_tool_call
+        # won't crash on the round trip.
+        _json.dumps(out)

--- a/tests/unit/test_swap.py
+++ b/tests/unit/test_swap.py
@@ -315,3 +315,163 @@ def test_try_any_distance_search_uses_citywide_radius(mocker) -> None:
     assert match is not None
     assert match.distance_m == 4800.0
     assert captured[0] == 30_000
+
+
+# ─── apply_swap + bounded_retime + promote_pending + question (Task 10) ─
+
+
+def test_apply_swap_replaces_stop_at_position(mocker) -> None:
+    from app.agent.state import ItineraryState
+    from app.agent.swap import _apply_swap
+
+    s1 = _stop(place_id="s1", name="S1")
+    s2_closed = _stop(place_id="s2_closed", name="S2 closed")
+    s3 = _stop(place_id="s3", name="S3")
+    state = ItineraryState(stops=[s1, s2_closed, s3])
+    replacement = _stop(place_id="s2_new", name="S2 new")
+    leg_durations_min = [10.0, 5.0]
+
+    # Avoid touching the real DB during enrich
+    mocker.patch("app.agent.swap.enrich_stops_with_booking", return_value=None)
+
+    new_stops = _apply_swap(
+        state,
+        stop_index=1,
+        replacement=replacement,
+        leg_durations_min=leg_durations_min,
+    )
+
+    assert [s.place_id for s in new_stops] == ["s1", "s2_new", "s3"]
+
+
+def test_bounded_retime_after_swap_calls_route_legs_once(mocker) -> None:
+    """The bounded retime helper makes at most ONE extra route_legs call per
+    swap-node invocation. Mock route_legs and confirm call_count == 1."""
+    import asyncio
+
+    from app.agent.swap import _bounded_retime_after_swap
+    from app.tools.directions import DirectionsLeg, DirectionsResult
+
+    call_count = {"n": 0}
+
+    async def _fake_route(stops, mode="walk"):
+        call_count["n"] += 1
+        legs = [DirectionsLeg(duration_s=600, distance_m=400.0)] * max(len(stops) - 1, 1)
+        return DirectionsResult(
+            legs=legs,
+            total_duration_s=600 * len(legs),
+            mode=mode,
+            source="haversine_fallback",
+        )
+
+    mocker.patch("app.agent.swap.route_legs", side_effect=_fake_route)
+    stops = [_stop(place_id="a"), _stop(place_id="b"), _stop(place_id="c")]
+    retimed = asyncio.run(_bounded_retime_after_swap(stops))
+    assert call_count["n"] == 1
+    assert len(retimed) == 3
+
+
+def test_promote_pending_flips_first_queued_to_pending() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _promote_pending
+
+    queued1 = ClosureContext(
+        place_id="q1",
+        place_name="Q1",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="queued_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=0,
+    )
+    queued2 = queued1.model_copy(update={"place_id": "q2"})
+    auto = queued1.model_copy(update={"place_id": "a", "outcome": "auto_swapped"})
+
+    promoted = _promote_pending([auto, queued1, queued2])
+    outcomes = [c.outcome for c in promoted]
+    assert outcomes == ["auto_swapped", "pending_user_decision", "queued_user_decision"]
+
+
+def test_promote_pending_is_noop_when_no_queued() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _promote_pending
+
+    auto = ClosureContext(
+        place_id="a",
+        place_name="A",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="auto_swapped",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=0,
+    )
+    assert [c.outcome for c in _promote_pending([auto])] == ["auto_swapped"]
+
+
+def test_promote_pending_is_noop_when_pending_already_present() -> None:
+    """If pending already exists, don't promote a queued one too."""
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _promote_pending
+
+    pending = ClosureContext(
+        place_id="p",
+        place_name="P",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=0,
+    )
+    queued = pending.model_copy(update={"place_id": "q", "outcome": "queued_user_decision"})
+    promoted = _promote_pending([pending, queued])
+    outcomes = [c.outcome for c in promoted]
+    assert outcomes == ["pending_user_decision", "queued_user_decision"]
+
+
+def test_formulate_closure_question_with_proposal() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _formulate_closure_question
+
+    proposal = _stop(place_id="alt", name="Sophie's Crepes")
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Mochill Mochidonut",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=2,
+        proposed_alternative=proposal,
+        proposed_distance_m=4800.0,
+    )
+    q = _formulate_closure_question(ctx)
+    assert "Sophie's Crepes" in q
+    assert "Mochill Mochidonut" in q
+    # ~3 mi rounding from 4800m is expected
+    assert "3" in q
+
+
+def test_formulate_closure_question_without_proposal() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _formulate_closure_question
+
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="Mochill Mochidonut",
+        family="dessert",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id=None,
+        insert_before_place_id=None,
+        stop_index_hint=2,
+        proposed_alternative=None,
+        proposed_distance_m=None,
+    )
+    q = _formulate_closure_question(ctx)
+    assert "Mochill Mochidonut" in q
+    # No proposal -> message should ask user to pick / change category
+    assert "pick" in q.lower() or "different" in q.lower() or "skip" in q.lower()

--- a/tests/unit/test_swap.py
+++ b/tests/unit/test_swap.py
@@ -1,0 +1,102 @@
+"""Unit tests for app/agent/swap.py.
+
+All DB access (place_is_open SQL function) is mocked via _execute_closure_query
+or the helper's direct cursor calls. Live-DB behavior is covered separately
+in tests/integration/test_swap_real_db.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.agent.state import Stop
+
+SF = ZoneInfo("America/Los_Angeles")
+
+
+def _stop(
+    place_id: str = "p",
+    name: str = "X",
+    arrival_iso: str = "2026-05-19T19:00:00-07:00",
+    lat: float = 37.78,
+    lng: float = -122.41,
+    primary_type: str = "Bar",
+) -> Stop:
+    return Stop(
+        place_id=place_id,
+        name=name,
+        rationale="r",
+        source="google_places",
+        arrival_time=datetime.fromisoformat(arrival_iso),
+        latitude=lat,
+        longitude=lng,
+        primary_type=primary_type,
+        planned_duration_min=60,
+    )
+
+
+def test_per_stop_closure_status_all_open(mocker) -> None:
+    """Every stop returns is_open=True → list of all False (False = not closed)."""
+    from app.agent.swap import _per_stop_closure_status
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"p1": True, "p2": True},
+    )
+    stops = [_stop(place_id="p1"), _stop(place_id="p2")]
+    statuses = _per_stop_closure_status(stops)
+    # _per_stop_closure_status returns True for "closed", False for "open".
+    assert statuses == [False, False]
+
+
+def test_per_stop_closure_status_one_closed(mocker) -> None:
+    from app.agent.swap import _per_stop_closure_status
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"p1": True, "p2": False},
+    )
+    stops = [_stop(place_id="p1"), _stop(place_id="p2")]
+    statuses = _per_stop_closure_status(stops)
+    assert statuses == [False, True]
+
+
+def test_per_stop_closure_status_skips_stops_without_arrival_time(mocker) -> None:
+    """A stop with arrival_time=None can't be checked; treat as not-closed."""
+    from app.agent.swap import _per_stop_closure_status
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"p1": True},
+    )
+    stops = [_stop(place_id="p1")]
+    stops.append(
+        Stop(
+            place_id="p2",
+            name="no time",
+            rationale="r",
+            source="google_places",
+            arrival_time=None,
+            latitude=37.78,
+            longitude=-122.41,
+            primary_type="Bar",
+            planned_duration_min=60,
+        )
+    )
+    statuses = _per_stop_closure_status(stops)
+    assert statuses == [False, False]
+
+
+def test_per_stop_closure_status_db_failure_fails_open(mocker) -> None:
+    """A DB blip must NOT block /chat — the helper returns [False] * n
+    (no closure detected) so the plan ships unchanged. Matches checks.py
+    fail-open precedent at lines 200-205."""
+    from app.agent.swap import _per_stop_closure_status
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        side_effect=Exception("db down"),
+    )
+    statuses = _per_stop_closure_status([_stop(place_id="p1"), _stop(place_id="p2")])
+    assert statuses == [False, False]

--- a/tests/unit/test_swap.py
+++ b/tests/unit/test_swap.py
@@ -100,3 +100,94 @@ def test_per_stop_closure_status_db_failure_fails_open(mocker) -> None:
     )
     statuses = _per_stop_closure_status([_stop(place_id="p1"), _stop(place_id="p2")])
     assert statuses == [False, False]
+
+
+# ─── _resolve_insert_position + _score_candidate (Task 8) ───────────────
+
+
+def test_resolve_insert_position_uses_insert_after_when_anchor_present() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _resolve_insert_position
+
+    stops = [_stop(place_id="a"), _stop(place_id="b"), _stop(place_id="c")]
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="X",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="a",
+        insert_before_place_id=None,
+        stop_index_hint=99,
+    )
+    # insert_after a (index 0) -> position 1
+    assert _resolve_insert_position(ctx, stops) == 1
+
+
+def test_resolve_insert_position_falls_back_to_insert_before() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _resolve_insert_position
+
+    stops = [_stop(place_id="a"), _stop(place_id="b")]
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="X",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="missing",
+        insert_before_place_id="b",
+        stop_index_hint=99,
+    )
+    # insert_after missing; insert_before b (index 1) -> position 1
+    assert _resolve_insert_position(ctx, stops) == 1
+
+
+def test_resolve_insert_position_falls_back_to_index_hint_clamped() -> None:
+    from app.agent.state import ClosureContext
+    from app.agent.swap import _resolve_insert_position
+
+    stops = [_stop(place_id="a"), _stop(place_id="b")]
+    ctx = ClosureContext(
+        place_id="closed",
+        place_name="X",
+        family="bar",
+        attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+        outcome="pending_user_decision",
+        insert_after_place_id="missing",
+        insert_before_place_id="also_missing",
+        stop_index_hint=99,
+    )
+    # Both anchors absent; clamp hint to len(stops)
+    assert _resolve_insert_position(ctx, stops) == 2
+
+
+def test_score_candidate_prefers_lower_route_impact() -> None:
+    """Two candidates with identical family-match: the one with smaller
+    combined prev+next distance scores higher."""
+    from app.agent.swap import _score_candidate
+
+    closed = _stop(place_id="closed", lat=37.78, lng=-122.41)
+    prev_ = _stop(place_id="prev", lat=37.78, lng=-122.41)
+    next_ = _stop(place_id="next", lat=37.785, lng=-122.41)
+
+    close_candidate = _stop(place_id="c1", lat=37.78, lng=-122.41)
+    far_candidate = _stop(place_id="c2", lat=37.90, lng=-122.41)
+
+    s_close = _score_candidate(close_candidate, closed, prev_, next_, family_match=True)
+    s_far = _score_candidate(far_candidate, closed, prev_, next_, family_match=True)
+    assert s_close > s_far
+
+
+def test_score_candidate_prefers_family_match() -> None:
+    """All else equal, a family-matching candidate beats one that doesn't."""
+    from app.agent.swap import _score_candidate
+
+    closed = _stop(place_id="closed")
+    prev_ = _stop(place_id="prev")
+    next_ = _stop(place_id="next")
+    candidate = _stop(place_id="c", lat=37.78, lng=-122.41)
+
+    s_match = _score_candidate(candidate, closed, prev_, next_, family_match=True)
+    s_nomatch = _score_candidate(candidate, closed, prev_, next_, family_match=False)
+    assert s_match > s_nomatch

--- a/tests/unit/test_swap_node.py
+++ b/tests/unit/test_swap_node.py
@@ -1,0 +1,263 @@
+"""Smoke tests for the swap_closed_stops graph node.
+
+Uses real ItineraryState + Stop models, with the SQL helpers and Routes API
+mocked. Verifies the orchestration: no-op when nothing's closed, auto-swap
+batches, escalation to pending, queueing additional pending entries, etc.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.agent.state import ClosureContext, ItineraryState, Stop
+from app.tools.directions import DirectionsLeg, DirectionsResult
+from app.tools.retrieval import PlaceHit
+
+SF = ZoneInfo("America/Los_Angeles")
+
+
+def _stop(
+    place_id: str,
+    *,
+    name: str = "X",
+    arrival_iso: str = "2026-05-19T19:00:00-07:00",
+    primary_type: str = "Bar",
+    lat: float = 37.78,
+    lng: float = -122.41,
+) -> Stop:
+    return Stop(
+        place_id=place_id,
+        name=name,
+        rationale="r",
+        source="google_places",
+        arrival_time=datetime.fromisoformat(arrival_iso),
+        latitude=lat,
+        longitude=lng,
+        primary_type=primary_type,
+        planned_duration_min=60,
+    )
+
+
+def _fake_route_factory():
+    """Returns an async fake for route_legs that returns one leg per pair."""
+
+    async def _r(stops, mode="walk"):
+        legs = [DirectionsLeg(duration_s=600, distance_m=400.0)] * max(len(stops) - 1, 1)
+        return DirectionsResult(
+            legs=legs,
+            total_duration_s=600 * len(legs),
+            mode=mode,
+            source="haversine_fallback",
+        )
+
+    return _r
+
+
+def test_swap_node_noop_when_nothing_closed(mocker) -> None:
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch("app.agent.swap._execute_closure_query", return_value={"a": True, "b": True})
+    state = ItineraryState(stops=[_stop("a"), _stop("b")])
+    update = asyncio.run(swap_closed_stops(state))
+    # No-op -> empty update (the graph state stays as-is)
+    assert update == {}
+
+
+def test_swap_node_auto_swap_silent_when_candidate_found(mocker) -> None:
+    """Closure detected at stop 1; walking-distance candidate exists ->
+    silent swap, closure_context records auto_swapped, summary reply (no
+    "Caveats:" text)."""
+    from app.agent.swap import swap_closed_stops
+
+    # Stop b is closed initially; after the swap, all are open
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        side_effect=[
+            {"a": True, "b": False, "c": True},  # initial closure check
+            {"a": True, "b_alt": True, "c": True},  # post-swap re-check
+        ],
+    )
+    candidate = PlaceHit(
+        place_id="b_alt",
+        name="B Alt",
+        primary_type="Bar",
+        latitude=37.78,
+        longitude=-122.41,
+        source="google_places",
+        similarity=0.0,
+        dist_m=200.0,
+    )
+    mocker.patch("app.agent.swap._nearby_search", return_value=[candidate])
+    mocker.patch("app.agent.swap.route_legs", side_effect=_fake_route_factory())
+    mocker.patch("app.agent.swap.enrich_stops_with_booking", return_value=None)
+
+    state = ItineraryState(
+        stops=[
+            _stop("a", primary_type="Bar"),
+            _stop("b", primary_type="Bar"),
+            _stop("c", primary_type="Bar"),
+        ],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    new_stops = update.get("stops")
+    assert new_stops is not None
+    assert [s.place_id for s in new_stops] == ["a", "b_alt", "c"]
+    new_ctx = update["closure_context"]
+    assert any(c.outcome == "auto_swapped" and c.place_id == "b" for c in new_ctx)
+    # Silent swap -> reply is the regenerated summary
+    reply = update.get("final_reply", "")
+    assert "Caveats" not in reply
+    assert "B Alt" in reply
+
+
+def test_swap_node_escalates_to_pending_when_no_walking_match(mocker) -> None:
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"a": True, "b": False},
+    )
+    # Walking search returns empty; citywide search returns one far candidate.
+    mocker.patch(
+        "app.agent.swap._nearby_search",
+        side_effect=[
+            [],  # walking-distance result
+            [
+                PlaceHit(
+                    place_id="b_far",
+                    name="B Far",
+                    primary_type="Bar",
+                    latitude=37.80,
+                    longitude=-122.45,
+                    source="google_places",
+                    similarity=0.0,
+                    dist_m=4800.0,
+                )
+            ],  # citywide fallback
+        ],
+    )
+    state = ItineraryState(
+        stops=[_stop("a", primary_type="Bar"), _stop("b", primary_type="Bar")],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    new_ctx = update["closure_context"]
+    pending = [c for c in new_ctx if c.outcome == "pending_user_decision"]
+    assert len(pending) == 1
+    assert pending[0].place_id == "b"
+    assert pending[0].proposed_alternative is not None
+    assert pending[0].proposed_alternative.place_id == "b_far"
+    # Reply is the question text, not a summary
+    assert update["final_reply"]
+    assert "B" in update["final_reply"]
+
+
+def test_swap_node_queues_additional_pending_closures(mocker) -> None:
+    """Two stops closed, neither walking-fixable -> first becomes pending,
+    second becomes queued."""
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"a": False, "b": False},
+    )
+    mocker.patch("app.agent.swap._nearby_search", return_value=[])
+    state = ItineraryState(
+        stops=[_stop("a", primary_type="Bar"), _stop("b", primary_type="Bar")],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    outcomes = [c.outcome for c in update["closure_context"]]
+    assert outcomes.count("pending_user_decision") == 1
+    assert outcomes.count("queued_user_decision") == 1
+
+
+def test_swap_node_skips_when_family_unresolved(mocker) -> None:
+    """A stop whose primary_type has no family (e.g. 'Spaceship') escalates
+    to a pending entry with no proposal — we can't search."""
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        return_value={"a": True, "b": False},
+    )
+    mocker.patch("app.agent.swap._nearby_search", return_value=[])
+    state = ItineraryState(
+        stops=[
+            _stop("a", primary_type="Bar"),
+            _stop("b", primary_type="Spaceship"),  # unknown family
+        ],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    new_ctx = update["closure_context"]
+    pending = [c for c in new_ctx if c.outcome == "pending_user_decision"]
+    assert len(pending) == 1
+    assert pending[0].family == ""
+    assert pending[0].proposed_alternative is None
+
+
+def test_swap_node_caps_closure_context_at_max(mocker) -> None:
+    """When closure_context grows past MAX_CLOSURE_CONTEXT_ENTRIES, oldest
+    entries are dropped."""
+    from app.agent.state import MAX_CLOSURE_CONTEXT_ENTRIES
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        side_effect=[{"x": False}, {"y_alt": True}],
+    )
+    candidate = PlaceHit(
+        place_id="y_alt",
+        name="Y Alt",
+        primary_type="Bar",
+        latitude=37.78,
+        longitude=-122.41,
+        source="google_places",
+        similarity=0.0,
+        dist_m=200.0,
+    )
+    mocker.patch("app.agent.swap._nearby_search", return_value=[candidate])
+    mocker.patch("app.agent.swap.route_legs", side_effect=_fake_route_factory())
+    mocker.patch("app.agent.swap.enrich_stops_with_booking", return_value=None)
+
+    existing = [
+        ClosureContext(
+            place_id=f"old_{i}",
+            place_name=f"Old {i}",
+            family="bar",
+            attempted_arrival=datetime(2026, 5, 19, 20, 0, tzinfo=SF),
+            outcome="auto_swapped",
+            insert_after_place_id=None,
+            insert_before_place_id=None,
+            stop_index_hint=0,
+        )
+        for i in range(MAX_CLOSURE_CONTEXT_ENTRIES)
+    ]
+    state = ItineraryState(
+        stops=[_stop("x", primary_type="Bar")],
+        closure_context=existing,
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    new_ctx = update["closure_context"]
+    assert len(new_ctx) == MAX_CLOSURE_CONTEXT_ENTRIES
+    # The oldest "old_0" should be dropped; the new entry should be present.
+    place_ids = {c.place_id for c in new_ctx}
+    assert "old_0" not in place_ids
+    assert "x" in place_ids
+
+
+def test_swap_node_fail_open_on_initial_db_error(mocker) -> None:
+    """If the initial closure query fails, the node is a no-op and ships
+    the plan as-is. Matches checks.py:200-205 precedent."""
+    from app.agent.swap import swap_closed_stops
+
+    mocker.patch(
+        "app.agent.swap._execute_closure_query",
+        side_effect=Exception("db down"),
+    )
+    state = ItineraryState(
+        stops=[_stop("a", primary_type="Bar"), _stop("b", primary_type="Bar")],
+    )
+    update = asyncio.run(swap_closed_stops(state))
+    # No-op (closure-status helper returns [False, False] on DB error)
+    assert update == {}

--- a/tests/unit/test_tools_retrieval.py
+++ b/tests/unit/test_tools_retrieval.py
@@ -299,3 +299,46 @@ def test_get_details_many_omits_missing_ids_silently(patch_get_conn) -> None:
     out = get_details_many(["p1", "p2"])
     assert "p1" in out
     assert "p2" not in out
+
+
+# --- dist_m projection (closure-aware swap) -------------------------------
+
+
+def test_place_hit_dist_m_defaults_to_none() -> None:
+    """Backward compatibility: semantic_search rows have no dist_m column,
+    so PlaceHit must accept missing dist_m and default to None."""
+    hit = PlaceHit(
+        place_id="p1",
+        name="x",
+        source="google_places",
+        similarity=0.7,
+    )
+    assert hit.dist_m is None
+
+
+def test_nearby_projects_dist_m_in_select_and_returns_it(patch_get_conn) -> None:
+    """nearby() must SELECT dist_m alongside existing fields so the closure
+    swap node can score candidates by route impact."""
+    cursor = patch_get_conn(
+        [
+            {
+                "place_id": "p2",
+                "name": "near",
+                "primary_type": "Bar",
+                "formatted_address": "...",
+                "latitude": 37.78,
+                "longitude": -122.41,
+                "rating": 4.5,
+                "price_level": None,
+                "business_status": "OPERATIONAL",
+                "source": "google_places",
+                "similarity": 0.0,
+                "snippet": "snippet",
+                "dist_m": 250.0,
+            }
+        ]
+    )
+    hits = nearby(place_id="anchor", radius_m=800)
+    # The outer SELECT must project dist_m alongside the other fields.
+    assert "dist_m" in cursor.executed_sql
+    assert hits[0].dist_m == 250.0


### PR DESCRIPTION
## Summary

Three rounds of reliability work shipped as one branch. Replaces the
\`temporal_coherence\` caveat (broken plan + ugly warning) with a real
silent-swap-or-ask-user flow, and fixes two bugs found while live-testing
that flow.

- **Closure-aware itinerary swap** (16 commits) — New \`swap_closed_stops\`
  LangGraph node sits between \`retime\` and \`END\`. When a committed stop
  will be closed at its planned arrival, it tries a walking-distance swap
  in the same category family; if none exists, it asks the user one clear
  question (accept the closest open option / drop the stop / re-plan).
  Closure history persists across turns via an opaque
  \`conversation_state\` field round-tripped through \`/chat\`. Sql-layer
  \`excluded_place_ids\` enforcement on \`semantic_search\` / \`nearby\` /
  \`kg_traverse\` so closures are filtered out even when the prompt fails.
- **Bare-number reply parsing** (1 commit) — When the user replies with
  just \`"3"\` to "how many stops would you like?", \`num_stops\` is
  parsed correctly. Without this, the deterministic count guardrail
  never engaged and gpt-4o-mini occasionally over-looped into the
  step-limit short-circuit.
- **JSON-safe tool_call args across plan steps** (1 commit) — Fixes a
  500 that surfaced on turn 3 of the omakase flow. \`act()\` was
  reassigning \`tc["args"]\` which mutated the dict LangChain stores
  inside \`AIMessage.tool_calls\`; the next \`plan()\` step crashed when
  langchain serialized the AIMessage for OpenAI's API. Fix: helpers
  return dict-shaped filters; \`act()\` uses a local \`effective_args\`.

## Test Plan

- [x] Full unit suite passes: \`make test\` → 583 passed, 93% coverage
- [x] Lint clean: \`make lint\`
- [x] Mypy clean: \`make typecheck\`
- [x] Frontend tests + build: \`cd frontend && npm test && npm run build\` → 30 pass
- [x] Integration tests gated on \`APP_ENV=integration\` (3 in
      \`tests/integration/test_swap_real_db.py\`)
- [x] Live verified end-to-end via curl with the omakase Mission/Japantown
      query — bare-number + JSON-safety bugs no longer reproduce

## Honest follow-ups (NOT in scope for this PR — tracked for v2.0)

5 live runs against this branch surfaced 4 agent-behavior bugs that exist
independent of the closure-swap work:
- Category compliance (committed places don't match user's named categories)
- Rationale-stop alignment (rationale text bleeds across stops on refinement)
- Minimal-edit refinement (one-stop edits rewrite the whole plan)
- Step-budget exhaustion on revision+closure cascades

Plus two infrastructure gaps:
- No way to test candidate models without touching the shared MLflow
  \`production\` alias
- No reproducible eval; model variance hides regressions

These are the v2.0 Production Readiness milestone scope, planned as a
separate roadmap after this lands. Merging this gives that milestone a
stable baseline to measure against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)