### PR TITLE
feat: RAG_MODEL_OVERRIDE env var for MLflow version/alias routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,31 @@ poetry run python scripts/log_model_to_mlflow.py \
    ```
 4. Restart the app — it loads the `production` alias at startup.
 
+### Model Override
+
+`RAG_MODEL_OVERRIDE` lets a developer or eval runner route `/chat` through a
+candidate MLflow model without touching the shared `production` alias.
+
+```bash
+# Recommended: pin to a specific numeric version
+RAG_MODEL_OVERRIDE=version:7 poetry run uvicorn app.main:app --reload
+
+# Also supported: a named alias
+RAG_MODEL_OVERRIDE=alias:my-test-alias poetry run uvicorn app.main:app --reload
+```
+
+`version:N` is the recommended form: `alias:NAME` re-resolves on every load and
+can race if a teammate moves the alias mid-eval. Use named aliases only when you
+need a moving target (e.g. a `staging` alias that auto-tracks the latest registered
+version).
+
+Confirm the override took effect by looking for the `load_registered_rag_chain:
+using override kind=... version=...` INFO log line at startup, or hit `/health`
+and check `chat_model`.
+
+Unsetting the variable (or restarting without it) falls back to the `production`
+alias — full backward compatibility.
+
 ## Common Commands
 
 Run `make help` to see all targets.

--- a/app/config.py
+++ b/app/config.py
@@ -101,6 +101,10 @@ class Settings(BaseSettings):
     mlflow_tracking_uri: str = "http://localhost:5000"
     mlflow_artifacts_uri: str = "mlflow-artifacts://localhost:5000"
     mlflow_model_name: str = "city-concierge-rag"
+    # When set (e.g. "version:7" or "alias:my-test-alias"), load_registered_rag_chain
+    # bypasses the shared "production" alias and loads the named version/alias instead.
+    # Unset (None) preserves all existing behavior. See app.main._parse_model_override.
+    rag_model_override: str | None = None
     retriever_k: int = 5
     embedding_table: str = "place_embeddings_v2"
     db_pool_min_connections: int = 0

--- a/app/main.py
+++ b/app/main.py
@@ -167,6 +167,31 @@ def parse_active_model_config(
     )
 
 
+_OVERRIDE_FORMAT_HINT = (
+    "RAG_MODEL_OVERRIDE must be 'version:N' or 'alias:NAME'; got {raw!r}. "
+    "version:N is recommended (alias:NAME re-resolves per request and can race "
+    "with alias moves)."
+)
+
+
+def _parse_model_override(raw: str) -> tuple[Literal["version", "alias"], str]:
+    """Parse RAG_MODEL_OVERRIDE into (kind, value).
+
+    Accepts 'version:N' or 'alias:NAME'. Whitespace around the value is stripped
+    (env exports from shells sometimes leak stray spaces). Empty input and any
+    other shape raises ValueError with an actionable message naming both valid
+    forms — the caller is responsible for short-circuiting on None / unset
+    before invoking this helper.
+    """
+    if not raw or ":" not in raw:
+        raise ValueError(_OVERRIDE_FORMAT_HINT.format(raw=raw))
+    prefix, _, value = raw.partition(":")
+    value = value.strip()
+    if prefix not in ("version", "alias") or not value:
+        raise ValueError(_OVERRIDE_FORMAT_HINT.format(raw=raw))
+    return prefix, value  # type: ignore[return-value]
+
+
 def load_registered_rag_chain() -> LoadedConfig:
     settings = get_settings()
     tracking_uri = settings.mlflow_tracking_uri

--- a/app/main.py
+++ b/app/main.py
@@ -167,28 +167,21 @@ def parse_active_model_config(
     )
 
 
-_OVERRIDE_FORMAT_HINT = (
-    "RAG_MODEL_OVERRIDE must be 'version:N' or 'alias:NAME'; got {raw!r}. "
-    "version:N is recommended (alias:NAME re-resolves per request and can race "
-    "with alias moves)."
-)
-
-
 def _parse_model_override(raw: str) -> tuple[Literal["version", "alias"], str]:
-    """Parse RAG_MODEL_OVERRIDE into (kind, value).
+    """Parse RAG_MODEL_OVERRIDE into (kind, value); accepts 'version:N' or 'alias:NAME'.
 
-    Accepts 'version:N' or 'alias:NAME'. Whitespace around the value is stripped
-    (env exports from shells sometimes leak stray spaces). Empty input and any
-    other shape raises ValueError with an actionable message naming both valid
-    forms — the caller is responsible for short-circuiting on None / unset
-    before invoking this helper.
+    Whitespace around the value is stripped (shell exports leak stray spaces).
+    Empty input and any other shape raises ValueError. Caller is responsible
+    for short-circuiting on None / unset before invoking this helper.
     """
-    if not raw or ":" not in raw:
-        raise ValueError(_OVERRIDE_FORMAT_HINT.format(raw=raw))
-    prefix, _, value = raw.partition(":")
+    prefix, sep, value = raw.partition(":")
     value = value.strip()
-    if prefix not in ("version", "alias") or not value:
-        raise ValueError(_OVERRIDE_FORMAT_HINT.format(raw=raw))
+    if not sep or prefix not in ("version", "alias") or not value:
+        raise ValueError(
+            f"RAG_MODEL_OVERRIDE must be 'version:N' or 'alias:NAME'; got {raw!r}. "
+            "version:N is recommended (alias:NAME re-resolves per request "
+            "and can race with alias moves)."
+        )
     return prefix, value  # type: ignore[return-value]
 
 
@@ -199,16 +192,39 @@ def load_registered_rag_chain() -> LoadedConfig:
     mlflow.set_tracking_uri(tracking_uri)
     client = mlflow.MlflowClient(tracking_uri=tracking_uri)
 
-    try:
-        model_version = client.get_model_version_by_alias(
-            settings.mlflow_model_name,
-            "production",
+    # RAG_MODEL_OVERRIDE routes /chat through a candidate version/alias without
+    # touching the shared "production" alias. version:N is recommended; alias:NAME
+    # re-resolves on every load and can race if someone moves the alias mid-eval.
+    raw_override = (settings.rag_model_override or "").strip()
+    if raw_override:
+        kind, value = _parse_model_override(raw_override)
+        try:
+            model_version = (
+                client.get_model_version(settings.mlflow_model_name, value)
+                if kind == "version"
+                else client.get_model_version_by_alias(settings.mlflow_model_name, value)
+            )
+        except Exception as exc:  # pragma: no cover - exercised via startup tests
+            raise RuntimeError(
+                f"Unable to load MLflow model for RAG_MODEL_OVERRIDE={raw_override!r}."
+            ) from exc
+        logger.info(
+            "load_registered_rag_chain: using override kind=%s value=%s version=%s",
+            kind,
+            value,
+            model_version.version,
         )
-    except Exception as exc:  # pragma: no cover - exercised via startup tests
-        raise RuntimeError(
-            "Unable to load the MLflow production alias for "
-            f"registered model '{settings.mlflow_model_name}'."
-        ) from exc
+    else:
+        try:
+            model_version = client.get_model_version_by_alias(
+                settings.mlflow_model_name,
+                "production",
+            )
+        except Exception as exc:  # pragma: no cover - exercised via startup tests
+            raise RuntimeError(
+                "Unable to load the MLflow production alias for "
+                f"registered model '{settings.mlflow_model_name}'."
+            ) from exc
 
     run = client.get_run(model_version.run_id)
     config = parse_active_model_config(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -86,3 +86,24 @@ def test_resolve_llm_api_key_supports_deepseek_and_kimi(monkeypatch) -> None:
     get_settings.cache_clear()
     assert resolve_llm_api_key("deepseek") == "ds-key"
     assert resolve_llm_api_key("kimi") == "ms-key"
+
+
+def test_rag_model_override_defaults_none(monkeypatch) -> None:
+    """Unset RAG_MODEL_OVERRIDE -> Settings.rag_model_override is None.
+
+    Backward-compat sentinel (OVR-03): every existing test path must see None
+    so load_registered_rag_chain takes the 'production' alias branch.
+    """
+    monkeypatch.delenv("RAG_MODEL_OVERRIDE", raising=False)
+    get_settings.cache_clear()
+    assert get_settings().rag_model_override is None
+
+
+def test_rag_model_override_reads_env_var(monkeypatch) -> None:
+    """RAG_MODEL_OVERRIDE env var flows through pydantic-settings (OVR-01, OVR-05).
+
+    Uses monkeypatch.setenv, never os.environ[...] (OVR-05 contract).
+    """
+    monkeypatch.setenv("RAG_MODEL_OVERRIDE", "version:7")
+    get_settings.cache_clear()
+    assert get_settings().rag_model_override == "version:7"

--- a/tests/unit/test_main_load_registered_rag_chain.py
+++ b/tests/unit/test_main_load_registered_rag_chain.py
@@ -1,0 +1,40 @@
+"""Unit tests for the RAG_MODEL_OVERRIDE plumbing in app.main.
+
+Parser cases live alongside the helper module (app.main._parse_model_override);
+integration cases for load_registered_rag_chain are added in Task 2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.main import _parse_model_override
+
+
+def test_parse_model_override_version_returns_version_kind() -> None:
+    assert _parse_model_override("version:7") == ("version", "7")
+
+
+def test_parse_model_override_alias_returns_alias_kind() -> None:
+    assert _parse_model_override("alias:my-test-alias") == ("alias", "my-test-alias")
+
+
+def test_parse_model_override_strips_whitespace_from_value() -> None:
+    # Shell env exports often have stray spaces; treat them as harmless.
+    assert _parse_model_override("version: 7 ") == ("version", "7")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "garbage", "version:", "alias:", "run_id:abc", "versionNoColon"],
+)
+def test_parse_model_override_rejects_malformed_value(raw: str) -> None:
+    with pytest.raises(ValueError, match=r"version:N.*alias:NAME"):
+        _parse_model_override(raw)
+
+
+def test_parse_model_override_error_message_contains_offending_value() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        _parse_model_override("garbage")
+    # repr("garbage") -> "'garbage'" — the developer sees exactly what they typed.
+    assert repr("garbage") in str(exc_info.value)

--- a/tests/unit/test_main_load_registered_rag_chain.py
+++ b/tests/unit/test_main_load_registered_rag_chain.py
@@ -1,14 +1,49 @@
 """Unit tests for the RAG_MODEL_OVERRIDE plumbing in app.main.
 
 Parser cases live alongside the helper module (app.main._parse_model_override);
-integration cases for load_registered_rag_chain are added in Task 2.
+integration cases exercise load_registered_rag_chain's override branch end-to-end
+with mocked MLflow and downstream chain construction.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
-from app.main import _parse_model_override
+from app.config import get_settings
+from app.main import _parse_model_override, load_registered_rag_chain
+
+
+def _stub_mlflow_for_load(mocker, *, version: str = "7", run_id: str = "run-xyz"):
+    """Patch mlflow + downstream dependencies so load_registered_rag_chain runs
+    purely against fakes. Returns the MlflowClient instance so callers can assert
+    on get_model_version / get_model_version_by_alias calls.
+    """
+    fake_version = SimpleNamespace(version=version, run_id=run_id)
+    fake_run = SimpleNamespace(
+        data=SimpleNamespace(
+            params={
+                "llm_provider": "openai",
+                "chat_model": "gpt-4o-mini",
+                "k": "5",
+                "temperature": "0.0",
+            }
+        )
+    )
+    fake_client = mocker.Mock()
+    fake_client.get_model_version.return_value = fake_version
+    fake_client.get_model_version_by_alias.return_value = fake_version
+    fake_client.get_run.return_value = fake_run
+
+    mocker.patch("app.main.mlflow.set_tracking_uri")
+    mocker.patch("app.main.mlflow.MlflowClient", return_value=fake_client)
+    mocker.patch("app.main.resolve_llm_api_key", return_value="fake-key")
+    mocker.patch(
+        "app.main.build_rag_chain",
+        return_value=SimpleNamespace(chain=object(), llm=object()),
+    )
+    return fake_client
 
 
 def test_parse_model_override_version_returns_version_kind() -> None:
@@ -38,3 +73,86 @@ def test_parse_model_override_error_message_contains_offending_value() -> None:
         _parse_model_override("garbage")
     # repr("garbage") -> "'garbage'" — the developer sees exactly what they typed.
     assert repr("garbage") in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for load_registered_rag_chain — exercise the override
+# branch end-to-end with mocked MLflow + downstream chain construction.
+# ---------------------------------------------------------------------------
+
+
+def test_load_registered_rag_chain_uses_production_alias_when_override_unset(
+    mocker, monkeypatch
+) -> None:
+    """OVR-03 regression sentinel: unset override -> existing production-alias path.
+
+    Must call get_model_version_by_alias("city-concierge-rag", "production") exactly
+    once and never call get_model_version.
+    """
+    monkeypatch.delenv("RAG_MODEL_OVERRIDE", raising=False)
+    get_settings.cache_clear()
+    client = _stub_mlflow_for_load(mocker)
+
+    loaded = load_registered_rag_chain()
+
+    client.get_model_version_by_alias.assert_called_once_with("city-concierge-rag", "production")
+    client.get_model_version.assert_not_called()
+    assert loaded.params.llm_provider == "openai"
+    assert loaded.params.chat_model == "gpt-4o-mini"
+    assert loaded.params.model_version == "7"
+
+
+def test_load_registered_rag_chain_uses_version_when_override_is_version(
+    mocker, monkeypatch
+) -> None:
+    """OVR-02: 'version:N' routes to client.get_model_version(name, N)."""
+    monkeypatch.setenv("RAG_MODEL_OVERRIDE", "version:7")
+    get_settings.cache_clear()
+    client = _stub_mlflow_for_load(mocker)
+
+    load_registered_rag_chain()
+
+    client.get_model_version.assert_called_once_with("city-concierge-rag", "7")
+    client.get_model_version_by_alias.assert_not_called()
+
+
+def test_load_registered_rag_chain_uses_alias_when_override_is_named_alias(
+    mocker, monkeypatch
+) -> None:
+    """OVR-02: 'alias:NAME' routes to client.get_model_version_by_alias(name, NAME)."""
+    monkeypatch.setenv("RAG_MODEL_OVERRIDE", "alias:my-test-alias")
+    get_settings.cache_clear()
+    client = _stub_mlflow_for_load(mocker)
+
+    load_registered_rag_chain()
+
+    client.get_model_version_by_alias.assert_called_once_with("city-concierge-rag", "my-test-alias")
+    client.get_model_version.assert_not_called()
+
+
+def test_load_registered_rag_chain_treats_empty_override_as_unset(mocker, monkeypatch) -> None:
+    """OVR-04: empty string is treated as unset (must NOT raise).
+
+    Falls back to the 'production' alias path so an accidentally-blank env var
+    in CI/Cloud Run doesn't crash the lifespan.
+    """
+    monkeypatch.setenv("RAG_MODEL_OVERRIDE", "")
+    get_settings.cache_clear()
+    client = _stub_mlflow_for_load(mocker)
+
+    load_registered_rag_chain()
+
+    client.get_model_version_by_alias.assert_called_once_with("city-concierge-rag", "production")
+    client.get_model_version.assert_not_called()
+
+
+def test_load_registered_rag_chain_raises_on_malformed_override(mocker, monkeypatch) -> None:
+    """OVR-04: malformed override surfaces the parser ValueError unwrapped so the
+    actionable 'version:N or alias:NAME' message reaches lifespan logs.
+    """
+    monkeypatch.setenv("RAG_MODEL_OVERRIDE", "garbage")
+    get_settings.cache_clear()
+    _stub_mlflow_for_load(mocker)
+
+    with pytest.raises(ValueError, match=r"version:N.*alias:NAME"):
+        load_registered_rag_chain()


### PR DESCRIPTION
## Summary

Adds `RAG_MODEL_OVERRIDE` env var that routes `/chat` and `/predict` through a developer-specified MLflow model version (`version:N`) or named alias (`alias:NAME`) instead of the shared `production` alias. When unset, behavior is byte-equivalent to today (full backward compat).

Unblocks Phase 3 eval-harness work and safe candidate-model testing without anyone touching the shared `production` alias that prod Cloud Run pins to.

### What shipped

- `Settings.rag_model_override: str | None = None` in `app/config.py` (pydantic-settings auto-reads env var).
- `_parse_model_override(raw) -> tuple[Literal["version", "alias"], str]` private helper in `app/main.py`. Strips whitespace; raises `ValueError` with actionable message containing both literal `version:N` and `alias:NAME` plus `repr(raw)` on malformed input.
- Override branch inside `load_registered_rag_chain` (env var read in function body, not at module load). Short-circuits on `None`/whitespace-only to preserve the existing `production` alias path. Wraps the override lookup in a `RuntimeError`-raising try/except.
- INFO log line `"load_registered_rag_chain: using override kind=%s value=%s version=%s"` for eval-run provenance.
- 3-line code comment: `version:N is recommended; alias:NAME re-resolves on every load and can race if someone moves the alias mid-eval`.
- New `### Model Override` README subsection under `## MLflow` documenting both syntaxes, explicitly recommending `version:N`, with worked invocation and unset-falls-back-to-production note.

### Diff size

5 files, 258 insertions, 9 deletions. Production code: ~15 lines of new logic (parser is ~15 lines; override branch is a single if/else). The `app/main.py` deletions are the existing `production`-alias try/except being wrapped under `else:` — same lines re-added inside the `else` branch.

### Requirements addressed

OVR-01 through OVR-06 (all six). See `.planning/phases/02-model-override/VERIFICATION.md` for the goal-backward verification report.

## Test plan

- [x] `poetry run pytest tests/unit/test_main_load_registered_rag_chain.py -v` — 15 tests pass (5 logical parser cases × parametrization + 5 integration cases)
- [x] `poetry run pytest tests/unit/ -v` — 600 tests pass (was 583 on main; net +17 = 15 new + 2 in test_config.py)
- [x] Backward-compat sentinel: `git diff main -- tests/unit/test_chat_endpoint.py tests/unit/test_chat_functional.py tests/unit/test_predict_endpoint.py` shows zero modifications (OVR-03)
- [x] OVR-05 monkeypatch contract: `grep -rn 'os\.environ\[.RAG_MODEL_OVERRIDE\|os\.environ\.get(.RAG_MODEL_OVERRIDE' tests/ app/` returns empty
- [x] Pre-commit ruff hooks passed on every commit
- [x] CI green
- [x] Smoke: `RAG_MODEL_OVERRIDE=version:7 poetry run uvicorn app.main:app` loads MLflow version 7 (INFO log line visible); unsetting falls back to `production` alias in same process restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)